### PR TITLE
HTTP Ranger

### DIFF
--- a/examples/eestream/serve-collected/main.go
+++ b/examples/eestream/serve-collected/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/vivint/infectious"
+
 	"storj.io/storj/pkg/eestream"
 	"storj.io/storj/pkg/ranger"
 )

--- a/examples/eestream/serve-collected/main.go
+++ b/examples/eestream/serve-collected/main.go
@@ -37,8 +37,9 @@ func Main() error {
 		return err
 	}
 	es := eestream.NewRSScheme(fc, *pieceBlockSize)
-	decrypter, err := eestream.NewSecretboxDecrypter(encKey[:],
-		es.DecodedBlockSize())
+	var firstNonce [24]byte
+	decrypter, err := eestream.NewSecretboxDecrypter(
+		&encKey, &firstNonce, es.DecodedBlockSize())
 	if err != nil {
 		return err
 	}

--- a/examples/eestream/serve-collected/main.go
+++ b/examples/eestream/serve-collected/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/vivint/infectious"
@@ -27,7 +28,8 @@ var (
 func main() {
 	err := Main()
 	if err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
 	}
 }
 

--- a/examples/eestream/serve-collected/main.go
+++ b/examples/eestream/serve-collected/main.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package main
+
+import (
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/vivint/infectious"
+	"storj.io/storj/pkg/eestream"
+	"storj.io/storj/pkg/ranger"
+)
+
+var (
+	addr           = flag.String("addr", "localhost:8080", "address to serve from")
+	pieceBlockSize = flag.Int("piece_block_size", 4*1024, "block size of pieces")
+	key            = flag.String("key", "a key", "the secret key")
+	rsk            = flag.Int("required", 20, "rs required")
+	rsn            = flag.Int("total", 40, "rs total")
+)
+
+func main() {
+	err := Main()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Main() error {
+	encKey := sha256.Sum256([]byte(*key))
+	fc, err := infectious.NewFEC(*rsk, *rsn)
+	if err != nil {
+		return err
+	}
+	es := eestream.NewRSScheme(fc, *pieceBlockSize)
+	decrypter, err := eestream.NewSecretboxDecrypter(encKey[:],
+		es.DecodedBlockSize())
+	if err != nil {
+		return err
+	}
+	rrs := map[int]ranger.Ranger{}
+	for i := 0; i < 40; i++ {
+		url := fmt.Sprintf("http://localhost:%d", 10000+i)
+		rrs[i], err = ranger.HTTPRanger(url)
+		if err != nil {
+			return err
+		}
+	}
+	rr, err := eestream.Decode(rrs, es)
+	if err != nil {
+		return err
+	}
+	rr, err = eestream.Transform(rr, decrypter)
+	if err != nil {
+		return err
+	}
+	rr, err = eestream.UnpadSlow(rr)
+	if err != nil {
+		return err
+	}
+
+	return http.ListenAndServe(*addr, http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			ranger.ServeContent(w, r, flag.Arg(0), time.Time{}, rr)
+		}))
+}

--- a/examples/eestream/serve-pieces/main.go
+++ b/examples/eestream/serve-pieces/main.go
@@ -22,7 +22,8 @@ func main() {
 	}
 	err := Main()
 	if err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
 	}
 }
 

--- a/examples/eestream/serve-pieces/main.go
+++ b/examples/eestream/serve-pieces/main.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	flag.Parse()
+	if flag.Arg(0) == "" {
+		fmt.Printf("usage: %s <targetdir>\n", os.Args[0])
+		os.Exit(1)
+	}
+	err := Main()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Main() error {
+	pieces, err := ioutil.ReadDir(flag.Arg(0))
+	if err != nil {
+		return err
+	}
+	for _, piece := range pieces {
+		pieceNum, err := strconv.Atoi(strings.TrimSuffix(piece.Name(), ".piece"))
+		if err != nil {
+			return err
+		}
+		pieceAddr := "localhost:" + strconv.Itoa(10000+pieceNum)
+		piecePath := filepath.Join(flag.Arg(0), piece.Name())
+		go http.ListenAndServe(pieceAddr, http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				http.ServeFile(w, r, piecePath)
+			}))
+	}
+
+	select {} // sleep forever
+}

--- a/examples/eestream/serve/main.go
+++ b/examples/eestream/serve/main.go
@@ -37,7 +37,8 @@ func main() {
 	}
 	err := Main()
 	if err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
 	}
 }
 

--- a/examples/eestream/serve/main.go
+++ b/examples/eestream/serve/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/vivint/infectious"
+
 	"storj.io/storj/pkg/eestream"
 	"storj.io/storj/pkg/ranger"
 )

--- a/examples/eestream/serve/main.go
+++ b/examples/eestream/serve/main.go
@@ -1,0 +1,93 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package main
+
+import (
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vivint/infectious"
+	"storj.io/storj/pkg/eestream"
+	"storj.io/storj/pkg/ranger"
+)
+
+var (
+	addr           = flag.String("addr", "localhost:8080", "address to serve from")
+	pieceBlockSize = flag.Int("piece_block_size", 4*1024, "block size of pieces")
+	key            = flag.String("key", "a key", "the secret key")
+	rsk            = flag.Int("required", 20, "rs required")
+	rsn            = flag.Int("total", 40, "rs total")
+)
+
+func main() {
+	flag.Parse()
+	if flag.Arg(0) == "" {
+		fmt.Printf("usage: %s <targetdir>\n", os.Args[0])
+		os.Exit(1)
+	}
+	err := Main()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Main() error {
+	encKey := sha256.Sum256([]byte(*key))
+	fc, err := infectious.NewFEC(*rsk, *rsn)
+	if err != nil {
+		return err
+	}
+	es := eestream.NewRSScheme(fc, *pieceBlockSize)
+	decrypter, err := eestream.NewSecretboxDecrypter(encKey[:],
+		es.DecodedBlockSize())
+	if err != nil {
+		return err
+	}
+	pieces, err := ioutil.ReadDir(flag.Arg(0))
+	if err != nil {
+		return err
+	}
+	rrs := map[int]ranger.Ranger{}
+	for _, piece := range pieces {
+		piecenum, err := strconv.Atoi(strings.TrimSuffix(piece.Name(), ".piece"))
+		if err != nil {
+			return err
+		}
+		fh, err := os.Open(filepath.Join(flag.Arg(0), piece.Name()))
+		if err != nil {
+			return err
+		}
+		defer fh.Close()
+		fs, err := fh.Stat()
+		if err != nil {
+			return err
+		}
+		rrs[piecenum] = ranger.ReaderAtRanger(fh, fs.Size())
+	}
+	rr, err := eestream.Decode(rrs, es)
+	if err != nil {
+		return err
+	}
+	rr, err = eestream.Transform(rr, decrypter)
+	if err != nil {
+		return err
+	}
+	rr, err = eestream.UnpadSlow(rr)
+	if err != nil {
+		return err
+	}
+
+	return http.ListenAndServe(*addr, http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			ranger.ServeContent(w, r, flag.Arg(0), time.Time{}, rr)
+		}))
+}

--- a/examples/eestream/serve/main.go
+++ b/examples/eestream/serve/main.go
@@ -47,8 +47,9 @@ func Main() error {
 		return err
 	}
 	es := eestream.NewRSScheme(fc, *pieceBlockSize)
-	decrypter, err := eestream.NewSecretboxDecrypter(encKey[:],
-		es.DecodedBlockSize())
+	var firstNonce [24]byte
+	decrypter, err := eestream.NewSecretboxDecrypter(
+		&encKey, &firstNonce, es.DecodedBlockSize())
 	if err != nil {
 		return err
 	}

--- a/examples/eestream/store/main.go
+++ b/examples/eestream/store/main.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 
 	"github.com/vivint/infectious"
+
 	"storj.io/storj/pkg/eestream"
 )
 

--- a/examples/eestream/store/main.go
+++ b/examples/eestream/store/main.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package main
+
+import (
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/vivint/infectious"
+	"storj.io/storj/pkg/eestream"
+)
+
+var (
+	pieceBlockSize = flag.Int("piece_block_size", 4*1024, "block size of pieces")
+	key            = flag.String("key", "a key", "the secret key")
+	rsk            = flag.Int("required", 20, "rs required")
+	rsn            = flag.Int("total", 40, "rs total")
+)
+
+func main() {
+	flag.Parse()
+	if flag.Arg(0) == "" {
+		fmt.Printf("usage: cat data | %s <targetdir>\n", os.Args[0])
+		os.Exit(1)
+	}
+	err := Main()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Main() error {
+	err := os.MkdirAll(flag.Arg(0), 0755)
+	if err != nil {
+		return err
+	}
+	fc, err := infectious.NewFEC(*rsk, *rsn)
+	if err != nil {
+		return err
+	}
+	es := eestream.NewRSScheme(fc, *pieceBlockSize)
+	encKey := sha256.Sum256([]byte(*key))
+	encrypter, err := eestream.NewSecretboxEncrypter(encKey[:],
+		es.DecodedBlockSize())
+	if err != nil {
+		return err
+	}
+	readers := eestream.EncodeReader(eestream.TransformReader(
+		eestream.PadReader(os.Stdin, encrypter.InBlockSize()), encrypter, 0), es)
+	errs := make(chan error, len(readers))
+	for i := range readers {
+		go func(i int) {
+			fh, err := os.Create(
+				filepath.Join(flag.Arg(0), fmt.Sprintf("%d.piece", i)))
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer fh.Close()
+			_, err = io.Copy(fh, readers[i])
+			errs <- err
+		}(i)
+	}
+	for range readers {
+		err := <-errs
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/examples/eestream/store/main.go
+++ b/examples/eestream/store/main.go
@@ -31,7 +31,8 @@ func main() {
 	}
 	err := Main()
 	if err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
 	}
 }
 

--- a/examples/eestream/store/main.go
+++ b/examples/eestream/store/main.go
@@ -45,8 +45,9 @@ func Main() error {
 	}
 	es := eestream.NewRSScheme(fc, *pieceBlockSize)
 	encKey := sha256.Sum256([]byte(*key))
-	encrypter, err := eestream.NewSecretboxEncrypter(encKey[:],
-		es.DecodedBlockSize())
+	var firstNonce [24]byte
+	encrypter, err := eestream.NewSecretboxEncrypter(
+		&encKey, &firstNonce, es.DecodedBlockSize())
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/readcloser/fatal.go
+++ b/internal/pkg/readcloser/fatal.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package readcloser
+
+import "io"
+
+// FatalReadCloser returns a ReadCloser that always fails with err.
+func FatalReadCloser(err error) io.ReadCloser {
+	return &fatalReadCloser{Err: err}
+}
+
+type fatalReadCloser struct {
+	Err error
+}
+
+func (f *fatalReadCloser) Read(p []byte) (n int, err error) {
+	return 0, f.Err
+}
+
+func (f *fatalReadCloser) Close() error {
+	return nil
+}

--- a/internal/pkg/readcloser/lazy.go
+++ b/internal/pkg/readcloser/lazy.go
@@ -25,9 +25,8 @@ func (l *lazyReadCloser) Read(p []byte) (n int, err error) {
 }
 
 func (l *lazyReadCloser) Close() error {
-	if l.r == nil {
-		l.r = l.fn()
-		l.fn = nil
+	if l.r != nil {
+		return l.r.Close()
 	}
-	return l.r.Close()
+	return nil
 }

--- a/internal/pkg/readcloser/lazy.go
+++ b/internal/pkg/readcloser/lazy.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package readcloser
+
+import "io"
+
+// LazyReadCloser returns an ReadCloser that doesn't initialize the backing
+// Reader until the first Read.
+func LazyReadCloser(reader func() io.ReadCloser) io.ReadCloser {
+	return &lazyReadCloser{fn: reader}
+}
+
+type lazyReadCloser struct {
+	fn func() io.ReadCloser
+	r  io.ReadCloser
+}
+
+func (l *lazyReadCloser) Read(p []byte) (n int, err error) {
+	if l.r == nil {
+		l.r = l.fn()
+		l.fn = nil
+	}
+	return l.r.Read(p)
+}
+
+func (l *lazyReadCloser) Close() error {
+	if l.r == nil {
+		l.r = l.fn()
+		l.fn = nil
+	}
+	return l.r.Close()
+}

--- a/internal/pkg/readcloser/limit.go
+++ b/internal/pkg/readcloser/limit.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package readcloser
+
+import "io"
+
+// LimitReadCloser is a LimitReader extension that returns a ReadCloser
+// that reads from r but stops with EOF after n bytes.
+func LimitReadCloser(r io.ReadCloser, n int64) io.ReadCloser {
+	return &limitedReadCloser{io.LimitReader(r, n), r}
+}
+
+type limitedReadCloser struct {
+	R io.Reader
+	C io.Closer
+}
+
+func (l *limitedReadCloser) Read(p []byte) (n int, err error) {
+	return l.R.Read(p)
+}
+
+func (l *limitedReadCloser) Close() error {
+	return l.C.Close()
+}

--- a/internal/pkg/readcloser/multi.go
+++ b/internal/pkg/readcloser/multi.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package readcloser
+
+import "io"
+
+// MultiReadCloser is a MultiReader extension that returns a ReaderCloser
+// that's the logical concatenation of the provided input readers.
+// They're read sequentially. Once all inputs have returned EOF,
+// Read will return EOF.  If any of the readers return a non-nil,
+// non-EOF error, Read will return that error.
+func MultiReadCloser(readers ...io.ReadCloser) io.ReadCloser {
+	r := make([]io.Reader, len(readers))
+	for i := range readers {
+		r[i] = readers[i]
+	}
+	c := make([]io.Closer, len(readers))
+	for i := range readers {
+		c[i] = readers[i]
+	}
+	return &multiReadCloser{io.MultiReader(r...), c}
+}
+
+type multiReadCloser struct {
+	multireader io.Reader
+	closers     []io.Closer
+}
+
+func (l *multiReadCloser) Read(p []byte) (n int, err error) {
+	return l.multireader.Read(p)
+}
+
+func (l *multiReadCloser) Close() error {
+	// close all in parallel
+	errs := make(chan error, len(l.closers))
+	for i := range l.closers {
+		go func(i int) {
+			err := l.closers[i].Close()
+			errs <- err
+		}(i)
+	}
+	// catch all the errors
+	for range l.closers {
+		err := <-errs
+		if err != nil {
+			// return on the first failure
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/eestream/decode.go
+++ b/pkg/eestream/decode.go
@@ -7,11 +7,12 @@ import (
 	"io"
 	"io/ioutil"
 
+	"storj.io/storj/internal/pkg/readcloser"
 	"storj.io/storj/pkg/ranger"
 )
 
 type decodedReader struct {
-	rs     map[int]io.Reader
+	rs     map[int]io.ReadCloser
 	es     ErasureScheme
 	inbufs map[int][]byte
 	outbuf []byte
@@ -21,7 +22,7 @@ type decodedReader struct {
 // DecodeReaders takes a map of readers and an ErasureScheme returning a
 // combined Reader. The map, 'rs', must be a mapping of erasure piece numbers
 // to erasure piece streams.
-func DecodeReaders(rs map[int]io.Reader, es ErasureScheme) io.Reader {
+func DecodeReaders(rs map[int]io.ReadCloser, es ErasureScheme) io.ReadCloser {
 	dr := &decodedReader{
 		rs:     rs,
 		es:     es,
@@ -79,6 +80,32 @@ func (dr *decodedReader) Read(p []byte) (n int, err error) {
 	return n, nil
 }
 
+func (dr *decodedReader) Close() error {
+	// we're going to kick off a bunch of goroutines. make a
+	// channel to catch those goroutine errors. importantly,
+	// the channel has a buffer size to contain all the errors
+	// even if we read none, so we can return without receiving
+	// every channel value
+	errs := make(chan error, len(dr.rs))
+	for i := range dr.rs {
+		go func(i int) {
+			// close the reader
+			err := dr.rs[i].Close()
+			errs <- err
+		}(i)
+	}
+	// catch all the errors
+	for range dr.rs {
+		err := <-errs
+		if err != nil {
+			// return on the first failure
+			dr.err = err
+			return err
+		}
+	}
+	return nil
+}
+
 type decodedRanger struct {
 	es     ErasureScheme
 	rrs    map[int]ranger.Ranger
@@ -123,14 +150,14 @@ func (dr *decodedRanger) Size() int64 {
 	return blocks * int64(dr.es.DecodedBlockSize())
 }
 
-func (dr *decodedRanger) Range(offset, length int64) io.Reader {
+func (dr *decodedRanger) Range(offset, length int64) io.ReadCloser {
 	// offset and length might not be block-aligned. figure out which
 	// blocks contain this request
 	firstBlock, blockCount := calcEncompassingBlocks(
 		offset, length, dr.es.DecodedBlockSize())
 
 	// go ask for ranges for all those block boundaries
-	readers := make(map[int]io.Reader, len(dr.rrs))
+	readers := make(map[int]io.ReadCloser, len(dr.rrs))
 	for i, rr := range dr.rrs {
 		readers[i] = rr.Range(
 			firstBlock*int64(dr.es.EncodedBlockSize()),
@@ -142,8 +169,8 @@ func (dr *decodedRanger) Range(offset, length int64) io.Reader {
 	_, err := io.CopyN(ioutil.Discard, r,
 		offset-firstBlock*int64(dr.es.DecodedBlockSize()))
 	if err != nil {
-		return ranger.FatalReader(Error.Wrap(err))
+		return readcloser.FatalReadCloser(Error.Wrap(err))
 	}
 	// length might not have included all of the blocks, limit what we return
-	return io.LimitReader(r, length)
+	return readcloser.LimitReadCloser(r, length)
 }

--- a/pkg/eestream/rs_test.go
+++ b/pkg/eestream/rs_test.go
@@ -20,9 +20,9 @@ func TestRS(t *testing.T) {
 	}
 	rs := NewRSScheme(fc, 8*1024)
 	readers := EncodeReader(bytes.NewReader(data), rs)
-	readerMap := make(map[int]io.Reader, len(readers))
+	readerMap := make(map[int]io.ReadCloser, len(readers))
 	for i, reader := range readers {
-		readerMap[i] = reader
+		readerMap[i] = ioutil.NopCloser(reader)
 	}
 	data2, err := ioutil.ReadAll(DecodeReaders(readerMap, rs))
 	if err != nil {

--- a/pkg/eestream/secretbox_test.go
+++ b/pkg/eestream/secretbox_test.go
@@ -26,8 +26,8 @@ func TestSecretbox(t *testing.T) {
 		t.Fatal(err)
 	}
 	data := randData(encrypter.InBlockSize() * 10)
-	encrypted := TransformReader(bytes.NewReader(data),
-		encrypter, 0)
+	encrypted := TransformReader(
+		ioutil.NopCloser(bytes.NewReader(data)), encrypter, 0)
 	decrypter, err := NewSecretboxDecrypter(key, 4*1024)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/ranger/content.go
+++ b/pkg/ranger/content.go
@@ -47,7 +47,9 @@ func ServeContent(w http.ResponseWriter, r *http.Request, name string,
 				amount = sniffLen
 			}
 			// TODO: cache this somewhere so we don't have to pull it out again
-			n, _ := io.ReadFull(content.Range(0, amount), buf[:])
+			r := content.Range(0, amount)
+			defer r.Close()
+			n, _ := io.ReadFull(r, buf[:])
 			ctype = http.DetectContentType(buf[:n])
 		}
 		w.Header().Set("Content-Type", ctype)
@@ -64,7 +66,7 @@ func ServeContent(w http.ResponseWriter, r *http.Request, name string,
 
 	// handle Content-Range header.
 	sendSize := size
-	sendContent := func() io.Reader {
+	sendContent := func() io.ReadCloser {
 		return content.Range(0, size)
 	}
 
@@ -97,7 +99,7 @@ func ServeContent(w http.ResponseWriter, r *http.Request, name string,
 		// A response to a request for a single range MUST NOT
 		// be sent using the multipart/byteranges media type."
 		ra := ranges[0]
-		sendContent = func() io.Reader { return content.Range(ra.start, ra.length) }
+		sendContent = func() io.ReadCloser { return content.Range(ra.start, ra.length) }
 		sendSize = ra.length
 		code = http.StatusPartialContent
 		w.Header().Set("Content-Range", ra.contentRange(size))
@@ -109,7 +111,7 @@ func ServeContent(w http.ResponseWriter, r *http.Request, name string,
 		mw := multipart.NewWriter(pw)
 		w.Header().Set("Content-Type",
 			"multipart/byteranges; boundary="+mw.Boundary())
-		sendContent = func() io.Reader { return pr }
+		sendContent = func() io.ReadCloser { return pr }
 		// cause writing goroutine to fail and exit if CopyN doesn't finish.
 		defer pr.Close()
 		go func() {
@@ -120,6 +122,7 @@ func ServeContent(w http.ResponseWriter, r *http.Request, name string,
 					return
 				}
 				partReader := content.Range(ra.start, ra.length)
+				defer partReader.Close()
 				if _, err := io.Copy(part, partReader); err != nil {
 					pw.CloseWithError(err)
 					return
@@ -138,7 +141,9 @@ func ServeContent(w http.ResponseWriter, r *http.Request, name string,
 	w.WriteHeader(code)
 
 	if r.Method != "HEAD" {
-		io.CopyN(w, sendContent(), sendSize)
+		r := sendContent()
+		defer r.Close()
+		io.CopyN(w, r, sendSize)
 	}
 }
 

--- a/pkg/ranger/content.go
+++ b/pkg/ranger/content.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -111,7 +112,7 @@ func ServeContent(w http.ResponseWriter, r *http.Request, name string,
 		mw := multipart.NewWriter(pw)
 		w.Header().Set("Content-Type",
 			"multipart/byteranges; boundary="+mw.Boundary())
-		sendContent = func() io.ReadCloser { return pr }
+		sendContent = func() io.ReadCloser { return ioutil.NopCloser(pr) }
 		// cause writing goroutine to fail and exit if CopyN doesn't finish.
 		defer pr.Close()
 		go func() {

--- a/pkg/ranger/http.go
+++ b/pkg/ranger/http.go
@@ -1,0 +1,73 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package ranger
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+)
+
+type httpRanger struct {
+	URL  string
+	size int64
+}
+
+// HTTPRanger turns an HTTP URL into a Ranger
+func HTTPRanger(URL string) (Ranger, error) {
+	resp, err := http.Head(URL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, Error.New("unexpected status code: %d (expected %d)",
+			resp.StatusCode, http.StatusOK)
+	}
+	contentLength := resp.Header.Get("Content-Length")
+	size, err := strconv.Atoi(contentLength)
+	if err != nil {
+		return nil, err
+	}
+	return &httpRanger{
+		URL:  URL,
+		size: int64(size),
+	}, nil
+}
+
+// Size implements Ranger.Size
+func (r *httpRanger) Size() int64 {
+	return r.size
+}
+
+// Range implements Ranger.Range
+func (r *httpRanger) Range(offset, length int64) io.ReadCloser {
+	if offset < 0 {
+		return FatalReader(Error.New("negative offset"))
+	}
+	if offset+length > r.size {
+		return FatalReader(Error.New("range beyond end"))
+	}
+	if length == 0 {
+		return ioutil.NopCloser(bytes.NewReader([]byte{}))
+	}
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", r.URL, nil)
+	if err != nil {
+		return FatalReader(err)
+	}
+	req.Header.Add("Range", fmt.Sprintf("bytes=%d-%d", offset, offset+length-1))
+	resp, err := client.Do(req)
+	if err != nil {
+		return FatalReader(err)
+	}
+	if resp.StatusCode != http.StatusPartialContent {
+		return FatalReader(Error.New("unexpected status code: %d (expected %d)",
+			resp.StatusCode, http.StatusPartialContent))
+	}
+	return resp.Body
+}

--- a/pkg/ranger/http.go
+++ b/pkg/ranger/http.go
@@ -71,6 +71,7 @@ func (r *httpRanger) Range(offset, length int64) io.ReadCloser {
 		return readcloser.FatalReadCloser(err)
 	}
 	if resp.StatusCode != http.StatusPartialContent {
+		resp.Body.Close()
 		return readcloser.FatalReadCloser(
 			Error.New("unexpected status code: %d (expected %d)",
 				resp.StatusCode, http.StatusPartialContent))

--- a/pkg/ranger/http_test.go
+++ b/pkg/ranger/http_test.go
@@ -4,13 +4,15 @@
 package ranger
 
 import (
-	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHTTPRanger(t *testing.T) {
@@ -21,40 +23,36 @@ func TestHTTPRanger(t *testing.T) {
 		}))
 	defer ts.Close()
 
-	for _, example := range []struct {
+	for i, tt := range []struct {
 		data                 string
 		size, offset, length int64
 		substr               string
-		fail                 bool
+		errString            string
 	}{
-		{"", 0, 0, 0, "", false},
-		{"abcdef", 6, 0, 0, "", false},
-		{"abcdef", 6, 0, 6, "abcdef", false},
-		{"abcdef", 6, 0, 5, "abcde", false},
-		{"abcdef", 6, 0, 4, "abcd", false},
-		{"abcdef", 6, 1, 4, "bcde", false},
-		{"abcdef", 6, 2, 4, "cdef", false},
-		{"abcdefg", 7, 1, 4, "bcde", false},
-		{"abcdef", 6, 0, 7, "abcdef", true},
-		{"abcdef", 6, -1, 7, "abcde", true},
+		{"", 0, 0, 0, "", ""},
+		{"abcdef", 6, 0, 0, "", ""},
+		{"abcdef", 6, 3, 0, "", ""},
+		{"abcdef", 6, 0, 6, "abcdef", ""},
+		{"abcdef", 6, 0, 5, "abcde", ""},
+		{"abcdef", 6, 0, 4, "abcd", ""},
+		{"abcdef", 6, 1, 4, "bcde", ""},
+		{"abcdef", 6, 2, 4, "cdef", ""},
+		{"abcdefg", 7, 1, 4, "bcde", ""},
+		{"abcdef", 6, 0, 7, "abcdef", "ranger error: range beyond end"},
+		{"abcdef", 6, -1, 7, "abcde", "ranger error: negative offset"},
+		{"abcdef", 6, 0, -1, "abcde", "ranger error: negative length"},
 	} {
-		content = example.data
+		errTag := fmt.Sprintf("Test case #%d", i)
+		content = tt.data
 		r, err := HTTPRanger(ts.URL)
-		if r.Size() != example.size {
-			t.Fatalf("invalid size: %v != %v", r.Size(), example.size)
+		assert.Equal(t, tt.size, r.Size(), errTag)
+		data, err := ioutil.ReadAll(r.Range(tt.offset, tt.length))
+		if tt.errString != "" {
+			assert.EqualError(t, err, tt.errString, errTag)
+			continue
 		}
-		data, err := ioutil.ReadAll(r.Range(example.offset, example.length))
-		if example.fail {
-			if err == nil {
-				t.Fatalf("expected error")
-			}
-		} else {
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
-			if !bytes.Equal(data, []byte(example.substr)) {
-				t.Fatalf("invalid subrange: %#v != %#v", string(data), example.substr)
-			}
+		if assert.NoError(t, err, errTag) {
+			assert.Equal(t, data, []byte(tt.substr), errTag)
 		}
 	}
 }

--- a/pkg/ranger/http_test.go
+++ b/pkg/ranger/http_test.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package ranger
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHTTPRanger(t *testing.T) {
+	var content string
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			http.ServeContent(w, r, "test", time.Now(), strings.NewReader(content))
+		}))
+	defer ts.Close()
+
+	for _, example := range []struct {
+		data                 string
+		size, offset, length int64
+		substr               string
+		fail                 bool
+	}{
+		{"", 0, 0, 0, "", false},
+		{"abcdef", 6, 0, 0, "", false},
+		{"abcdef", 6, 0, 6, "abcdef", false},
+		{"abcdef", 6, 0, 5, "abcde", false},
+		{"abcdef", 6, 0, 4, "abcd", false},
+		{"abcdef", 6, 1, 4, "bcde", false},
+		{"abcdef", 6, 2, 4, "cdef", false},
+		{"abcdefg", 7, 1, 4, "bcde", false},
+		{"abcdef", 6, 0, 7, "abcdef", true},
+		{"abcdef", 6, -1, 7, "abcde", true},
+	} {
+		content = example.data
+		r, err := HTTPRanger(ts.URL)
+		if r.Size() != example.size {
+			t.Fatalf("invalid size: %v != %v", r.Size(), example.size)
+		}
+		data, err := ioutil.ReadAll(r.Range(example.offset, example.length))
+		if example.fail {
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if !bytes.Equal(data, []byte(example.substr)) {
+				t.Fatalf("invalid subrange: %#v != %#v", string(data), example.substr)
+			}
+		}
+	}
+}

--- a/pkg/ranger/reader.go
+++ b/pkg/ranger/reader.go
@@ -57,11 +57,11 @@ func (c *concatReader) Range(offset, length int64) io.ReadCloser {
 	if offset >= r1Size {
 		return c.r2.Range(offset-r1Size, length)
 	}
-	return ioutil.NopCloser(io.MultiReader(
+	return readcloser.MultiReadCloser(
 		c.r1.Range(offset, r1Size-offset),
 		readcloser.LazyReadCloser(func() io.ReadCloser {
 			return c.r2.Range(0, length-(r1Size-offset))
-		})))
+		}))
 }
 
 func concat2(r1, r2 Ranger) Ranger {

--- a/pkg/ranger/reader_test.go
+++ b/pkg/ranger/reader_test.go
@@ -18,6 +18,7 @@ func TestByteRanger(t *testing.T) {
 	}{
 		{"", 0, 0, 0, "", false},
 		{"abcdef", 6, 0, 0, "", false},
+		{"abcdef", 6, 3, 0, "", false},
 		{"abcdef", 6, 0, 6, "abcdef", false},
 		{"abcdef", 6, 0, 5, "abcde", false},
 		{"abcdef", 6, 0, 4, "abcd", false},
@@ -26,6 +27,7 @@ func TestByteRanger(t *testing.T) {
 		{"abcdefg", 7, 1, 4, "bcde", false},
 		{"abcdef", 6, 0, 7, "", true},
 		{"abcdef", 6, -1, 7, "abcde", true},
+		{"abcdef", 6, 0, -1, "abcde", true},
 	} {
 		r := ByteRanger([]byte(example.data))
 		if r.Size() != example.size {

--- a/pkg/ranger/reader_test.go
+++ b/pkg/ranger/reader_test.go
@@ -16,6 +16,8 @@ func TestByteRanger(t *testing.T) {
 		substr               string
 		fail                 bool
 	}{
+		{"", 0, 0, 0, "", false},
+		{"abcdef", 6, 0, 0, "", false},
 		{"abcdef", 6, 0, 6, "abcdef", false},
 		{"abcdef", 6, 0, 5, "abcde", false},
 		{"abcdef", 6, 0, 4, "abcd", false},

--- a/pkg/ranger/readerat.go
+++ b/pkg/ranger/readerat.go
@@ -5,6 +5,8 @@ package ranger
 
 import (
 	"io"
+
+	"storj.io/storj/internal/pkg/readcloser"
 )
 
 type readerAtRanger struct {
@@ -31,10 +33,13 @@ type readerAtReader struct {
 
 func (r *readerAtRanger) Range(offset, length int64) io.ReadCloser {
 	if offset < 0 {
-		return FatalReader(Error.New("negative offset"))
+		return readcloser.FatalReadCloser(Error.New("negative offset"))
+	}
+	if length < 0 {
+		return readcloser.FatalReadCloser(Error.New("negative length"))
 	}
 	if offset+length > r.size {
-		return FatalReader(Error.New("buffer runoff"))
+		return readcloser.FatalReadCloser(Error.New("buffer runoff"))
 	}
 	return &readerAtReader{r: r.r, offset: offset, length: length}
 }

--- a/pkg/ranger/readerat.go
+++ b/pkg/ranger/readerat.go
@@ -29,7 +29,7 @@ type readerAtReader struct {
 	offset, length int64
 }
 
-func (r *readerAtRanger) Range(offset, length int64) io.Reader {
+func (r *readerAtRanger) Range(offset, length int64) io.ReadCloser {
 	if offset < 0 {
 		return FatalReader(Error.New("negative offset"))
 	}
@@ -50,4 +50,8 @@ func (r *readerAtReader) Read(p []byte) (n int, err error) {
 	r.offset += int64(n)
 	r.length -= int64(n)
 	return n, err
+}
+
+func (r *readerAtReader) Close() error {
+	return nil
 }


### PR DESCRIPTION
This PR does the following:
- Implements the `HTTPRanger` type
- Updates the `ranger` and `eestream` libraries to use `io.ReadCloser` instead of `io.Reader`
- Extracts an internal package `/internal/pkg/readcloser` with ReadCloser helper types
- Provides CLI tools under `/examples/eestream` to demonstrate the usage of the `eestream` library with `HTTTRanger`.