### PR TITLE
Group erasure shares before sending them to storage nodes

### DIFF
--- a/pkg/piecestore/rpc/client/client.go
+++ b/pkg/piecestore/rpc/client/client.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"log"
@@ -76,9 +77,12 @@ func (client *Client) Put(ctx context.Context, id PieceID, data io.Reader, ttl t
 		}
 	}()
 
-	_, err = io.Copy(writer, data)
-
-	return err
+	bufw := bufio.NewWriterSize(writer, 32*1024)
+	_, err = io.Copy(bufw, data)
+	if err != nil {
+		return err
+	}
+	return bufw.Flush()
 }
 
 // Get begins downloading a Piece from a piece store Server


### PR DESCRIPTION
First step in resolving https://storjlabs.atlassian.net/browse/V3-208

If having small erasure shares (e.g. 20 bytes) the piece store client would send each of them in a separate gRPC message, which is not efficient.

This patch uses a bufio.Writer to group erasure shares up to 32 KB before sending them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/210)
<!-- Reviewable:end -->
