### PR TITLE
Optimize DecodeReader performance

### DIFF
--- a/pkg/eestream/decode.go
+++ b/pkg/eestream/decode.go
@@ -7,9 +7,6 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-	"reflect"
-
-	"github.com/vivint/infectious"
 
 	"storj.io/storj/internal/pkg/readcloser"
 	"storj.io/storj/pkg/ranger"
@@ -20,18 +17,11 @@ type decodedReader struct {
 	cancel context.CancelFunc
 	rs     map[int]io.ReadCloser
 	es     ErasureScheme
+	sr     *StripeReader
 	outbuf []byte
 	err    error
-	chans  map[int]chan block
-	cb     int64 // current block number
-	eb     int64 // expected number of blocks
-}
-
-type block struct {
-	i    int    // reader index in the map
-	num  int64  // block number
-	data []byte // block data
-	err  error  // error reading the block
+	cb     int64 // current stripe number
+	eb     int64 // expected number of stripes
 }
 
 // DecodeReaders takes a map of readers and an ErasureScheme returning a
@@ -54,48 +44,19 @@ func DecodeReaders(ctx context.Context, rs map[int]io.ReadCloser,
 	if err := checkMBM(mbm); err != nil {
 		return readcloser.FatalReadCloser(err)
 	}
-	chanSize := mbm / (len(rs) * es.EncodedBlockSize())
-	if chanSize < 1 {
-		chanSize = 1
-	}
-	context, cancel := context.WithCancel(ctx)
 	dr := &decodedReader{
-		ctx:    context,
-		cancel: cancel,
 		rs:     rs,
 		es:     es,
+		sr:     NewStripeReader(rs, es, mbm),
 		outbuf: make([]byte, 0, es.DecodedBlockSize()),
-		chans:  make(map[int]chan block, len(rs)),
 		eb:     expectedSize / int64(es.DecodedBlockSize()),
 	}
-	// Kick off a goroutine for each reader. Each reads a block from the
-	// reader and adds it to a buffered channel. If an error is read
-	// (including EOF), a block with the error is added to the channel,
-	// the channel is closed and the goroutine exits.
-	for i := range rs {
-		dr.chans[i] = make(chan block, chanSize)
-		go func(i int, ch chan block) {
-			// close the channel when the goroutine exits
-			defer close(ch)
-			for blockNum := int64(0); ; blockNum++ {
-				// read the next block
-				data := make([]byte, es.EncodedBlockSize())
-				_, err := io.ReadFull(dr.rs[i], data)
-				// add it to the channel
-				select {
-				case ch <- block{i, blockNum, data, err}:
-					if err != nil {
-						// exit the goroutine (will close the channel)
-						return
-					}
-				case <-ctx.Done():
-					// Close() has been called
-					// exit the goroutine (will close the channel)
-					return
-				}
-			}
-		}(i, dr.chans[i])
-	}
+	dr.ctx, dr.cancel = context.WithCancel(ctx)
+	// Kick off a goroutine to watch for context cancelation.
+	go func() {
+		<-dr.ctx.Done()
+		dr.Close()
+	}()
 	return dr
 }
 
@@ -106,25 +67,16 @@ func (dr *decodedReader) Read(p []byte) (n int, err error) {
 		if dr.err != nil {
 			return 0, dr.err
 		}
-		// return EOF is the expected blocks are read
+		// return EOF is the expected stripes were read
 		if dr.cb >= dr.eb {
 			dr.err = io.EOF
 			return 0, dr.err
 		}
-		// read the input buffers of the next block - may also decode it
-		inbufs := make(map[int][]byte, len(dr.chans))
-		dr.err = dr.readBlock(inbufs)
+		// read the input buffers of the next stripe - may also decode it
+		dr.outbuf, dr.err = dr.sr.ReadStripe(dr.cb, dr.outbuf)
 		if dr.err != nil {
 			return 0, dr.err
 		}
-		// if not decoded yet, decode now what's available
-		if len(dr.outbuf) <= 0 {
-			dr.outbuf, dr.err = dr.es.Decode(dr.outbuf, inbufs)
-			if dr.err != nil {
-				return 0, dr.err
-			}
-		}
-		// increment the block counter
 		dr.cb++
 	}
 
@@ -148,77 +100,12 @@ func (dr *decodedReader) Close() error {
 			firstErr = err
 		}
 	}
+	// close the stripe reader
+	err := dr.sr.Close()
+	if firstErr == nil {
+		firstErr = err
+	}
 	return firstErr
-}
-
-func (dr *decodedReader) makeSelectCases() []reflect.SelectCase {
-	cases := make([]reflect.SelectCase, len(dr.chans)+1)
-	// default case for non-blocking selection
-	cases[0] = reflect.SelectCase{
-		Dir: reflect.SelectDefault, Chan: reflect.Value{}}
-	// case for each channel
-	for i, ch := range dr.chans {
-		cases[i+1] = reflect.SelectCase{
-			Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ch)}
-	}
-	return cases
-}
-
-func (dr *decodedReader) removeCase(
-	cases []reflect.SelectCase, index int) []reflect.SelectCase {
-	return append(cases[:index], cases[index+1:]...)
-}
-
-func (dr *decodedReader) readBlock(inbufs map[int][]byte) error {
-	// use reflect to select from the array of channels
-	cases := dr.makeSelectCases()
-	// iterate until the new block is received from enough channels
-	for len(cases) > 1 {
-		// non-blocking select - harvest available input buffers
-		chosen, value, ok := reflect.Select(cases)
-		if chosen == 0 {
-			// default case - no more input buffers available
-			// required+1 will be enough to decode or detect most errors
-			if len(inbufs) >= dr.es.RequiredCount()+1 ||
-				len(inbufs) >= dr.es.TotalCount() {
-				// we have enough input buffers, fill the decoded output buffer
-				var err error
-				dr.outbuf, err = dr.es.Decode(dr.outbuf, inbufs)
-				if err == nil {
-					return nil
-				}
-				// if error is detected, iterate more to try error correction
-				// with more input buffers
-				if !infectious.NotEnoughShares.Contains(err) &&
-					!infectious.TooManyErrors.Contains(err) {
-					return err
-				}
-			}
-			// blocking select - wait for more input buffers
-			chosen, value, ok = reflect.Select(cases[1:])
-			chosen++
-		}
-		if !ok {
-			// the channel is closed - remove it from further selects
-			cases = dr.removeCase(cases, chosen)
-			continue
-		}
-		b := value.Interface().(block)
-		if b.err != nil {
-			// read error - remove the channel from further selects
-			cases = dr.removeCase(cases, chosen)
-			continue
-		}
-		// check if this is the expected block number
-		// if not (slow reader), discard it and make another select
-		if b.num == dr.cb {
-			inbufs[b.i] = b.data
-			// remove the channel from further selects to avoid reading
-			// the next block if reader is fast
-			cases = dr.removeCase(cases, chosen)
-		}
-	}
-	return nil
 }
 
 type decodedRanger struct {
@@ -278,7 +165,6 @@ func (dr *decodedRanger) Range(ctx context.Context, offset, length int64) (io.Re
 	// blocks contain this request
 	firstBlock, blockCount := calcEncompassingBlocks(
 		offset, length, dr.es.DecodedBlockSize())
-
 	// go ask for ranges for all those block boundaries
 	// do it parallel to save from network latency
 	readers := make(map[int]io.ReadCloser, len(dr.rrs))

--- a/pkg/eestream/encode.go
+++ b/pkg/eestream/encode.go
@@ -108,6 +108,13 @@ type encodedReader struct {
 	done   int // number of readers done
 }
 
+type block struct {
+	i    int    // reader index in the map
+	num  int64  // block number
+	data []byte // block data
+	err  error  // error reading the block
+}
+
 // EncodeReader takes a Reader and a RedundancyStrategy and returns a slice of
 // Readers.
 //

--- a/pkg/eestream/piecebuf.go
+++ b/pkg/eestream/piecebuf.go
@@ -51,13 +51,22 @@ func (b *PieceBuffer) Read(p []byte) (n int, err error) {
 		b.cv.Wait()
 	}
 
-	if b.rpos < b.wpos {
-		n = copy(p, b.buf[b.rpos:b.wpos])
-	} else {
-		n = copy(p, b.buf[b.rpos:])
+	if b.rpos >= b.wpos {
+		bytesRead := copy(p, b.buf[b.rpos:])
+		n += bytesRead
+		b.rpos = (b.rpos + bytesRead) % len(b.buf)
+		p = p[n:]
 	}
-	b.rpos = (b.rpos + n) % len(b.buf)
-	b.full = false
+
+	if b.rpos < b.wpos {
+		bytesRead := copy(p, b.buf[b.rpos:b.wpos])
+		n += bytesRead
+		b.rpos += bytesRead
+	}
+
+	if n > 0 {
+		b.full = false
+	}
 
 	return n, nil
 }

--- a/pkg/eestream/piecebuf.go
+++ b/pkg/eestream/piecebuf.go
@@ -1,0 +1,219 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package eestream
+
+import (
+	"io"
+	"io/ioutil"
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+// PieceBuffer is a synchronized buffer for storing erasure shares for a piece.
+type PieceBuffer struct {
+	buf        []byte
+	shareSize  int
+	cv         *sync.Cond
+	cvNewData  *sync.Cond
+	rpos, wpos int
+	full       bool
+	c          int64 // current erasure share number
+	err        error
+}
+
+// NewPieceBuffer creates and initializes a new PieceBuffer using buf as its
+// internal content. If new data is written to the buffer, cvNewData will be
+// notified.
+func NewPieceBuffer(buf []byte, shareSize int, cvNewData *sync.Cond) *PieceBuffer {
+	return &PieceBuffer{
+		buf:       buf,
+		shareSize: shareSize,
+		cv:        sync.NewCond(&sync.Mutex{}),
+		cvNewData: cvNewData,
+	}
+}
+
+// Read reads the next len(p) bytes from the buffer or until the buffer is
+// drained. The return value n is the number of bytes read. If the buffer has
+// no data to return and no error is set, the call will block until new data is
+// written to the buffer. Otherwise the error will be returned.
+func (b *PieceBuffer) Read(p []byte) (n int, err error) {
+	defer b.cv.Broadcast()
+	b.cv.L.Lock()
+	defer b.cv.L.Unlock()
+
+	for b.empty() {
+		if b.err != nil {
+			return 0, b.err
+		}
+		b.cv.Wait()
+	}
+
+	if b.rpos < b.wpos {
+		n = copy(p, b.buf[b.rpos:b.wpos])
+	} else {
+		n = copy(p, b.buf[b.rpos:])
+	}
+	b.rpos = (b.rpos + n) % len(b.buf)
+	b.full = false
+
+	return n, nil
+}
+
+// Write writes the contents of p into the buffer. If the buffer is full it
+// will block until some data is read from it, or an error is set. The return
+// value n is the number of bytes written. If an error was set, it be returned.
+func (b *PieceBuffer) Write(p []byte) (n int, err error) {
+	defer b.cv.Broadcast()
+	b.cv.L.Lock()
+	defer b.cv.L.Unlock()
+
+	for n < len(p) {
+		for b.full {
+			if b.err != nil {
+				return n, b.err
+			}
+			b.cv.Wait()
+		}
+
+		var wr int
+		if b.wpos < b.rpos {
+			wr = copy(b.buf[b.wpos:b.rpos], p[n:])
+		} else {
+			wr = copy(b.buf[b.wpos:], p[n:])
+		}
+
+		n += wr
+		b.wpos = (b.wpos + wr) % len(b.buf)
+		if b.wpos == b.rpos {
+			b.full = true
+		}
+
+		// Unlock the mutex when notifying for new data to avoid deadlocks
+		b.cv.L.Unlock()
+		b.notifyNewData()
+		b.cv.L.Lock()
+	}
+
+	return n, nil
+}
+
+// Close sets io.ErrClosedPipe to the buffer to prevent further writes and
+// blocking on read.
+func (b *PieceBuffer) Close() error {
+	b.SetError(io.ErrClosedPipe)
+	return nil
+}
+
+// SetError sets an error to be returned by Read and Write. Read will return
+// the error after all data is read from the buffer.
+func (b *PieceBuffer) SetError(err error) {
+	b.setError(err)
+	b.notifyNewData()
+}
+
+// setError sets is a helper method that locks the mutex before setting the
+// error.
+func (b *PieceBuffer) setError(err error) {
+	defer b.cv.Broadcast()
+	b.cv.L.Lock()
+	defer b.cv.L.Unlock()
+
+	b.err = err
+}
+
+// notifyNewData notifies cvNewData that new data is written to the buffer.
+func (b *PieceBuffer) notifyNewData() {
+	b.cvNewData.L.Lock()
+	defer b.cvNewData.L.Unlock()
+
+	b.cvNewData.Broadcast()
+}
+
+// empty chacks if the buffer is empty.
+func (b *PieceBuffer) empty() bool {
+	return !b.full && b.rpos == b.wpos
+}
+
+// buffered returns the number of bytes that can be read from the buffer
+// without blocking.
+func (b *PieceBuffer) buffered() int {
+	switch {
+	case b.rpos < b.wpos:
+		return b.wpos - b.rpos
+	case b.rpos > b.wpos:
+		return len(b.buf) + b.wpos - b.rpos
+	case b.full:
+		return len(b.buf)
+	default: // empty
+		return 0
+	}
+}
+
+// HasShare checks if the num-th share can be read from the buffer without
+// blocking. If there are older erasure shares in the buffer, they will be
+// discarded to leave room for the newer erasure shares to be written.
+func (b *PieceBuffer) HasShare(num int64) bool {
+	if num < b.c {
+		// we should never get here!
+		zap.S().Fatalf("Checking for erasure share %d while the current erasure share is %d.", num, b.c)
+	}
+
+	if b.err != nil {
+		return true
+	}
+
+	bufShares := int64(b.buffered() / b.shareSize)
+	if num-b.c > 0 {
+		if bufShares > num-b.c {
+			b.discardUntil(num)
+		} else {
+			b.discardUntil(b.c + bufShares)
+		}
+		bufShares = int64(b.buffered() / b.shareSize)
+	}
+
+	return bufShares > num-b.c
+}
+
+// ReadShare reads the num-th erasure share from the buffer into p. Any shares
+// before num will be discarded from the buffer.
+func (b *PieceBuffer) ReadShare(num int64, p []byte) error {
+	if num < b.c {
+		// we should never get here!
+		zap.S().Fatalf("Trying to read erasure share %d while the current erasure share is already %d.", num, b.c)
+	}
+
+	err := b.discardUntil(num)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.ReadFull(b, p)
+	if err != nil {
+		return err
+	}
+
+	b.c++
+
+	return nil
+}
+
+// discardUntil discards all erasure shares from the buffer until the num-th
+// erasure share exclusively.
+func (b *PieceBuffer) discardUntil(num int64) error {
+	if num <= b.c {
+		return nil
+	}
+
+	_, err := io.CopyN(ioutil.Discard, b, (num-b.c)*int64(b.shareSize))
+	if err != nil {
+		return err
+	}
+
+	b.c = num
+
+	return nil
+}

--- a/pkg/eestream/piecebuf.go
+++ b/pkg/eestream/piecebuf.go
@@ -56,7 +56,7 @@ func (b *PieceBuffer) Read(p []byte) (n int, err error) {
 		nn := copy(p, b.buf[b.rpos:])
 		n += nn
 		b.rpos = (b.rpos + nn) % len(b.buf)
-		p = p[n:]
+		p = p[nn:]
 	}
 
 	if b.rpos < b.wpos {

--- a/pkg/eestream/piecebuf.go
+++ b/pkg/eestream/piecebuf.go
@@ -51,16 +51,16 @@ func (b *PieceBuffer) Read(p []byte) (n int, err error) {
 	}
 
 	if b.rpos >= b.wpos {
-		bytesRead := copy(p, b.buf[b.rpos:])
-		n += bytesRead
-		b.rpos = (b.rpos + bytesRead) % len(b.buf)
+		nn := copy(p, b.buf[b.rpos:])
+		n += nn
+		b.rpos = (b.rpos + nn) % len(b.buf)
 		p = p[n:]
 	}
 
 	if b.rpos < b.wpos {
-		bytesRead := copy(p, b.buf[b.rpos:b.wpos])
-		n += bytesRead
-		b.rpos += bytesRead
+		nn := copy(p, b.buf[b.rpos:b.wpos])
+		n += nn
+		b.rpos += nn
 	}
 
 	if n > 0 {

--- a/pkg/eestream/rs_test.go
+++ b/pkg/eestream/rs_test.go
@@ -48,9 +48,7 @@ func TestRS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(data, data2) {
-		t.Fatalf("rs encode/decode failed")
-	}
+	assert.Equal(t, data, data2)
 }
 
 // Check that io.ReadFull will return io.ErrUnexpectedEOF
@@ -450,7 +448,7 @@ func testRSProblematic(t *testing.T, tt testCase, i int, fn problematicReadClose
 		return
 	}
 	readerMap := make(map[int]io.ReadCloser, len(readers))
-	// some readers will return EOF later
+	// some readers will have problematic behavior
 	for i := 0; i < tt.problematic; i++ {
 		readerMap[i] = fn(pieces[i])
 	}

--- a/pkg/eestream/stripe.go
+++ b/pkg/eestream/stripe.go
@@ -1,0 +1,144 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package eestream
+
+import (
+	"io"
+	"sync"
+
+	"github.com/vivint/infectious"
+)
+
+// StripeReader can read and decodes stripes from a set of readers
+type StripeReader struct {
+	es     ErasureScheme
+	cv     *sync.Cond
+	bufs   map[int]*PieceBuffer
+	inbufs [][]byte
+	inmap  map[int][]byte
+	errmap map[int]bool
+}
+
+// NewStripeReader creates a new StripeReader from the given readers, erasure
+// scheme and max buffer memory.
+func NewStripeReader(rs map[int]io.ReadCloser, es ErasureScheme, mbm int) *StripeReader {
+	bufSize := mbm / es.TotalCount()
+	bufSize -= bufSize % es.EncodedBlockSize()
+	if bufSize < es.EncodedBlockSize() {
+		bufSize = es.EncodedBlockSize()
+	}
+
+	r := &StripeReader{
+		es:     es,
+		cv:     sync.NewCond(&sync.Mutex{}),
+		bufs:   make(map[int]*PieceBuffer, es.TotalCount()),
+		inbufs: make([][]byte, es.TotalCount()),
+		inmap:  make(map[int][]byte, es.TotalCount()),
+		errmap: make(map[int]bool, es.TotalCount()),
+	}
+
+	for i := 0; i < es.TotalCount(); i++ {
+		r.inbufs[i] = make([]byte, es.EncodedBlockSize())
+		r.bufs[i] = NewPieceBuffer(make([]byte, bufSize), es.EncodedBlockSize(), r.cv)
+	}
+
+	// Kick off a goroutine each reader to be copied into a PieceBuffer.
+	for i, buf := range r.bufs {
+		go func(r io.Reader, buf *PieceBuffer) {
+			_, err := io.Copy(buf, r)
+			if err != nil {
+				buf.SetError(err)
+				return
+			}
+			buf.SetError(io.EOF)
+		}(rs[i], buf)
+	}
+
+	return r
+}
+
+// Close closes the StripeReader and all PieceBuffers.
+func (r *StripeReader) Close() error {
+	errs := make(chan error, len(r.bufs))
+	for _, buf := range r.bufs {
+		go func(c io.Closer) {
+			errs <- c.Close()
+		}(buf)
+	}
+	var first error
+	for range r.bufs {
+		err := <-errs
+		if err != nil && first == nil {
+			first = Error.Wrap(err)
+		}
+	}
+	return first
+}
+
+// ReadStripe reads and decodes the num-th stripe and concatenates it to p. The
+// return value is the updated byte slice.
+func (r *StripeReader) ReadStripe(num int64, p []byte) ([]byte, error) {
+	for i := range r.inmap {
+		delete(r.inmap, i)
+	}
+
+	r.cv.L.Lock()
+	defer r.cv.L.Unlock()
+
+	for {
+		for r.readAvailableShares(num) == 0 {
+			r.cv.Wait()
+		}
+		if r.hasEnoughShares() {
+			out, err := r.es.Decode(p, r.inmap)
+			if err != nil {
+				if r.shouldWaitForMore(err) {
+					continue
+				}
+				return nil, err
+			}
+			return out, nil
+		}
+	}
+}
+
+// readAvailableShares reads the available num-th erasure shares from the piece
+// buffers without blocking. The return value n is the number of erasure shares
+// read.
+func (r *StripeReader) readAvailableShares(num int64) (n int) {
+	for i := 0; i < len(r.bufs); i++ {
+		if r.inmap[i] != nil || r.errmap[i] {
+			continue
+		}
+		if r.bufs[i].HasShare(num) {
+			err := r.bufs[i].ReadShare(num, r.inbufs[i])
+			if err != nil {
+				r.errmap[i] = true
+			} else {
+				r.inmap[i] = r.inbufs[i]
+			}
+			n++
+		}
+	}
+	return n
+}
+
+// hasEnoughShares check if there are enough erasure shares read to attempt
+// a decode.
+func (r *StripeReader) hasEnoughShares() bool {
+	return len(r.inmap) >= r.es.RequiredCount()+1 ||
+		len(r.inmap)+len(r.errmap) >= r.es.TotalCount()
+}
+
+// shouldWaitForMore checks the returned decode error if it makes sense to wait
+// for more erasure shares to attempt an error correction.
+func (r *StripeReader) shouldWaitForMore(err error) bool {
+	// check if the error is due to error detection
+	if !infectious.NotEnoughShares.Contains(err) &&
+		!infectious.TooManyErrors.Contains(err) {
+		return false
+	}
+	// check if there are more input buffers to wait for
+	return len(r.inmap)+len(r.errmap) < r.es.TotalCount()
+}


### PR DESCRIPTION
This PR improves the decoding performance of the eestream: ~3.5x faster for 40% less CPU.

The main idea is to switch from using channels to fixed size buffers. The new logic is encapsulated in two new types: PieceBuffer and StripeReader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/256)
<!-- Reviewable:end -->
