### PR TITLE
Fix go.mod to work with vgo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,7 @@
-module "github.com/Storj/storj"
+module "storj.io/storj"
+
+require (
+	"github.com/tyler-smith/go-bip39" v0.0.0-20160629163856-8e7a99b3e716
+	"github.com/urfave/cli" v1.20.0
+	"golang.org/x/crypto" v0.0.0-20180410182641-f70185d77e82
+)


### PR DESCRIPTION
`vgo run cmd/storj/main.go` will now build and pull dependencies in correctly.