### PR TITLE
cmd/hc, cmd/gw, cmd/captplanet: simplify setup/run commands

### DIFF
--- a/cmd/captplanet/main.go
+++ b/cmd/captplanet/main.go
@@ -4,11 +4,9 @@
 package main
 
 import (
-	"flag"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	monkit "gopkg.in/spacemonkeygo/monkit.v2"
 	"storj.io/storj/pkg/process"
 )
@@ -25,7 +23,10 @@ var (
 )
 
 func main() {
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	process.ExecuteWithConfig(rootCmd,
-		filepath.Join(defaultConfDir, "config.yaml"))
+	// process.Exec will load this for this command.
+	runCmd.Flags().String("config",
+		filepath.Join(defaultConfDir, "config.yaml"), "path to configuration")
+	setupCmd.Flags().String("config",
+		filepath.Join(defaultConfDir, "setup.yaml"), "path to configuration")
+	process.Exec(rootCmd)
 }

--- a/cmd/captplanet/run.go
+++ b/cmd/captplanet/run.go
@@ -5,8 +5,6 @@ package main
 
 import (
 	"fmt"
-	"net"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -20,122 +18,76 @@ import (
 	"storj.io/storj/pkg/provider"
 )
 
+const (
+	farmerCount = 40
+)
+
+type HeavyClient struct {
+	Identity  provider.IdentityConfig
+	Kademlia  kademlia.Config
+	PointerDB pointerdb.Config
+	Overlay   overlay.Config
+}
+
+type Farmer struct {
+	Identity provider.IdentityConfig
+	Kademlia kademlia.Config
+	Storage  psservice.Config
+}
+
 var (
 	runCmd = &cobra.Command{
 		Use:   "run",
 		Short: "Run all providers",
 		RunE:  cmdRun,
 	}
-	runCfg Config
+
+	runCfg struct {
+		HeavyClient HeavyClient
+		Farmers     [farmerCount]Farmer
+		Gateway     miniogw.Config
+	}
 )
 
 func init() {
 	rootCmd.AddCommand(runCmd)
-	cfgstruct.Bind(runCmd.Flags(), &runCfg,
-		cfgstruct.ConfDir(defaultConfDir),
-	)
+	cfgstruct.Bind(runCmd.Flags(), &runCfg, cfgstruct.ConfDir(defaultConfDir))
 }
 
 func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	ctx := process.Ctx(cmd)
 	defer mon.Task()(&ctx)(&err)
 
-	startingPort := runCfg.StartingPort
-
-	errch := make(chan error, runCfg.FarmerCount+2)
-
-	// define heavy client config programmatically
-	type HeavyClient struct {
-		Identity  provider.IdentityConfig
-		Kademlia  kademlia.Config
-		PointerDB pointerdb.Config
-		Overlay   overlay.Config
-	}
-
-	hc := HeavyClient{
-		Identity: provider.IdentityConfig{
-			CertPath: filepath.Join(runCfg.BasePath, "hc", "ident.leaf.cert"),
-			KeyPath:  filepath.Join(runCfg.BasePath, "hc", "ident.leaf.key"),
-			Address:  joinHostPort(runCfg.ListenHost, startingPort+1),
-		},
-		Kademlia: kademlia.Config{
-			TODOListenAddr: joinHostPort(runCfg.ListenHost, startingPort+2),
-			BootstrapAddr:  joinHostPort(runCfg.ListenHost, startingPort+4),
-		},
-		PointerDB: pointerdb.Config{
-			DatabaseURL: "bolt://" + filepath.Join(
-				runCfg.BasePath, "hc", "pointerdb.db"),
-		},
-		Overlay: overlay.Config{
-			DatabaseURL: "bolt://" + filepath.Join(
-				runCfg.BasePath, "hc", "overlay.db"),
-		},
-	}
+	errch := make(chan error, len(runCfg.Farmers)+2)
 
 	// start heavy client
 	go func() {
-		_, _ = fmt.Printf("starting heavy client on %s\n", hc.Identity.Address)
-		errch <- hc.Identity.Run(ctx, hc.Kademlia, hc.PointerDB, hc.Overlay)
+		_, _ = fmt.Printf("starting heavy client on %s\n",
+			runCfg.HeavyClient.Identity.Address)
+		errch <- runCfg.HeavyClient.Identity.Run(ctx,
+			runCfg.HeavyClient.Kademlia,
+			runCfg.HeavyClient.PointerDB,
+			runCfg.HeavyClient.Overlay)
 	}()
 
-	// define and start a bunch of farmers programmatically
-	type Farmer struct {
-		Identity provider.IdentityConfig
-		Kademlia kademlia.Config
-		Storage  psservice.Config
-	}
-
-	for i := 0; i < runCfg.FarmerCount; i++ {
-		basepath := filepath.Join(runCfg.BasePath, fmt.Sprintf("f%d", i))
-		farmer := Farmer{
-			Identity: provider.IdentityConfig{
-				CertPath: filepath.Join(basepath, "ident.leaf.cert"),
-				KeyPath:  filepath.Join(basepath, "ident.leaf.key"),
-				Address:  joinHostPort(runCfg.ListenHost, startingPort+i*2+3),
-			},
-			Kademlia: kademlia.Config{
-				TODOListenAddr: joinHostPort(runCfg.ListenHost, startingPort+i*2+4),
-				BootstrapAddr:  joinHostPort(runCfg.ListenHost, startingPort+1),
-			},
-			Storage: psservice.Config{
-				Path: filepath.Join(basepath, "data"),
-			},
-		}
+	// start the farmers
+	for i := 0; i < len(runCfg.Farmers); i++ {
 		go func(i int) {
-			_, _ = fmt.Printf("starting farmer %d grpc on %s, kad on %s\n",
-				i, farmer.Identity.Address, farmer.Kademlia.TODOListenAddr)
-			errch <- farmer.Identity.Run(ctx, farmer.Kademlia, farmer.Storage)
+			_, _ = fmt.Printf("starting farmer %d grpc on %s, kad on %s\n", i,
+				runCfg.Farmers[i].Identity.Address,
+				runCfg.Farmers[i].Kademlia.TODOListenAddr)
+			errch <- runCfg.Farmers[i].Identity.Run(ctx,
+				runCfg.Farmers[i].Kademlia,
+				runCfg.Farmers[i].Storage)
 		}(i)
 	}
 
 	// start s3 gateway
-	gw := miniogw.Config{
-		IdentityConfig: provider.IdentityConfig{
-			CertPath: filepath.Join(runCfg.BasePath, "gw", "ident.leaf.cert"),
-			KeyPath:  filepath.Join(runCfg.BasePath, "gw", "ident.leaf.key"),
-			Address:  joinHostPort(runCfg.ListenHost, startingPort),
-		},
-		MinioConfig: runCfg.MinioConfig,
-		ClientConfig: miniogw.ClientConfig{
-			OverlayAddr: joinHostPort(
-				runCfg.ListenHost, startingPort+1),
-			PointerDBAddr: joinHostPort(
-				runCfg.ListenHost, startingPort+1),
-		},
-		RSConfig: runCfg.RSConfig,
-	}
-	gw.MinioConfig.MinioDir = filepath.Join(runCfg.BasePath, "gw", "minio")
-
-	// start s3 gateway
 	go func() {
 		_, _ = fmt.Printf("starting minio gateway on %s\n",
-			gw.IdentityConfig.Address)
-		errch <- gw.Run(ctx)
+			runCfg.Gateway.IdentityConfig.Address)
+		errch <- runCfg.Gateway.Run(ctx)
 	}()
 
 	return <-errch
-}
-
-func joinHostPort(host string, port int) string {
-	return net.JoinHostPort(host, fmt.Sprint(port))
 }


### PR DESCRIPTION
also allows much more customization of services within captain planet,
such as reconfiguring the overlay service to use redis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/178)
<!-- Reviewable:end -->
