### PR TITLE
begins adding inline segment support for segmentstore

### DIFF
--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -5,6 +5,7 @@ package miniogw
 
 import (
 	"context"
+	"flag"
 	"os"
 
 	"github.com/minio/cli"
@@ -22,6 +23,15 @@ import (
 	"storj.io/storj/pkg/storage/streams"
 	"storj.io/storj/pkg/transport"
 )
+
+var (
+	maxInlineSize int
+)
+
+func init() {
+	// maxInlineSize is the maximum size for an inline segment in bytes
+	flag.IntVar(&maxInlineSize, "segments.max_inline_size", 4*1024, "max inline segment size in bytes")
+}
 
 // RSConfig is a configuration struct that keeps details about default
 // redundancy strategy information
@@ -131,7 +141,7 @@ func (c Config) action(ctx context.Context, cliCtx *cli.Context,
 		return err
 	}
 
-	segments := segment.NewSegmentStore(oc, ec, pdb, rs, 0)
+	segments := segment.NewSegmentStore(oc, ec, pdb, rs, maxInlineSize)
 
 	// TODO(jt): wrap segments and turn segments into streams actually
 	// TODO: passthrough is bad

--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -131,7 +131,7 @@ func (c Config) action(ctx context.Context, cliCtx *cli.Context,
 		return err
 	}
 
-	segments := segment.NewSegmentStore(oc, ec, pdb, rs)
+	segments := segment.NewSegmentStore(oc, ec, pdb, rs, 0)
 
 	// TODO(jt): wrap segments and turn segments into streams actually
 	// TODO: passthrough is bad

--- a/pkg/storage/segments/peek.go
+++ b/pkg/storage/segments/peek.go
@@ -25,20 +25,12 @@ func NewPeekThresholdReader(r io.Reader) (pt *PeekThresholdReader) {
 func (pt *PeekThresholdReader) Read(p []byte) (n int, err error) {
 	pt.readCalled = true
 
+	if len(pt.thresholdBuf) == 0 {
+		return pt.r.Read(p)
+	}
+
 	n = copy(p, pt.thresholdBuf)
 	pt.thresholdBuf = pt.thresholdBuf[n:]
-
-	if len(pt.thresholdBuf) == 0 {
-		buf := make([]byte, len(p)-n)
-		k, err := io.ReadFull(pt.r, buf)
-		if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
-			return 0, err
-		}
-		for i := range buf[:k] {
-			p[n+i] = buf[i]
-		}
-		return k + n, nil
-	}
 	return n, nil
 }
 

--- a/pkg/storage/segments/peek.go
+++ b/pkg/storage/segments/peek.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package segments
+
+import "io"
+
+// PeekThresholdReader allows a check to see if the size of a given reader
+// exceeds the maximum inline segment size or not.
+type PeekThresholdReader struct {
+	r              io.Reader
+	thresholdBuf   []byte
+	isLargerCalled bool
+	readCalled     bool
+}
+
+// NewPeekThresholdReader creates a new instance of PeekThresholdReader
+func NewPeekThresholdReader(r io.Reader) (pt *PeekThresholdReader) {
+	return &PeekThresholdReader{r: r}
+}
+
+// Read initially reads bytes from the internal buffer, then continues
+// reading from the wrapped data reader. The number of bytes read `n`
+// is returned.
+func (pt *PeekThresholdReader) Read(p []byte) (n int, err error) {
+	pt.readCalled = true
+
+	if len(pt.thresholdBuf) == 0 {
+		return pt.r.Read(p)
+	}
+
+	n = copy(p, pt.thresholdBuf)
+	pt.thresholdBuf = pt.thresholdBuf[n:]
+	return n, nil
+}
+
+// IsLargerThan returns a bool to determine whether a reader's size
+// is larger than the given threshold or not.
+func (pt *PeekThresholdReader) IsLargerThan(thresholdSize int) (inline bool, err error) {
+	if pt.isLargerCalled {
+		return false, Error.New("IsLargerThan can't be called more than once")
+	}
+	if pt.readCalled {
+		return false, Error.New("IsLargerThan can't be called after Read has been called")
+	}
+	buf := make([]byte, thresholdSize+1)
+	n, err := io.ReadFull(pt.r, buf)
+	if err != nil {
+		// in this case, reader size is equal or less than the threshold
+		if err == io.ErrUnexpectedEOF {
+			return true, err
+		}
+		return false, err
+	}
+	pt.thresholdBuf = buf[0:n]
+	if len(pt.thresholdBuf) <= thresholdSize {
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/storage/segments/peek_test.go
+++ b/pkg/storage/segments/peek_test.go
@@ -1,0 +1,4 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package segments

--- a/pkg/storage/segments/peek_test.go
+++ b/pkg/storage/segments/peek_test.go
@@ -5,6 +5,7 @@ package segments
 
 import (
 	"bytes"
+	"io"
 	"testing"
 )
 
@@ -22,7 +23,10 @@ func TestStrictlyLessThanThresh(t *testing.T) {
 	}
 
 	outputBuf := make([]byte, 30)
-	n, err := p.Read(outputBuf)
+	n, err := io.ReadFull(p, outputBuf)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		t.Fatal("unexpected err from ReadFull:\n", err)
+	}
 	if n != len(file) {
 		t.Fatal("expected size of n to equal length of file")
 	}
@@ -44,7 +48,10 @@ func TestStrictlyGreaterThanThresh(t *testing.T) {
 	}
 
 	outputBuf := make([]byte, 30)
-	n, err := p.Read(outputBuf)
+	n, err := io.ReadFull(p, outputBuf)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		t.Fatal("unexpected err from ReadFull:\n", err)
+	}
 	if n != len(file) {
 		t.Fatal("expected size of n to equal length of file")
 	}
@@ -67,7 +74,10 @@ func TestReadLessThanThresholdBuf(t *testing.T) {
 	}
 
 	outputBuf := make([]byte, 10)
-	n, err := p.Read(outputBuf)
+	n, err := io.ReadFull(p, outputBuf)
+	if err != nil {
+		t.Fatal("unexpected err from ReadFull:\n", err)
+	}
 	if n != len(outputBuf) {
 		t.Fatal("expected size of n to equal length of outputBuf")
 	}

--- a/pkg/storage/segments/peek_test.go
+++ b/pkg/storage/segments/peek_test.go
@@ -5,84 +5,51 @@ package segments
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestStrictlyLessThanThresh(t *testing.T) {
-	file := []byte("abcdefghijklmnopqrstuvwxyz")
-	ioReader := bytes.NewReader(file)
-	p := NewPeekThresholdReader(ioReader)
+func TestThresholdBufAndRead(t *testing.T) {
+	for i, tt := range []struct {
+		name             string
+		file             []byte
+		thresholdSize    int
+		expectedIsRemote bool
+		outputBufLen     int
+		readsToEnd       bool
+	}{
+		{"Test strictly less than threshold", []byte("abcdefghijklmnopqrstuvwxyz"), 30, false, 30, true},
+		{"Test strictly greater than threshold", []byte("abcdefghijklmnopqrstuvwxyz"), 10, true, 30, true},
+		{"Test read less than threshold buf", []byte("abcdefghijklmnopqrstuvwxyz"), 20, true, 10, false},
+	} {
+		errTag := fmt.Sprintf("Test case index %d\n", i)
 
-	isRemote, err := p.IsLargerThan(30)
-	if isRemote {
-		t.Fatal("expected isRemote to be false")
-	}
-	if err != nil {
-		t.Fatal("expected no err", err)
-	}
+		ioReader := bytes.NewReader(tt.file)
+		p := NewPeekThresholdReader(ioReader)
 
-	outputBuf := make([]byte, 30)
-	n, err := io.ReadFull(p, outputBuf)
-	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
-		t.Fatal("unexpected err from ReadFull:\n", err)
-	}
-	if n != len(file) {
-		t.Fatal("expected size of n to equal length of file")
-	}
-	if !bytes.Equal(outputBuf[:n], file) {
-		t.Fatal("expected data in outputBuf to match data in file")
-	}
-}
-func TestStrictlyGreaterThanThresh(t *testing.T) {
-	file := []byte("abcdefghijklmnopqrstuvwxyz")
-	ioReader := bytes.NewReader(file)
-	p := NewPeekThresholdReader(ioReader)
+		isRemote, err := p.IsLargerThan(tt.thresholdSize)
+		assert.Equal(t, isRemote, tt.expectedIsRemote, errTag)
+		assert.NoError(t, err, errTag)
 
-	isRemote, err := p.IsLargerThan(10)
-	if !isRemote {
-		t.Fatal("expected isRemote to be true")
-	}
-	if err != nil {
-		t.Fatal("expected no err", err)
-	}
-
-	outputBuf := make([]byte, 30)
-	n, err := io.ReadFull(p, outputBuf)
-	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
-		t.Fatal("unexpected err from ReadFull:\n", err)
-	}
-	if n != len(file) {
-		t.Fatal("expected size of n to equal length of file")
-	}
-	if !bytes.Equal(outputBuf[:n], file) {
-		t.Fatal("expected data in outputBuf to match data in file")
-	}
-}
-
-func TestReadLessThanThresholdBuf(t *testing.T) {
-	file := []byte("abcdefghijklmnopqrstuvwxyz")
-	ioReader := bytes.NewReader(file)
-	p := NewPeekThresholdReader(ioReader)
-
-	isRemote, err := p.IsLargerThan(20)
-	if !isRemote {
-		t.Fatal("expected isRemote to be true")
-	}
-	if err != nil {
-		t.Fatal("expected no err", err)
-	}
-
-	outputBuf := make([]byte, 10)
-	n, err := io.ReadFull(p, outputBuf)
-	if err != nil {
-		t.Fatal("unexpected err from ReadFull:\n", err)
-	}
-	if n != len(outputBuf) {
-		t.Fatal("expected size of n to equal length of outputBuf")
-	}
-	if !bytes.Equal(outputBuf, file[:n]) {
-		t.Fatal("expected data in outputBuf to match data in beginning of file")
+		outputBuf := make([]byte, tt.outputBufLen)
+		n, err := io.ReadFull(p, outputBuf)
+		if tt.readsToEnd && err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+			t.Fatalf(errTag+"unexpected err from ReadFull:\n%s", err.Error())
+		} else if !tt.readsToEnd && err != nil {
+			t.Fatalf(errTag+"unexpected err from ReadFull:\n%s", err.Error())
+		}
+		if tt.readsToEnd && n != len(tt.file) {
+			t.Fatalf(errTag + "expected size of n to equal length of file")
+		}
+		if !tt.readsToEnd && n != tt.outputBufLen {
+			t.Fatalf(errTag + "expected n to equal length of outputBuf")
+		}
+		if !bytes.Equal(outputBuf[:n], tt.file[:n]) {
+			t.Fatalf(errTag + "expected data in outputBuf to match data in file")
+		}
 	}
 }
 
@@ -91,13 +58,8 @@ func TestMultipleIsLargerCall(t *testing.T) {
 	ioReader := bytes.NewReader(file)
 	p := NewPeekThresholdReader(ioReader)
 
-	isRemote, err := p.IsLargerThan(20)
-	if !isRemote {
-		t.Fatal("expected isRemote to be true")
-	}
-	if err != nil {
-		t.Fatal("expected no err", err)
-	}
+	_, err := p.IsLargerThan(20)
+	assert.NoError(t, err)
 
 	_, err = p.IsLargerThan(20)
 	if err == nil {
@@ -112,9 +74,7 @@ func TestIsLargerThanCalledAfterRead(t *testing.T) {
 
 	outputBuf := make([]byte, 10)
 	_, err := p.Read(outputBuf)
-	if err != nil {
-		t.Fatal("expected no err from Read")
-	}
+	assert.NoError(t, err)
 
 	_, err = p.IsLargerThan(20)
 	if err == nil {

--- a/pkg/storage/segments/peek_test.go
+++ b/pkg/storage/segments/peek_test.go
@@ -2,3 +2,112 @@
 // See LICENSE for copying information.
 
 package segments
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestStrictlyLessThanThresh(t *testing.T) {
+	file := []byte("abcdefghijklmnopqrstuvwxyz")
+	ioReader := bytes.NewReader(file)
+	p := NewPeekThresholdReader(ioReader)
+
+	isRemote, err := p.IsLargerThan(30)
+	if isRemote {
+		t.Fatal("expected isRemote to be false")
+	}
+	if err != nil {
+		t.Fatal("expected no err", err)
+	}
+
+	outputBuf := make([]byte, 30)
+	n, err := p.Read(outputBuf)
+	if n != len(file) {
+		t.Fatal("expected size of n to equal length of file")
+	}
+	if !bytes.Equal(outputBuf[:n], file) {
+		t.Fatal("expected data in outputBuf to match data in file")
+	}
+}
+func TestStrictlyGreaterThanThresh(t *testing.T) {
+	file := []byte("abcdefghijklmnopqrstuvwxyz")
+	ioReader := bytes.NewReader(file)
+	p := NewPeekThresholdReader(ioReader)
+
+	isRemote, err := p.IsLargerThan(10)
+	if !isRemote {
+		t.Fatal("expected isRemote to be true")
+	}
+	if err != nil {
+		t.Fatal("expected no err", err)
+	}
+
+	outputBuf := make([]byte, 30)
+	n, err := p.Read(outputBuf)
+	if n != len(file) {
+		t.Fatal("expected size of n to equal length of file")
+	}
+	if !bytes.Equal(outputBuf[:n], file) {
+		t.Fatal("expected data in outputBuf to match data in file")
+	}
+}
+
+func TestReadLessThanThresholdBuf(t *testing.T) {
+	file := []byte("abcdefghijklmnopqrstuvwxyz")
+	ioReader := bytes.NewReader(file)
+	p := NewPeekThresholdReader(ioReader)
+
+	isRemote, err := p.IsLargerThan(20)
+	if !isRemote {
+		t.Fatal("expected isRemote to be true")
+	}
+	if err != nil {
+		t.Fatal("expected no err", err)
+	}
+
+	outputBuf := make([]byte, 10)
+	n, err := p.Read(outputBuf)
+	if n != len(outputBuf) {
+		t.Fatal("expected size of n to equal length of outputBuf")
+	}
+	if !bytes.Equal(outputBuf, file[:n]) {
+		t.Fatal("expected data in outputBuf to match data in beginning of file")
+	}
+}
+
+func TestMultipleIsLargerCall(t *testing.T) {
+	file := []byte("abcdefghijklmnopqrstuvwxyz")
+	ioReader := bytes.NewReader(file)
+	p := NewPeekThresholdReader(ioReader)
+
+	isRemote, err := p.IsLargerThan(20)
+	if !isRemote {
+		t.Fatal("expected isRemote to be true")
+	}
+	if err != nil {
+		t.Fatal("expected no err", err)
+	}
+
+	_, err = p.IsLargerThan(20)
+	if err == nil {
+		t.Fatal("expected to err because multiple call")
+	}
+}
+
+func TestIsLargerThanCalledAfterRead(t *testing.T) {
+	file := []byte("abcdefghijklmnopqrstuvwxyz")
+	ioReader := bytes.NewReader(file)
+	p := NewPeekThresholdReader(ioReader)
+
+	outputBuf := make([]byte, 10)
+	_, err := p.Read(outputBuf)
+	if err != nil {
+		t.Fatal("expected no err from Read")
+	}
+
+	_, err = p.IsLargerThan(20)
+	if err == nil {
+		t.Fatal("expected to err because IsLargerThan called after Read")
+	}
+}

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -92,7 +92,7 @@ func (s *segmentStore) Put(ctx context.Context, path paths.Path, data io.Reader,
 
 	exp, err := ptypes.TimestampProto(expiration)
 	if err != nil {
-		return nil, Error.Wrap(err)
+		return Meta{}, Error.Wrap(err)
 	}
 
 	peekReader := NewPeekThresholdReader(data)

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -122,7 +122,7 @@ func (s *segmentStore) Put(ctx context.Context, path paths.Path, data io.Reader,
 		if err != nil {
 			return Meta{}, Error.Wrap(err)
 		}
-		p, err = s.makeRemotePointer(nodes, pieceID, sizedReader, exp, metadata)
+		p, err = s.makeRemotePointer(nodes, pieceID, sizedReader.Size(), exp, metadata)
 		if err != nil {
 			return Meta{}, err
 		}
@@ -143,7 +143,7 @@ func (s *segmentStore) Put(ctx context.Context, path paths.Path, data io.Reader,
 }
 
 // makeRemotePointer creates a pointer of type remote
-func (s *segmentStore) makeRemotePointer(nodes []*opb.Node, pieceID client.PieceID, sizedReader *SizedReader,
+func (s *segmentStore) makeRemotePointer(nodes []*opb.Node, pieceID client.PieceID, readerSize int64,
 	exp *timestamp.Timestamp, metadata []byte) (pointer *ppb.Pointer, err error) {
 	var remotePieces []*ppb.RemotePiece
 	for i := range nodes {
@@ -166,7 +166,7 @@ func (s *segmentStore) makeRemotePointer(nodes []*opb.Node, pieceID client.Piece
 			PieceId:      string(pieceID),
 			RemotePieces: remotePieces,
 		},
-		Size:           sizedReader.Size(),
+		Size:           readerSize,
 		ExpirationDate: exp,
 		Metadata:       metadata,
 	}

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -70,6 +70,84 @@ func NewSegmentStore(oc overlay.Client, ec ecclient.Client,
 	return &segmentStore{oc: oc, ec: ec, pdb: pdb, rs: rs, thresholdSize: t}
 }
 
+// PeekThresholdReader allows a check to see if the size of a given reader
+// exceeds the maximum inline segment size or not.
+type PeekThresholdReader struct {
+	r              io.Reader
+	n              int // number of bytes read into thresholdBuf
+	thresholdBuf   []byte
+	totalReadBytes int
+}
+
+// NewPeekThresholdReader creates a new instance of PeekThresholdReader
+func NewPeekThresholdReader(r io.Reader) (pt *PeekThresholdReader) {
+	return &PeekThresholdReader{r: r, n: 0, thresholdBuf: nil, totalReadBytes: 0}
+}
+
+// Read initially reads bytes from the internal buffer, then continues
+// reading from the wrapped data reader. The number of bytes read `n`
+// is returned.
+func (pt *PeekThresholdReader) Read(p []byte) (n int, err error) {
+
+	// Case 1: if the total number of bytes read is greater than the number
+	// of bytes read into the thresholdBuf, then Read is called on the given
+	// byte slice.
+	if pt.totalReadBytes > pt.n {
+		return pt.r.Read(p)
+	}
+
+	thresholdBytesRemaining := pt.n - pt.totalReadBytes
+
+	// Case 2: if the length of the given byte slice p is less than or equal
+	// to the number of threshold bytes remaining to be read, then the slice
+	// of the threshold buffer from the end of totalReadBytes to the length
+	// of p is copied to p.
+	if len(p) <= thresholdBytesRemaining {
+		tmp := pt.thresholdBuf[pt.totalReadBytes : pt.totalReadBytes+len(p)]
+		copy(p, tmp)
+		pt.totalReadBytes += len(p)
+		return len(p), nil
+	}
+
+	// Case 3: The buffer tail slice is created then read.
+	// A slice of read bytes is copied to the given byte slice p.
+	tmp := pt.thresholdBuf[pt.totalReadBytes : pt.totalReadBytes+thresholdBytesRemaining]
+	bufTail := make([]byte, len(p)-thresholdBytesRemaining)
+	numTailBytes, err := pt.r.Read(bufTail)
+	if err != nil {
+		return 0, err
+	}
+	tmp = append(tmp, bufTail...)
+	copy(p, tmp)
+	n = thresholdBytesRemaining + numTailBytes
+	pt.totalReadBytes += n
+	return n, nil
+}
+
+// checkSize returns a bool to determine whether a reader's size
+// is inline-sized or not.
+func (pt *PeekThresholdReader) isInline(thresholdSize int) (inline bool, err error) {
+	err = pt.makeThresholdBuffer(thresholdSize)
+	if err != nil {
+		return false, err
+	}
+	if pt.n < thresholdSize {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (pt *PeekThresholdReader) makeThresholdBuffer(thresholdSize int) (err error) {
+	buf := make([]byte, thresholdSize)
+	n, err := pt.r.Read(buf)
+	if err != nil {
+		return err
+	}
+	pt.n = n
+	pt.thresholdBuf = buf
+	return nil
+}
+
 // Meta retrieves the metadata of the segment
 func (s *segmentStore) Meta(ctx context.Context, path paths.Path) (meta Meta,
 	err error) {
@@ -90,9 +168,12 @@ func (s *segmentStore) Put(ctx context.Context, path paths.Path, data io.Reader,
 
 	var p *ppb.Pointer
 
-	// checks if pointer should be inline or remote
-	// TODO(nat): check that size is less than s.thresholdSize
-	if data == nil {
+	peekReader := NewPeekThresholdReader(data)
+	remoteSized, err := peekReader.isInline(s.thresholdSize)
+	if err != nil {
+		return Meta{}, err
+	}
+	if !remoteSized {
 		p = &ppb.Pointer{
 			Type:     ppb.Pointer_INLINE,
 			Metadata: metadata,

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -70,84 +70,6 @@ func NewSegmentStore(oc overlay.Client, ec ecclient.Client,
 	return &segmentStore{oc: oc, ec: ec, pdb: pdb, rs: rs, thresholdSize: t}
 }
 
-// PeekThresholdReader allows a check to see if the size of a given reader
-// exceeds the maximum inline segment size or not.
-type PeekThresholdReader struct {
-	r              io.Reader
-	n              int // number of bytes read into thresholdBuf
-	thresholdBuf   []byte
-	totalReadBytes int
-}
-
-// NewPeekThresholdReader creates a new instance of PeekThresholdReader
-func NewPeekThresholdReader(r io.Reader) (pt *PeekThresholdReader) {
-	return &PeekThresholdReader{r: r, n: 0, thresholdBuf: nil, totalReadBytes: 0}
-}
-
-// Read initially reads bytes from the internal buffer, then continues
-// reading from the wrapped data reader. The number of bytes read `n`
-// is returned.
-func (pt *PeekThresholdReader) Read(p []byte) (n int, err error) {
-
-	// Case 1: if the total number of bytes read is greater than the number
-	// of bytes read into the thresholdBuf, then Read is called on the given
-	// byte slice.
-	if pt.totalReadBytes > pt.n {
-		return pt.r.Read(p)
-	}
-
-	thresholdBytesRemaining := pt.n - pt.totalReadBytes
-
-	// Case 2: if the length of the given byte slice p is less than or equal
-	// to the number of threshold bytes remaining to be read, then the slice
-	// of the threshold buffer from the end of totalReadBytes to the length
-	// of p is copied to p.
-	if len(p) <= thresholdBytesRemaining {
-		tmp := pt.thresholdBuf[pt.totalReadBytes : pt.totalReadBytes+len(p)]
-		copy(p, tmp)
-		pt.totalReadBytes += len(p)
-		return len(p), nil
-	}
-
-	// Case 3: The buffer tail slice is created then read.
-	// A slice of read bytes is copied to the given byte slice p.
-	tmp := pt.thresholdBuf[pt.totalReadBytes : pt.totalReadBytes+thresholdBytesRemaining]
-	bufTail := make([]byte, len(p)-thresholdBytesRemaining)
-	numTailBytes, err := pt.r.Read(bufTail)
-	if err != nil {
-		return 0, err
-	}
-	tmp = append(tmp, bufTail...)
-	copy(p, tmp)
-	n = thresholdBytesRemaining + numTailBytes
-	pt.totalReadBytes += n
-	return n, nil
-}
-
-// checkSize returns a bool to determine whether a reader's size
-// is inline-sized or not.
-func (pt *PeekThresholdReader) isInline(thresholdSize int) (inline bool, err error) {
-	err = pt.makeThresholdBuffer(thresholdSize)
-	if err != nil {
-		return false, err
-	}
-	if pt.n < thresholdSize {
-		return true, nil
-	}
-	return false, nil
-}
-
-func (pt *PeekThresholdReader) makeThresholdBuffer(thresholdSize int) (err error) {
-	buf := make([]byte, thresholdSize)
-	n, err := pt.r.Read(buf)
-	if err != nil {
-		return err
-	}
-	pt.n = n
-	pt.thresholdBuf = buf
-	return nil
-}
-
 // Meta retrieves the metadata of the segment
 func (s *segmentStore) Meta(ctx context.Context, path paths.Path) (meta Meta,
 	err error) {
@@ -169,14 +91,15 @@ func (s *segmentStore) Put(ctx context.Context, path paths.Path, data io.Reader,
 	var p *ppb.Pointer
 
 	peekReader := NewPeekThresholdReader(data)
-	remoteSized, err := peekReader.isInline(s.thresholdSize)
+	remoteSized, err := peekReader.IsLargerThan(s.thresholdSize)
 	if err != nil {
 		return Meta{}, err
 	}
 	if !remoteSized {
 		p = &ppb.Pointer{
-			Type:     ppb.Pointer_INLINE,
-			Metadata: metadata,
+			Type:          ppb.Pointer_INLINE,
+			Metadata:      metadata,
+			InlineSegment: peekReader.thresholdBuf,
 		}
 	} else {
 		// uses overlay client to request a list of nodes
@@ -185,14 +108,17 @@ func (s *segmentStore) Put(ctx context.Context, path paths.Path, data io.Reader,
 			return Meta{}, Error.Wrap(err)
 		}
 		pieceID := client.NewPieceID()
-		sizedReader := SizeReader(data)
+		sizedReader := SizeReader(peekReader)
 
 		// puts file to ecclient
 		err = s.ec.Put(ctx, nodes, s.rs, pieceID, sizedReader, expiration)
 		if err != nil {
 			return Meta{}, Error.Wrap(err)
 		}
-		p = s.makeRemotePointer(nodes, pieceID, metadata)
+		p, err = s.makeRemotePointer(nodes, pieceID, expiration, metadata)
+		if err != nil {
+			return Meta{}, err
+		}
 	}
 
 	// puts pointer to pointerDB
@@ -211,7 +137,7 @@ func (s *segmentStore) Put(ctx context.Context, path paths.Path, data io.Reader,
 
 // makeRemotePointer creates a pointer of type remote
 func (s *segmentStore) makeRemotePointer(nodes []*opb.Node, pieceID client.PieceID,
-	metadata []byte) (pointer *ppb.Pointer) {
+	expiration time.Time, metadata []byte) (pointer *ppb.Pointer, err error) {
 	var remotePieces []*ppb.RemotePiece
 	for i := range nodes {
 		remotePieces = append(remotePieces, &ppb.RemotePiece{
@@ -219,12 +145,10 @@ func (s *segmentStore) makeRemotePointer(nodes []*opb.Node, pieceID client.Piece
 			NodeId:   nodes[i].Id,
 		})
 	}
-
 	exp, err := ptypes.TimestampProto(expiration)
 	if err != nil {
-		return Meta{}, Error.Wrap(err)
+		return nil, Error.Wrap(err)
 	}
-
 	pointer = &ppb.Pointer{
 		Type: ppb.Pointer_REMOTE,
 		Remote: &ppb.RemoteSegment{
@@ -242,7 +166,7 @@ func (s *segmentStore) makeRemotePointer(nodes []*opb.Node, pieceID client.Piece
 		ExpirationDate: exp,
 		Metadata:       metadata,
 	}
-	return pointer
+	return pointer, nil
 }
 
 // Get retrieves a segment using erasure code, overlay, and pointerdb clients
@@ -283,21 +207,19 @@ func (s *segmentStore) Delete(ctx context.Context, path paths.Path) (err error) 
 		return Error.Wrap(err)
 	}
 
-	if pr.GetType() != ppb.Pointer_REMOTE {
-		return Error.New("TODO: only getting remote pointers supported")
-	}
+	if pr.GetType() == ppb.Pointer_REMOTE {
+		seg := pr.GetRemote()
+		pid := client.PieceID(seg.PieceId)
+		nodes, err := s.lookupNodes(ctx, seg)
+		if err != nil {
+			return Error.Wrap(err)
+		}
 
-	seg := pr.GetRemote()
-	pid := client.PieceID(seg.PieceId)
-	nodes, err := s.lookupNodes(ctx, seg)
-	if err != nil {
-		return Error.Wrap(err)
-	}
-
-	// ecclient sends delete request
-	err = s.ec.Delete(ctx, nodes, pid)
-	if err != nil {
-		return Error.Wrap(err)
+		// ecclient sends delete request
+		err = s.ec.Delete(ctx, nodes, pid)
+		if err != nil {
+			return Error.Wrap(err)
+		}
 	}
 
 	// deletes pointer from pointerdb

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -122,7 +122,7 @@ func (s *segmentStore) Put(ctx context.Context, path paths.Path, data io.Reader,
 		if err != nil {
 			return Meta{}, Error.Wrap(err)
 		}
-		p, err = s.makeRemotePointer(nodes, pieceID, expiration, metadata)
+		p, err = s.makeRemotePointer(nodes, pieceID, sizedReader, exp, metadata)
 		if err != nil {
 			return Meta{}, err
 		}
@@ -143,8 +143,8 @@ func (s *segmentStore) Put(ctx context.Context, path paths.Path, data io.Reader,
 }
 
 // makeRemotePointer creates a pointer of type remote
-func (s *segmentStore) makeRemotePointer(nodes []*opb.Node, pieceID client.PieceID,
-	expiration time.Time, metadata []byte) (pointer *ppb.Pointer, err error) {
+func (s *segmentStore) makeRemotePointer(nodes []*opb.Node, pieceID client.PieceID, sizedReader *SizedReader,
+	exp *timestamp.Timestamp, metadata []byte) (pointer *ppb.Pointer, err error) {
 	var remotePieces []*ppb.RemotePiece
 	for i := range nodes {
 		remotePieces = append(remotePieces, &ppb.RemotePiece{
@@ -152,10 +152,7 @@ func (s *segmentStore) makeRemotePointer(nodes []*opb.Node, pieceID client.Piece
 			NodeId:   nodes[i].Id,
 		})
 	}
-	exp, err := ptypes.TimestampProto(expiration)
-	if err != nil {
-		return nil, Error.Wrap(err)
-	}
+
 	pointer = &ppb.Pointer{
 		Type: ppb.Pointer_REMOTE,
 		Remote: &ppb.RemoteSegment{

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -100,6 +100,7 @@ func (s *segmentStore) Put(ctx context.Context, path paths.Path, data io.Reader,
 			Type:          ppb.Pointer_INLINE,
 			Metadata:      metadata,
 			InlineSegment: peekReader.thresholdBuf,
+			Size:          len(peekReader.thresholdBuf),
 		}
 	} else {
 		// uses overlay client to request a list of nodes
@@ -179,20 +180,20 @@ func (s *segmentStore) Get(ctx context.Context, path paths.Path) (
 		return nil, Meta{}, Error.Wrap(err)
 	}
 
-	if pr.GetType() != ppb.Pointer_REMOTE {
-		return nil, Meta{}, Error.New("TODO: only getting remote pointers supported")
-	}
+	if pr.GetType() == ppb.Pointer_REMOTE {
+		seg := pr.GetRemote()
+		pid := client.PieceID(seg.PieceId)
+		nodes, err := s.lookupNodes(ctx, seg)
+		if err != nil {
+			return nil, Meta{}, Error.Wrap(err)
+		}
 
-	seg := pr.GetRemote()
-	pid := client.PieceID(seg.PieceId)
-	nodes, err := s.lookupNodes(ctx, seg)
-	if err != nil {
-		return nil, Meta{}, Error.Wrap(err)
-	}
-
-	rr, err = s.ec.Get(ctx, nodes, s.rs, pid, pr.GetSize())
-	if err != nil {
-		return nil, Meta{}, Error.Wrap(err)
+		rr, err = s.ec.Get(ctx, nodes, s.rs, pid, pr.GetSize())
+		if err != nil {
+			return nil, Meta{}, Error.Wrap(err)
+		}
+	} else {
+		rr = ranger.NopCloser(ranger.ByteRanger(pr.InlineSegment))
 	}
 
 	return rr, convertMeta(pr), nil

--- a/pkg/storage/segments/store_test.go
+++ b/pkg/storage/segments/store_test.go
@@ -1,0 +1,4 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package segments


### PR DESCRIPTION
So @kaloyan-raev and I decided that pointerdb does not have to change to accommodate S3 buckets. Instead, when the segment store receives a Put request (e.g. with path `l/my-bucket-name`) and an empty reader, it should put a pointer (of type INLINE) to pointerdb.

Before this PR, segment store does not support putting pointers of type inline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/162)
<!-- Reviewable:end -->
