### PR TITLE
ECClient pads data to fit RS block size

### DIFF
--- a/pkg/eestream/crc_test.go
+++ b/pkg/eestream/crc_test.go
@@ -78,12 +78,12 @@ func (c *crcChecker) Transform(out, in []byte, blockOffset int64) (
 
 // addCRC is a Ranger constructor, given a specific crc table and an existing
 // un-crced Ranger
-func addCRC(data ranger.Ranger, tab *crc32.Table) (ranger.Ranger, error) {
+func addCRC(data ranger.RangeCloser, tab *crc32.Table) (ranger.RangeCloser, error) {
 	return Transform(data, newCRCAdder(tab))
 }
 
 // checkCRC is a Ranger constructor, given a specific crc table and an existing
 // crced Ranger
-func checkCRC(data ranger.Ranger, tab *crc32.Table) (ranger.Ranger, error) {
+func checkCRC(data ranger.RangeCloser, tab *crc32.Table) (ranger.RangeCloser, error) {
 	return Transform(data, newCRCChecker(tab))
 }

--- a/pkg/eestream/pad.go
+++ b/pkg/eestream/pad.go
@@ -42,13 +42,13 @@ func Pad(data ranger.Ranger, blockSize int) (
 // Unpad takes a previously padded Ranger data source and returns an unpadded
 // ranger, given the amount of padding. This is preferable to UnpadSlow if you
 // can swing it.
-func Unpad(data ranger.Ranger, padding int) (ranger.Ranger, error) {
+func Unpad(data ranger.RangeCloser, padding int) (ranger.RangeCloser, error) {
 	return ranger.Subrange(data, 0, data.Size()-int64(padding))
 }
 
 // UnpadSlow is like Unpad, but does not require the amount of padding.
 // UnpadSlow will have to do extra work to make up for this missing information.
-func UnpadSlow(ctx context.Context, data ranger.Ranger) (ranger.Ranger, error) {
+func UnpadSlow(ctx context.Context, data ranger.RangeCloser) (ranger.RangeCloser, error) {
 	r, err := data.Range(ctx, data.Size()-uint32Size, uint32Size)
 	if err != nil {
 		return nil, Error.Wrap(err)

--- a/pkg/eestream/pad_test.go
+++ b/pkg/eestream/pad_test.go
@@ -44,7 +44,7 @@ func TestPad(t *testing.T) {
 		if int64(padding+len(example.data)) != padded.Size() {
 			t.Fatalf("invalid padding")
 		}
-		unpadded, err := Unpad(padded, padding)
+		unpadded, err := Unpad(ranger.NopCloser(padded), padding)
 		if err != nil {
 			t.Fatalf("unexpected error")
 		}
@@ -59,7 +59,7 @@ func TestPad(t *testing.T) {
 		if !bytes.Equal(data, []byte(example.data)) {
 			t.Fatalf("mismatch")
 		}
-		unpadded, err = UnpadSlow(ctx, padded)
+		unpadded, err = UnpadSlow(ctx, ranger.NopCloser(padded))
 		if err != nil {
 			t.Fatalf("unexpected error")
 		}

--- a/pkg/eestream/rs_test.go
+++ b/pkg/eestream/rs_test.go
@@ -113,7 +113,7 @@ func TestRSRanger(t *testing.T) {
 	}
 	rrs := map[int]ranger.RangeCloser{}
 	for i, piece := range pieces {
-		rrs[i] = ranger.NopCloser(ranger.ByteRanger(piece))
+		rrs[i] = ranger.ByteRangeCloser(piece)
 	}
 	decrypter, err := NewAESGCMDecrypter(
 		&encKey, &firstNonce, rs.DecodedBlockSize())

--- a/pkg/eestream/transform.go
+++ b/pkg/eestream/transform.go
@@ -92,12 +92,12 @@ func (t *transformedReader) Close() error {
 }
 
 type transformedRanger struct {
-	rr ranger.Ranger
+	rr ranger.RangeCloser
 	t  Transformer
 }
 
 // Transform will apply a Transformer to a Ranger.
-func Transform(rr ranger.Ranger, t Transformer) (ranger.Ranger, error) {
+func Transform(rr ranger.RangeCloser, t Transformer) (ranger.RangeCloser, error) {
 	if rr.Size()%int64(t.InBlockSize()) != 0 {
 		return nil, Error.New("invalid transformer and range reader combination." +
 			"the range reader size is not a multiple of the block size")
@@ -158,4 +158,8 @@ func (t *transformedRanger) Range(ctx context.Context, offset, length int64) (io
 	}
 	// the range might have been too long. only return what was requested
 	return readcloser.LimitReadCloser(tr, length), nil
+}
+
+func (t *transformedRanger) Close() error {
+	return t.rr.Close()
 }

--- a/pkg/eestream/transform_test.go
+++ b/pkg/eestream/transform_test.go
@@ -69,7 +69,7 @@ func TestCalcEncompassingBlocks(t *testing.T) {
 
 func TestCRC(t *testing.T) {
 	const blocks = 3
-	rr, err := addCRC(ranger.ByteRanger(bytes.Repeat([]byte{0}, blocks*64)),
+	rr, err := addCRC(ranger.ByteRangeCloser(bytes.Repeat([]byte{0}, blocks*64)),
 		crc32.IEEETable)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
@@ -87,7 +87,7 @@ func TestCRC(t *testing.T) {
 		t.Fatalf("unexpected: %v", err)
 	}
 
-	rr, err = checkCRC(ranger.ByteRanger(data), crc32.IEEETable)
+	rr, err = checkCRC(ranger.ByteRangeCloser(data), crc32.IEEETable)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestCRC(t *testing.T) {
 func TestCRCSubranges(t *testing.T) {
 	const blocks = 3
 	data := bytes.Repeat([]byte{0, 1, 2}, blocks*64)
-	internal, err := addCRC(ranger.ByteRanger(data), crc32.IEEETable)
+	internal, err := addCRC(ranger.ByteRangeCloser(data), crc32.IEEETable)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}

--- a/pkg/ranger/reader_test.go
+++ b/pkg/ranger/reader_test.go
@@ -115,7 +115,7 @@ func TestSubranger(t *testing.T) {
 		{"abcdefghijkl", 8, 4, 0, 3, "ijk"},
 		{"abcdefghijkl", 8, 4, 1, 3, "jkl"},
 	} {
-		rr, err := Subrange(ByteRanger([]byte(example.data)),
+		rr, err := Subrange(ByteRangeCloser([]byte(example.data)),
 			example.offset1, example.length1)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
@@ -148,7 +148,7 @@ func TestSubrangerError(t *testing.T) {
 		{name: "Length and offset is bigger than DataSize", data: "abcd", offset: 4, length: 1},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			rr, err := Subrange(ByteRanger([]byte(tt.data)), tt.offset, tt.length)
+			rr, err := Subrange(ByteRangeCloser([]byte(tt.data)), tt.offset, tt.length)
 			assert.Nil(t, rr)
 			assert.NotNil(t, err)
 		})

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -196,7 +196,7 @@ func (s *segmentStore) Get(ctx context.Context, path paths.Path) (
 			return nil, Meta{}, Error.Wrap(err)
 		}
 	} else {
-		rr = ranger.NopCloser(ranger.ByteRanger(pr.InlineSegment))
+		rr = ranger.ByteRangeCloser(pr.InlineSegment)
 	}
 
 	return rr, convertMeta(pr), nil


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/199)
<!-- Reviewable:end -->
