### PR TITLE
all: fix govet warnings

### DIFF
--- a/pkg/overlay/cache.go
+++ b/pkg/overlay/cache.go
@@ -91,7 +91,7 @@ func (o *Cache) Put(nodeID string, value overlay.Node) error {
 func (o *Cache) Bootstrap(ctx context.Context) error {
 	nodes, err := o.DHT.GetNodes(ctx, "", 1280)
 	if err != nil {
-		zap.Error(OverlayError.New("Error getting nodes from DHT", err))
+		zap.Error(OverlayError.New("Error getting nodes from DHT: %v", err))
 	}
 
 	for _, v := range nodes {

--- a/pkg/overlay/config_test.go
+++ b/pkg/overlay/config_test.go
@@ -48,7 +48,7 @@ func TestRun(t *testing.T) {
 				err := config.Run(ctx, nil)
 
 				assert.Error(t, err)
-				assert.Equal(t, err.Error(), "redis error: ping failed%!(EXTRA *net.OpError=dial tcp: address somedir: missing port in address)")
+				assert.Equal(t, err.Error(), "redis error: ping failed: dial tcp: address somedir: missing port in address")
 			},
 		},
 		{

--- a/pkg/peertls/peertls.go
+++ b/pkg/peertls/peertls.go
@@ -47,7 +47,7 @@ type PeerCertVerificationFunc func([][]byte, [][]*x509.Certificate) error
 func NewKey() (crypto.PrivateKey, error) {
 	k, err := ecdsa.GenerateKey(authECCurve, rand.Reader)
 	if err != nil {
-		return nil, ErrGenerate.New("failed to generate private key", err)
+		return nil, ErrGenerate.New("failed to generate private key: %v", err)
 	}
 
 	return k, nil

--- a/pkg/peertls/utils.go
+++ b/pkg/peertls/utils.go
@@ -44,7 +44,7 @@ func parseCerts(rawCerts [][]byte) ([]*x509.Certificate, error) {
 		var err error
 		certs[i], err = x509.ParseCertificate(c)
 		if err != nil {
-			return nil, ErrVerifyPeerCert.New("unable to parse certificate", err)
+			return nil, ErrVerifyPeerCert.New("unable to parse certificate: %v", err)
 		}
 	}
 	return certs, nil
@@ -84,7 +84,7 @@ func verifyCertSignature(parentCert, childCert *x509.Certificate) (bool, error) 
 	signature := new(ecdsaSignature)
 
 	if _, err := asn1.Unmarshal(childCert.Signature, signature); err != nil {
-		return false, ErrVerifySignature.New("unable to unmarshal ecdsa signature", err)
+		return false, ErrVerifySignature.New("unable to unmarshal ecdsa signature: %v", err)
 	}
 
 	h := crypto.SHA256.New()

--- a/pkg/pool/connection_pool_test.go
+++ b/pkg/pool/connection_pool_test.go
@@ -29,7 +29,8 @@ func TestGet(t *testing.T) {
 		},
 	}
 
-	for _, v := range cases {
+	for i := range cases {
+		v := &cases[i]
 		test, err := v.pool.Get(context.Background(), v.key)
 		assert.Equal(t, v.expectedError, err)
 		assert.Equal(t, v.expected, test)
@@ -53,7 +54,8 @@ func TestAdd(t *testing.T) {
 		},
 	}
 
-	for _, v := range cases {
+	for i := range cases {
+		v := &cases[i]
 		err := v.pool.Add(context.Background(), v.key, v.value)
 		assert.Equal(t, v.expectedError, err)
 
@@ -80,7 +82,8 @@ func TestRemove(t *testing.T) {
 		},
 	}
 
-	for _, v := range cases {
+	for i := range cases {
+		v := &cases[i]
 		err := v.pool.Remove(context.Background(), v.key)
 		assert.Equal(t, v.expectedError, err)
 

--- a/pkg/provider/certificate_authority.go
+++ b/pkg/provider/certificate_authority.go
@@ -95,7 +95,7 @@ func (caC CAConfig) Load() (*FullCertificateAuthority, error) {
 	kp, _ := pem.Decode(kb)
 	k, err := x509.ParseECPrivateKey(kp.Bytes)
 	if err != nil {
-		return nil, errs.New("unable to parse EC private key", err)
+		return nil, errs.New("unable to parse EC private key: %v", err)
 	}
 	i, err := idFromKey(k)
 	if err != nil {

--- a/pkg/provider/identity.go
+++ b/pkg/provider/identity.go
@@ -93,7 +93,7 @@ func FullIdentityFromPEM(chainPEM, keyPEM []byte) (*FullIdentity, error) {
 	// are, this uses the first one
 	k, err := x509.ParseECPrivateKey(kb[0])
 	if err != nil {
-		return nil, errs.New("unable to parse EC private key", err)
+		return nil, errs.New("unable to parse EC private key: %v", err)
 	}
 	ch, err := ParseCertChain(cb)
 	if err != nil {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -70,7 +70,8 @@ func SetupIdentity(ctx context.Context, c CASetupConfig, i IdentitySetupConfig) 
 		if err != nil {
 			return errs.Wrap(err)
 		}
-		ctx, _ = context.WithTimeout(ctx, t)
+		ctx, cancel := context.WithTimeout(ctx, t)
+		defer cancel()
 
 		// Load or create a certificate authority
 		ca, err := c.Create(ctx, 4)

--- a/pkg/provider/utils.go
+++ b/pkg/provider/utils.go
@@ -121,7 +121,7 @@ func openCert(path string, flag int) (*os.File, error) {
 
 	c, err := os.OpenFile(path, flag, 0644)
 	if err != nil {
-		return nil, errs.New("unable to open cert file for writing \"%s\"", path, err)
+		return nil, errs.New("unable to open cert file for writing \"%s\": %v", path, err)
 	}
 	return c, nil
 }
@@ -133,7 +133,7 @@ func openKey(path string, flag int) (*os.File, error) {
 
 	k, err := os.OpenFile(path, flag, 0600)
 	if err != nil {
-		return nil, errs.New("unable to open key file for writing \"%s\"", path, err)
+		return nil, errs.New("unable to open key file for writing \"%s\": %v", path, err)
 	}
 	return k, nil
 }

--- a/storage/redis/client.go
+++ b/storage/redis/client.go
@@ -41,7 +41,7 @@ func NewClient(address, password string, db int) (*Client, error) {
 
 	// ping here to verify we are able to connect to redis with the initialized client.
 	if err := c.db.Ping().Err(); err != nil {
-		return nil, Error.New("ping failed", err)
+		return nil, Error.New("ping failed: %v", err)
 	}
 
 	return c, nil
@@ -61,7 +61,7 @@ func (c *Client) Get(key storage.Key) (storage.Value, error) {
 		}
 
 		// TODO: log
-		return nil, Error.New("get error", err)
+		return nil, Error.New("get error: %v", err)
 	}
 
 	return b, nil
@@ -72,12 +72,12 @@ func (c *Client) Put(key storage.Key, value storage.Value) error {
 	v, err := value.MarshalBinary()
 
 	if err != nil {
-		return Error.New("put error", err)
+		return Error.New("put error: %v", err)
 	}
 
 	err = c.db.Set(key.String(), v, c.TTL).Err()
 	if err != nil {
-		return Error.New("put error", err)
+		return Error.New("put error: %v", err)
 	}
 
 	return nil
@@ -89,17 +89,17 @@ func (c *Client) List(startingKey storage.Key, limit storage.Limit) (storage.Key
 	if startingKey != nil {
 		_, cursor, err := c.db.Scan(0, fmt.Sprintf("%s", startingKey), int64(limit)).Result()
 		if err != nil {
-			return nil, Error.New("list error with starting key", err)
+			return nil, Error.New("list error with starting key: %v", err)
 		}
 		keys, _, err := c.db.Scan(cursor, "", int64(limit)).Result()
 		if err != nil {
-			return nil, Error.New("list error with starting key", err)
+			return nil, Error.New("list error with starting key: %v", err)
 		}
 		noOrderKeys = keys
 	} else if startingKey == nil {
 		keys, _, err := c.db.Scan(0, "", int64(limit)).Result()
 		if err != nil {
-			return nil, Error.New("list error without starting key", err)
+			return nil, Error.New("list error without starting key: %v", err)
 		}
 		noOrderKeys = keys
 	}
@@ -123,7 +123,7 @@ func (c *Client) ReverseList(startingKey storage.Key, limit storage.Limit) (stor
 func (c *Client) Delete(key storage.Key) error {
 	err := c.db.Del(key.String()).Err()
 	if err != nil {
-		return Error.New("delete error", err)
+		return Error.New("delete error: %v", err)
 	}
 
 	return err


### PR DESCRIPTION
Fixes go1.11 vet warnings.

Cancel on WithTimeout must always be called to avoid memory leak:

```
pkg/provider/provider.go:73: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
```

Range over non-copyable things:

```
pkg/pool/connection_pool_test.go:32: range var v copies lock: struct{pool pool.ConnectionPool; key string; expected pool.TestFoo; expectedError error} contains pool.ConnectionPool contains sync.RWMutex
pkg/pool/connection_pool_test.go:56: range var v copies lock: struct{pool pool.ConnectionPool; key string; value pool.TestFoo; expected pool.TestFoo; expectedError error} contains pool.ConnectionPool contains sync.RWMutex
pkg/pool/connection_pool_test.go:83: range var v copies lock: struct{pool pool.ConnectionPool; key string; value pool.TestFoo; expected interface{}; expectedError error} contains pool.ConnectionPool contains sync.RWMutex
```

zeebo/errs package always requires formatting directives:

```
pkg/peertls/peertls.go:50: Class.New call has arguments but no formatting directives
pkg/peertls/utils.go:47: Class.New call has arguments but no formatting directives
pkg/peertls/utils.go:87: Class.New call has arguments but no formatting directives
pkg/overlay/cache.go:94: Class.New call has arguments but no formatting directives
pkg/provider/certificate_authority.go:98: New call has arguments but no formatting directives
pkg/provider/identity.go:96: New call has arguments but no formatting directives
pkg/provider/utils.go:124: New call needs 1 arg but has 2 args
pkg/provider/utils.go:136: New call needs 1 arg but has 2 args
storage/redis/client.go:44: Class.New call has arguments but no formatting directives
storage/redis/client.go:64: Class.New call has arguments but no formatting directives
storage/redis/client.go:75: Class.New call has arguments but no formatting directives
storage/redis/client.go:80: Class.New call has arguments but no formatting directives
storage/redis/client.go:92: Class.New call has arguments but no formatting directives
storage/redis/client.go:96: Class.New call has arguments but no formatting directives
storage/redis/client.go:102: Class.New call has arguments but no formatting directives
storage/redis/client.go:126: Class.New call has arguments but no formatting directives
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/255)
<!-- Reviewable:end -->
