### PR TITLE
Use continue instead of return in table tests

### DIFF
--- a/pkg/eestream/rs_test.go
+++ b/pkg/eestream/rs_test.go
@@ -156,7 +156,7 @@ func TestRSEncoderInputParams(t *testing.T) {
 		data := randData(32 * 1024)
 		fc, err := infectious.NewFEC(2, 4)
 		if !assert.NoError(t, err, errTag) {
-			return
+			continue
 		}
 		rs := NewRSScheme(fc, 8*1024)
 		_, err = EncodeReader(ctx, bytes.NewReader(data), rs, tt.min, tt.opt, tt.mbm)
@@ -193,7 +193,7 @@ func TestRSRangerInputParams(t *testing.T) {
 		data := randData(32 * 1024)
 		fc, err := infectious.NewFEC(2, 4)
 		if !assert.NoError(t, err, errTag) {
-			return
+			continue
 		}
 		rs := NewRSScheme(fc, 8*1024)
 		_, err = EncodeReader(ctx, bytes.NewReader(data), rs, tt.min, tt.opt, tt.mbm)

--- a/pkg/ranger/grpc_test.go
+++ b/pkg/ranger/grpc_test.go
@@ -73,7 +73,7 @@ func TestGRPCRanger(t *testing.T) {
 		r, err := rr.Range(ctx, tt.offset, tt.length)
 		if tt.errString != "" {
 			assert.EqualError(t, err, tt.errString, errTag)
-			return
+			continue
 		}
 		assert.NoError(t, err, errTag)
 		data, err := ioutil.ReadAll(r)
@@ -131,7 +131,7 @@ func TestGRPCRangerSize(t *testing.T) {
 		r, err := rr.Range(ctx, tt.offset, tt.length)
 		if tt.errString != "" {
 			assert.EqualError(t, err, tt.errString, errTag)
-			return
+			continue
 		}
 		assert.NoError(t, err, errTag)
 		data, err := ioutil.ReadAll(r)

--- a/pkg/ranger/reader_test.go
+++ b/pkg/ranger/reader_test.go
@@ -39,7 +39,7 @@ func TestByteRanger(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error")
 			}
-			return
+			continue
 		}
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)


### PR DESCRIPTION
I did a dumb mistake for some of the table tests, which made some of the test cases not being executed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/106)
<!-- Reviewable:end -->
