### PR TITLE
Fixes downloads in Minio Browser

### DIFF
--- a/pkg/miniogw/gateway-storj.go
+++ b/pkg/miniogw/gateway-storj.go
@@ -113,6 +113,9 @@ func (s *storjObjects) GetObject(ctx context.Context, bucket, object string,
 		return err
 	}
 	defer utils.LogClose(rr)
+	if length == -1 {
+		length = rr.Size() - startOffset
+	}
 	r, err := rr.Range(ctx, startOffset, length)
 	if err != nil {
 		return err

--- a/pkg/miniogw/gateway-storj_test.go
+++ b/pkg/miniogw/gateway-storj_test.go
@@ -57,7 +57,8 @@ func TestGetObject(t *testing.T) {
 		{"mybucket", "myobject1", "abcdef", 0, 5, "abcde", nil, ""},
 		// error returned by the ranger in the code
 		{"mybucket", "myobject1", "abcdef", -1, 7, "abcde", nil, "ranger error: negative offset"},
-		{"mybucket", "myobject1", "abcdef", 0, -1, "abcde", nil, "ranger error: negative length"},
+		{"mybucket", "myobject1", "abcdef", 0, -1, "abcdef", nil, ""},
+		{"mybucket", "myobject1", "abcdef", 0, -2, "abcde", nil, "ranger error: negative length"},
 		{"mybucket", "myobject1", "abcdef", 1, 7, "bcde", nil, "ranger error: buffer runoff"},
 		// error returned by the objects.Get()
 		{"mybucket", "myobject1", "abcdef", 0, 6, "abcdef", errors.New("some err"), "some err"},


### PR DESCRIPTION
Fixes  https://storjlabs.atlassian.net/browse/V3-256

The Minio Browser does not call GetObjectInfo when downloading files. It  calls directly GetObject with length = -1. Calling Ranger.Range with length = -1 fails with "negative length" error.

The fix is to check for `length == -1` in the GetObject method and calculate the correct length before calling Ranger.Range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/264)
<!-- Reviewable:end -->
