### PR TITLE
Configure erasure-share-size to 1024 bytes

### DIFF
--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -28,7 +28,7 @@ import (
 // redundancy strategy information
 type RSConfig struct {
 	MaxBufferMem     int `help:"maximum buffer memory (in bytes) to be allocated for read buffers" default:"0x400000"`
-	StripeSize       int `help:"the size of each new stripe in bytes" default:"1024"`
+	ErasureShareSize int `help:"the size of each new erasure sure in bytes" default:"1024"`
 	MinThreshold     int `help:"the minimum pieces required to recover a segment. k." default:"20"`
 	RepairThreshold  int `help:"the minimum safe pieces before a repair is triggered. m." default:"30"`
 	SuccessThreshold int `help:"the desired total pieces for a segment. o." default:"40"`
@@ -145,7 +145,7 @@ func (c Config) NewGateway(ctx context.Context,
 		return nil, err
 	}
 	rs, err := eestream.NewRedundancyStrategy(
-		eestream.NewRSScheme(fc, c.StripeSize/c.MaxThreshold),
+		eestream.NewRSScheme(fc, c.ErasureShareSize),
 		c.RepairThreshold, c.SuccessThreshold)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR does 2 things:
- Changes the gateway configuration, so instead of `stripe-size` we are now configuring the `erasure-share-size`.
- Increases the size of erasure shares from 20 to 1024 to mitigate the current performance issues with small erasure share sizes. When we improve the performance, we can reduce the default to a lower value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/241)
<!-- Reviewable:end -->
