### PR TITLE
internal/test: switch errors to error classes

### DIFF
--- a/internal/test/util.go
+++ b/internal/test/util.go
@@ -43,11 +43,12 @@ type RedisServer struct {
 }
 
 var (
-	// ErrMissingKey is the error returned if a key is not in the mock store
-	ErrMissingKey = errs.New("missing")
+	// ErrMissingKey is the error class returned if a key is not in the mock store
+	ErrMissingKey = errs.Class("missing")
 
-	// ErrForced is the error returned when the forced error flag is passed to mock an error
-	ErrForced = errs.New("error forced by using 'error' key in mock")
+	// ErrForced is the error class returned when the forced error flag is passed
+	// to mock an error
+	ErrForced = errs.Class("error forced by using 'error' key in mock")
 
 	redisRefs = map[string]bool{}
 	testRedis = &RedisServer{
@@ -59,11 +60,11 @@ var (
 func (m *MockKeyValueStore) Get(key storage.Key) (storage.Value, error) {
 	m.GetCalled++
 	if key.String() == "error" {
-		return storage.Value{}, ErrForced
+		return storage.Value{}, ErrForced.New("forced error")
 	}
 	v, ok := m.Data[key.String()]
 	if !ok {
-		return storage.Value{}, ErrMissingKey
+		return storage.Value{}, ErrMissingKey.New("key %v missing", key)
 	}
 
 	return v, nil

--- a/pkg/overlay/cache.go
+++ b/pkg/overlay/cache.go
@@ -18,7 +18,7 @@ import (
 )
 
 // ErrNodeNotFound standardizes errors here
-var ErrNodeNotFound = errs.New("Node not found")
+var ErrNodeNotFound = errs.Class("Node not found")
 
 // Cache is used to store overlay data in Redis
 type Cache struct {

--- a/storage/redis/client.go
+++ b/storage/redis/client.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
+	// Error is a redis error
 	Error = errs.Class("redis error")
 )
 

--- a/storage/redis/client.go
+++ b/storage/redis/client.go
@@ -39,7 +39,7 @@ func NewClient(address, password string, db int) (storage.KeyValueStore, error) 
 
 	// ping here to verify we are able to connect to redis with the initialized client.
 	if err := c.db.Ping().Err(); err != nil {
-		return nil, err
+		return nil, Error.New("ping failed", err)
 	}
 
 	return c, nil
@@ -47,7 +47,12 @@ func NewClient(address, password string, db int) (storage.KeyValueStore, error) 
 
 // Get looks up the provided key from redis returning either an error or the result.
 func (c *redisClient) Get(key storage.Key) (storage.Value, error) {
-	return c.db.Get(string(key)).Bytes()
+	b, err := c.db.Get(string(key)).Bytes()
+	if err != nil {
+		return nil, Error.New("get error", err)
+	}
+
+	return b, nil
 }
 
 // Put adds a value to the provided key in redis, returning an error on failure.
@@ -55,17 +60,22 @@ func (c *redisClient) Put(key storage.Key, value storage.Value) error {
 	v, err := value.MarshalBinary()
 
 	if err != nil {
-		return err
+		return Error.New("put error", err)
 	}
 
-	return c.db.Set(key.String(), v, c.TTL).Err()
+	err = c.db.Set(key.String(), v, c.TTL).Err()
+	if err != nil {
+		return Error.New("put error", err)
+	}
+
+	return nil
 }
 
 // List returns either a list of keys for which boltdb has values or an error.
 func (c *redisClient) List() (_ storage.Keys, _ error) {
 	results, err := c.db.Keys("*").Result()
 	if err != nil {
-		return nil, Error.Wrap(err)
+		return nil, Error.New("list error", err)
 	}
 
 	keys := make(storage.Keys, len(results))
@@ -78,7 +88,12 @@ func (c *redisClient) List() (_ storage.Keys, _ error) {
 
 // Delete deletes a key/value pair from redis, for a given the key
 func (c *redisClient) Delete(key storage.Key) error {
-	return c.db.Del(key.String()).Err()
+	err := c.db.Del(key.String()).Err()
+	if err != nil {
+		return Error.New("delete error", err)
+	}
+
+	return err
 }
 
 // Close closes a redis client

--- a/storage/redis/client.go
+++ b/storage/redis/client.go
@@ -11,7 +11,13 @@ import (
 	"storj.io/storj/storage"
 )
 
-const defaultNodeExpiration = 61 * time.Minute
+var (
+	Error = errs.Class("redis error")
+)
+
+const (
+	defaultNodeExpiration = 61 * time.Minute
+)
 
 // redisClient is the entrypoint into Redis
 type redisClient struct {
@@ -58,7 +64,7 @@ func (c *redisClient) Put(key storage.Key, value storage.Value) error {
 func (c *redisClient) List() (_ storage.Keys, _ error) {
 	results, err := c.db.Keys("*").Result()
 	if err != nil {
-		return nil, errs.Wrap(err)
+		return nil, Error.Wrap(err)
 	}
 
 	keys := make(storage.Keys, len(results))


### PR DESCRIPTION
if you construct an error directly at package init time, you
won't get useful stack traces or anything. zeebo/errs expects that
you always construct an error (.New) when the error actually
happens. instead, you call Class at init time, then use (Class).Has
to test for error type membership.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/96)
<!-- Reviewable:end -->
