### PR TITLE
Use utils.LogClose for deferred closing in miniogw

### DIFF
--- a/pkg/miniogw/gateway-storj.go
+++ b/pkg/miniogw/gateway-storj.go
@@ -18,6 +18,7 @@ import (
 	"storj.io/storj/pkg/storage/buckets"
 	"storj.io/storj/pkg/storage/meta"
 	"storj.io/storj/pkg/storage/objects"
+	"storj.io/storj/pkg/utils"
 	"storj.io/storj/storage"
 )
 
@@ -111,22 +112,12 @@ func (s *storjObjects) GetObject(ctx context.Context, bucket, object string,
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := rr.Close(); err != nil {
-			// ignore for now
-		}
-	}()
+	defer utils.LogClose(rr)
 	r, err := rr.Range(ctx, startOffset, length)
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		if err = r.Close(); err != nil {
-			// ignore for now
-		}
-	}()
-
+	defer utils.LogClose(r)
 	_, err = io.Copy(writer, r)
 	return err
 }


### PR DESCRIPTION
Now as we have a utility function for properly closing io.Closers with logging of eventual errors, let's use it in the miniogw code too.

This path also fixes a bug in the GetObject where one of the deferred close is eclipsing the actual error that could occur during the download.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/239)
<!-- Reviewable:end -->
