### PR TITLE
Avoid logging any minio error in miniogw logging wrapper

### DIFF
--- a/pkg/miniogw/logging/logging_test.go
+++ b/pkg/miniogw/logging/logging_test.go
@@ -45,6 +45,7 @@ const (
 var (
 	ctx      = context.Background()
 	ErrTest  = errors.New(testError)
+	ErrMinio = minio.BucketNotFound{}
 	metadata = map[string]string{"key": "value"}
 )
 
@@ -115,7 +116,12 @@ func TestShutdown(t *testing.T) {
 	mol.EXPECT().Shutdown(ctx).Return(ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	err = ol.Shutdown(ctx)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+
+	// Minio error returned
+	mol.EXPECT().Shutdown(ctx).Return(ErrMinio)
+	err = ol.Shutdown(ctx)
+	assert.Error(t, err, ErrMinio.Error())
 }
 
 func TestStorageInfo(t *testing.T) {
@@ -147,7 +153,12 @@ func TestMakeBucketWithLocation(t *testing.T) {
 	mol.EXPECT().MakeBucketWithLocation(ctx, bucket, location).Return(ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	err = ol.MakeBucketWithLocation(ctx, bucket, location)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+
+	// Minio error returned
+	mol.EXPECT().MakeBucketWithLocation(ctx, bucket, location).Return(ErrMinio)
+	err = ol.MakeBucketWithLocation(ctx, bucket, location)
+	assert.Error(t, err, ErrMinio.Error())
 }
 
 func TestGetBucketInfo(t *testing.T) {
@@ -166,7 +177,13 @@ func TestGetBucketInfo(t *testing.T) {
 	mol.EXPECT().GetBucketInfo(ctx, bucket).Return(minio.BucketInfo{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	info, err = ol.GetBucketInfo(ctx, bucket)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, minio.BucketInfo{}, info)
+
+	// Minio error returned
+	mol.EXPECT().GetBucketInfo(ctx, bucket).Return(minio.BucketInfo{}, ErrMinio)
+	info, err = ol.GetBucketInfo(ctx, bucket)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, minio.BucketInfo{}, info)
 }
 
@@ -186,7 +203,13 @@ func TestListBuckets(t *testing.T) {
 	mol.EXPECT().ListBuckets(ctx).Return([]minio.BucketInfo{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	list, err = ol.ListBuckets(ctx)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, []minio.BucketInfo{}, list)
+
+	// Minio error returned
+	mol.EXPECT().ListBuckets(ctx).Return([]minio.BucketInfo{}, ErrMinio)
+	list, err = ol.ListBuckets(ctx)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, []minio.BucketInfo{}, list)
 }
 
@@ -205,7 +228,12 @@ func TestDeleteBucket(t *testing.T) {
 	mol.EXPECT().DeleteBucket(ctx, bucket).Return(ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	err = ol.DeleteBucket(ctx, bucket)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+
+	// Minio error returned
+	mol.EXPECT().DeleteBucket(ctx, bucket).Return(ErrMinio)
+	err = ol.DeleteBucket(ctx, bucket)
+	assert.Error(t, err, ErrMinio.Error())
 }
 
 func TestListObjects(t *testing.T) {
@@ -226,7 +254,14 @@ func TestListObjects(t *testing.T) {
 		Return(minio.ListObjectsInfo{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	list, err = ol.ListObjects(ctx, bucket, prefix, marker, delimiter, maxKeys)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, minio.ListObjectsInfo{}, list)
+
+	// Minio error returned
+	mol.EXPECT().ListObjects(ctx, bucket, prefix, marker, delimiter, maxKeys).
+		Return(minio.ListObjectsInfo{}, ErrMinio)
+	list, err = ol.ListObjects(ctx, bucket, prefix, marker, delimiter, maxKeys)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, minio.ListObjectsInfo{}, list)
 }
 
@@ -254,7 +289,15 @@ func TestListObjectsV2(t *testing.T) {
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	list, err = ol.ListObjectsV2(ctx, bucket, prefix, marker, delimiter,
 		maxKeys, owner, startAfter)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, minio.ListObjectsV2Info{}, list)
+
+	// Minio error returned
+	mol.EXPECT().ListObjectsV2(ctx, bucket, prefix, marker, delimiter, maxKeys,
+		owner, startAfter).Return(minio.ListObjectsV2Info{}, ErrMinio)
+	list, err = ol.ListObjectsV2(ctx, bucket, prefix, marker, delimiter,
+		maxKeys, owner, startAfter)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, minio.ListObjectsV2Info{}, list)
 }
 
@@ -276,7 +319,12 @@ func TestGetObject(t *testing.T) {
 	mol.EXPECT().GetObject(ctx, bucket, object, offset, length, w, etag).Return(ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	err = ol.GetObject(ctx, bucket, object, offset, length, w, etag)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+
+	// Minio error returned
+	mol.EXPECT().GetObject(ctx, bucket, object, offset, length, w, etag).Return(ErrMinio)
+	err = ol.GetObject(ctx, bucket, object, offset, length, w, etag)
+	assert.Error(t, err, ErrMinio.Error())
 }
 
 func TestGetObjectInfo(t *testing.T) {
@@ -295,7 +343,13 @@ func TestGetObjectInfo(t *testing.T) {
 	mol.EXPECT().GetObjectInfo(ctx, bucket, object).Return(minio.ObjectInfo{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	info, err = ol.GetObjectInfo(ctx, bucket, object)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, minio.ObjectInfo{}, info)
+
+	// Minio error returned
+	mol.EXPECT().GetObjectInfo(ctx, bucket, object).Return(minio.ObjectInfo{}, ErrMinio)
+	info, err = ol.GetObjectInfo(ctx, bucket, object)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, minio.ObjectInfo{}, info)
 }
 
@@ -317,7 +371,13 @@ func TestPutObject(t *testing.T) {
 	mol.EXPECT().PutObject(ctx, bucket, object, data, metadata).Return(minio.ObjectInfo{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	info, err = ol.PutObject(ctx, bucket, object, data, metadata)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, minio.ObjectInfo{}, info)
+
+	// Minio error returned
+	mol.EXPECT().PutObject(ctx, bucket, object, data, metadata).Return(minio.ObjectInfo{}, ErrMinio)
+	info, err = ol.PutObject(ctx, bucket, object, data, metadata)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, minio.ObjectInfo{}, info)
 }
 
@@ -339,7 +399,14 @@ func TestCopyObject(t *testing.T) {
 		Return(minio.ObjectInfo{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	info, err = ol.CopyObject(ctx, bucket, object, destBucket, destObject, objInfo)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, minio.ObjectInfo{}, info)
+
+	// Minio error returned
+	mol.EXPECT().CopyObject(ctx, bucket, object, destBucket, destObject, objInfo).
+		Return(minio.ObjectInfo{}, ErrMinio)
+	info, err = ol.CopyObject(ctx, bucket, object, destBucket, destObject, objInfo)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, minio.ObjectInfo{}, info)
 }
 
@@ -358,7 +425,12 @@ func TestDeleteObject(t *testing.T) {
 	mol.EXPECT().DeleteObject(ctx, bucket, object).Return(ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	err = ol.DeleteObject(ctx, bucket, object)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+
+	// Minio error returned
+	mol.EXPECT().DeleteObject(ctx, bucket, object).Return(ErrMinio)
+	err = ol.DeleteObject(ctx, bucket, object)
+	assert.Error(t, err, ErrMinio.Error())
 }
 
 func TestListMultipartUploads(t *testing.T) {
@@ -385,7 +457,15 @@ func TestListMultipartUploads(t *testing.T) {
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	list, err = ol.ListMultipartUploads(ctx, bucket, prefix, marker, uidMarker,
 		delimiter, maxKeys)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, minio.ListMultipartsInfo{}, list)
+
+	// Minio error returned
+	mol.EXPECT().ListMultipartUploads(ctx, bucket, prefix, marker, uidMarker,
+		delimiter, maxKeys).Return(minio.ListMultipartsInfo{}, ErrMinio)
+	list, err = ol.ListMultipartUploads(ctx, bucket, prefix, marker, uidMarker,
+		delimiter, maxKeys)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, minio.ListMultipartsInfo{}, list)
 }
 
@@ -405,7 +485,13 @@ func TestNewMultipartUpload(t *testing.T) {
 	mol.EXPECT().NewMultipartUpload(ctx, bucket, object, metadata).Return("", ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	id, err = ol.NewMultipartUpload(ctx, bucket, object, metadata)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, "", id)
+
+	// Minio error returned
+	mol.EXPECT().NewMultipartUpload(ctx, bucket, object, metadata).Return("", ErrMinio)
+	id, err = ol.NewMultipartUpload(ctx, bucket, object, metadata)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, "", id)
 }
 
@@ -429,7 +515,15 @@ func TestCopyObjectPart(t *testing.T) {
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	info, err = ol.CopyObjectPart(ctx, bucket, object, destBucket, destObject,
 		uploadID, partID, offset, length, objInfo)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, minio.PartInfo{}, info)
+
+	// Minio error returned
+	mol.EXPECT().CopyObjectPart(ctx, bucket, object, destBucket, destObject,
+		uploadID, partID, offset, length, objInfo).Return(minio.PartInfo{}, ErrMinio)
+	info, err = ol.CopyObjectPart(ctx, bucket, object, destBucket, destObject,
+		uploadID, partID, offset, length, objInfo)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, minio.PartInfo{}, info)
 }
 
@@ -453,7 +547,14 @@ func TestPutObjectPart(t *testing.T) {
 		Return(minio.PartInfo{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	info, err = ol.PutObjectPart(ctx, bucket, object, uploadID, partID, data)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, minio.PartInfo{}, info)
+
+	// Minio error returned
+	mol.EXPECT().PutObjectPart(ctx, bucket, object, uploadID, partID, data).
+		Return(minio.PartInfo{}, ErrMinio)
+	info, err = ol.PutObjectPart(ctx, bucket, object, uploadID, partID, data)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, minio.PartInfo{}, info)
 }
 
@@ -475,7 +576,14 @@ func TestListObjectParts(t *testing.T) {
 		Return(minio.ListPartsInfo{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	list, err = ol.ListObjectParts(ctx, bucket, object, uploadID, partMarker, maxKeys)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, minio.ListPartsInfo{}, list)
+
+	// Minio error returned
+	mol.EXPECT().ListObjectParts(ctx, bucket, object, uploadID, partMarker, maxKeys).
+		Return(minio.ListPartsInfo{}, ErrMinio)
+	list, err = ol.ListObjectParts(ctx, bucket, object, uploadID, partMarker, maxKeys)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, minio.ListPartsInfo{}, list)
 }
 
@@ -494,7 +602,12 @@ func TestAbortMultipartUpload(t *testing.T) {
 	mol.EXPECT().AbortMultipartUpload(ctx, bucket, object, uploadID).Return(ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	err = ol.AbortMultipartUpload(ctx, bucket, object, uploadID)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+
+	// Minio error returned
+	mol.EXPECT().AbortMultipartUpload(ctx, bucket, object, uploadID).Return(ErrMinio)
+	err = ol.AbortMultipartUpload(ctx, bucket, object, uploadID)
+	assert.Error(t, err, ErrMinio.Error())
 }
 
 func TestCompleteMultipartUpload(t *testing.T) {
@@ -517,7 +630,14 @@ func TestCompleteMultipartUpload(t *testing.T) {
 		Return(minio.ObjectInfo{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	info, err = ol.CompleteMultipartUpload(ctx, bucket, object, uploadID, parts)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, minio.ObjectInfo{}, info)
+
+	// Minio error returned
+	mol.EXPECT().CompleteMultipartUpload(ctx, bucket, object, uploadID, parts).
+		Return(minio.ObjectInfo{}, ErrMinio)
+	info, err = ol.CompleteMultipartUpload(ctx, bucket, object, uploadID, parts)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, minio.ObjectInfo{}, info)
 }
 
@@ -536,7 +656,12 @@ func TestReloadFormat(t *testing.T) {
 	mol.EXPECT().ReloadFormat(ctx, dryRun).Return(ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	err = ol.ReloadFormat(ctx, dryRun)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+
+	// Minio error returned
+	mol.EXPECT().ReloadFormat(ctx, dryRun).Return(ErrMinio)
+	err = ol.ReloadFormat(ctx, dryRun)
+	assert.Error(t, err, ErrMinio.Error())
 }
 
 func TestHealFormat(t *testing.T) {
@@ -555,7 +680,13 @@ func TestHealFormat(t *testing.T) {
 	mol.EXPECT().HealFormat(ctx, dryRun).Return(madmin.HealResultItem{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	item, err = ol.HealFormat(ctx, dryRun)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, madmin.HealResultItem{}, item)
+
+	// Minio error returned
+	mol.EXPECT().HealFormat(ctx, dryRun).Return(madmin.HealResultItem{}, ErrMinio)
+	item, err = ol.HealFormat(ctx, dryRun)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, madmin.HealResultItem{}, item)
 }
 
@@ -575,7 +706,13 @@ func TestHealBucket(t *testing.T) {
 	mol.EXPECT().HealBucket(ctx, bucket, dryRun).Return([]madmin.HealResultItem{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	list, err = ol.HealBucket(ctx, bucket, dryRun)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, []madmin.HealResultItem{}, list)
+
+	// Minio error returned
+	mol.EXPECT().HealBucket(ctx, bucket, dryRun).Return([]madmin.HealResultItem{}, ErrMinio)
+	list, err = ol.HealBucket(ctx, bucket, dryRun)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, []madmin.HealResultItem{}, list)
 }
 
@@ -595,7 +732,13 @@ func TestHealObject(t *testing.T) {
 	mol.EXPECT().HealObject(ctx, bucket, object, dryRun).Return(madmin.HealResultItem{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	item, err = ol.HealObject(ctx, bucket, object, dryRun)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, madmin.HealResultItem{}, item)
+
+	// Minio error returned
+	mol.EXPECT().HealObject(ctx, bucket, object, dryRun).Return(madmin.HealResultItem{}, ErrMinio)
+	item, err = ol.HealObject(ctx, bucket, object, dryRun)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, madmin.HealResultItem{}, item)
 }
 
@@ -615,7 +758,13 @@ func TestListBucketsHeal(t *testing.T) {
 	mol.EXPECT().ListBucketsHeal(ctx).Return([]minio.BucketInfo{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	list, err = ol.ListBucketsHeal(ctx)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, []minio.BucketInfo{}, list)
+
+	// Minio error returned
+	mol.EXPECT().ListBucketsHeal(ctx).Return([]minio.BucketInfo{}, ErrMinio)
+	list, err = ol.ListBucketsHeal(ctx)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, []minio.BucketInfo{}, list)
 }
 
@@ -637,7 +786,14 @@ func TestListObjectsHeal(t *testing.T) {
 		Return(minio.ListObjectsInfo{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	list, err = ol.ListObjectsHeal(ctx, bucket, prefix, marker, delimiter, maxKeys)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, minio.ListObjectsInfo{}, list)
+
+	// Minio error returned
+	mol.EXPECT().ListObjectsHeal(ctx, bucket, prefix, marker, delimiter, maxKeys).
+		Return(minio.ListObjectsInfo{}, ErrMinio)
+	list, err = ol.ListObjectsHeal(ctx, bucket, prefix, marker, delimiter, maxKeys)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, minio.ListObjectsInfo{}, list)
 }
 
@@ -658,7 +814,14 @@ func TestListLocks(t *testing.T) {
 		Return([]minio.VolumeLockInfo{}, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	list, err = ol.ListLocks(ctx, bucket, prefix, duration)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Equal(t, []minio.VolumeLockInfo{}, list)
+
+	// Minio error returned
+	mol.EXPECT().ListLocks(ctx, bucket, prefix, duration).
+		Return([]minio.VolumeLockInfo{}, ErrMinio)
+	list, err = ol.ListLocks(ctx, bucket, prefix, duration)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Equal(t, []minio.VolumeLockInfo{}, list)
 }
 
@@ -677,7 +840,12 @@ func TestClearLocks(t *testing.T) {
 	mol.EXPECT().ClearLocks(ctx, lockList).Return(ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	err = ol.ClearLocks(ctx, lockList)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+
+	// Minio error returned
+	mol.EXPECT().ClearLocks(ctx, lockList).Return(ErrMinio)
+	err = ol.ClearLocks(ctx, lockList)
+	assert.Error(t, err, ErrMinio.Error())
 }
 
 func TestSetBucketPolicy(t *testing.T) {
@@ -695,7 +863,12 @@ func TestSetBucketPolicy(t *testing.T) {
 	mol.EXPECT().SetBucketPolicy(ctx, n, plcy).Return(ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	err = ol.SetBucketPolicy(ctx, n, plcy)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+
+	// Minio error returned
+	mol.EXPECT().SetBucketPolicy(ctx, n, plcy).Return(ErrMinio)
+	err = ol.SetBucketPolicy(ctx, n, plcy)
+	assert.Error(t, err, ErrMinio.Error())
 }
 
 func TestGetBucketPolicy(t *testing.T) {
@@ -714,7 +887,13 @@ func TestGetBucketPolicy(t *testing.T) {
 	mol.EXPECT().GetBucketPolicy(ctx, n).Return(nil, ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	p, err = ol.GetBucketPolicy(ctx, n)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+	assert.Nil(t, p)
+
+	// Minio error returned
+	mol.EXPECT().GetBucketPolicy(ctx, n).Return(nil, ErrMinio)
+	p, err = ol.GetBucketPolicy(ctx, n)
+	assert.Error(t, err, ErrMinio.Error())
 	assert.Nil(t, p)
 }
 
@@ -733,7 +912,12 @@ func TestDeleteBucketPolicy(t *testing.T) {
 	mol.EXPECT().DeleteBucketPolicy(ctx, n).Return(ErrTest)
 	logger.EXPECT().Errorf(errTemplate, ErrTest)
 	err = ol.DeleteBucketPolicy(ctx, n)
-	assert.Error(t, err, testError)
+	assert.Error(t, err, ErrTest.Error())
+
+	// Minio error returned
+	mol.EXPECT().DeleteBucketPolicy(ctx, n).Return(ErrMinio)
+	err = ol.DeleteBucketPolicy(ctx, n)
+	assert.Error(t, err, ErrMinio.Error())
 }
 
 func TestIsNotificationSupported(t *testing.T) {


### PR DESCRIPTION
We want the logging wrapper of miniogw to log only unexpected errors, but not any minio.* errors. The latter are usually created by our code as part of the expected workflow, e.g. BucketNotFound, BucketAlreadyExists, ObjectNotFound, etc.

So far we've added explicit checks in the logging wrapper for each of the expected minio errors, but this turned to be time consuming and error-prone.

It turns out that all minio errors related to the object layer extend the `minio.GenericError` type: https://github.com/minio/minio/blob/master/cmd/object-api-errors.go#L124

This patch will check if the returned error is convertible `minio.GenericError` and will avoid logging it if it is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/240)
<!-- Reviewable:end -->
