### PR TITLE
don't require shallow clones of old commits

### DIFF
--- a/scripts/travis-deps.sh
+++ b/scripts/travis-deps.sh
@@ -2,7 +2,7 @@ set -x
 
 mkdir -p $HOME/gopath-staging
 cd $HOME/gopath-staging
-git clone --depth=1 --recursive --shallow-submodules https://github.com/storj/storj-vendor.git .
+git clone --recursive https://github.com/storj/storj-vendor.git .
 ./setup.sh
 mkdir -p src/storj.io
 mv $HOME/gopath/src/github.com/storj/storj src/storj.io


### PR DESCRIPTION
doesn't look like github allows it. hints here:
https://stackoverflow.com/questions/31278902/how-to-shallow-clone-a-specific-commit-with-depth-1