### PR TITLE
Identity fixes+:

### DIFF
--- a/pkg/peertls/peertls.go
+++ b/pkg/peertls/peertls.go
@@ -55,7 +55,7 @@ func NewKey() (crypto.PrivateKey, error) {
 
 // NewCert returns a new x509 certificate using the provided templates and
 // signed by the `signer` key
-func NewCert(template, parentTemplate *x509.Certificate, signer crypto.PrivateKey) (*x509.Certificate, error) {
+func NewCert(template, parentTemplate *x509.Certificate, pubKey crypto.PublicKey, signer crypto.PrivateKey) (*x509.Certificate, error) {
 	k, ok := signer.(*ecdsa.PrivateKey)
 	if !ok {
 		return nil, ErrUnsupportedKey.New("%T", k)
@@ -69,7 +69,7 @@ func NewCert(template, parentTemplate *x509.Certificate, signer crypto.PrivateKe
 		rand.Reader,
 		template,
 		parentTemplate,
-		&k.PublicKey,
+		pubKey,
 		k,
 	)
 	if err != nil {

--- a/pkg/peertls/utils.go
+++ b/pkg/peertls/utils.go
@@ -54,7 +54,7 @@ func verifyChainSignatures(certs []*x509.Certificate) error {
 	for i, cert := range certs {
 		j := len(certs)
 		if i+1 < j {
-			isValid, err := verifyCertSignature(certs[i], cert)
+			isValid, err := verifyCertSignature(certs[i+1], cert)
 			if err != nil {
 				return ErrVerifyPeerCert.Wrap(err)
 			}

--- a/pkg/provider/cert_authority_test.go
+++ b/pkg/provider/cert_authority_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGenerateCA(t *testing.T) {
+func TestNewCA(t *testing.T) {
 	expectedDifficulty := uint16(4)
 
-	ca, err := GenerateCA(context.Background(), expectedDifficulty, 5)
+	ca, err := NewCA(context.Background(), expectedDifficulty, 5)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, ca)
 
@@ -21,30 +21,30 @@ func TestGenerateCA(t *testing.T) {
 	assert.True(t, actualDifficulty >= expectedDifficulty)
 }
 
-func BenchmarkGenerateCA_Difficulty8_Concurrency1(b *testing.B) {
+func BenchmarkNewCA_Difficulty8_Concurrency1(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		expectedDifficulty := uint16(8)
-		GenerateCA(nil, expectedDifficulty, 1)
+		NewCA(nil, expectedDifficulty, 1)
 	}
 }
 
-func BenchmarkGenerateCA_Difficulty8_Concurrency2(b *testing.B) {
+func BenchmarkNewCA_Difficulty8_Concurrency2(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		expectedDifficulty := uint16(8)
-		GenerateCA(nil, expectedDifficulty, 2)
+		NewCA(nil, expectedDifficulty, 2)
 	}
 }
 
-func BenchmarkGenerateCA_Difficulty8_Concurrency5(b *testing.B) {
+func BenchmarkNewCA_Difficulty8_Concurrency5(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		expectedDifficulty := uint16(8)
-		GenerateCA(nil, expectedDifficulty, 5)
+		NewCA(nil, expectedDifficulty, 5)
 	}
 }
 
-func BenchmarkGenerateCA_Difficulty8_Concurrency10(b *testing.B) {
+func BenchmarkNewCA_Difficulty8_Concurrency10(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		expectedDifficulty := uint16(8)
-		GenerateCA(nil, expectedDifficulty, 10)
+		NewCA(nil, expectedDifficulty, 10)
 	}
 }

--- a/pkg/provider/identity.go
+++ b/pkg/provider/identity.go
@@ -146,7 +146,7 @@ func (is IdentitySetupConfig) Stat() TlsFilesStat {
 
 // Create generates and saves a CA using the config
 func (is IdentitySetupConfig) Create(ca *FullCertificateAuthority) (*FullIdentity, error) {
-	fi, err := ca.GenerateIdentity()
+	fi, err := ca.NewIdentity()
 	if err != nil {
 		return nil, err
 	}
@@ -251,9 +251,9 @@ func (fi *FullIdentity) ServerOption() (grpc.ServerOption, error) {
 
 // DialOption returns a grpc `DialOption` for making outgoing connections
 // to the node with this peer identity
-func (pi *PeerIdentity) DialOption(difficulty uint16) (grpc.DialOption, error) {
-	ch := [][]byte{pi.Leaf.Raw, pi.CA.Raw}
-	c, err := peertls.TLSCert(ch, pi.Leaf, nil)
+func (fi *FullIdentity) DialOption() (grpc.DialOption, error) {
+	ch := [][]byte{fi.Leaf.Raw, fi.CA.Raw}
+	c, err := peertls.TLSCert(ch, fi.Leaf, fi.Key)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/identity_test.go
+++ b/pkg/provider/identity_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/pem"
@@ -26,13 +27,18 @@ func TestPeerIdentityFromCertChain(t *testing.T) {
 	caT, err := peertls.CATemplate()
 	assert.NoError(t, err)
 
-	c, err := peertls.NewCert(caT, nil, k)
+	cp, _ := k.(*ecdsa.PrivateKey)
+	c, err := peertls.NewCert(caT, nil, &cp.PublicKey, k)
 	assert.NoError(t, err)
 
 	lT, err := peertls.LeafTemplate()
 	assert.NoError(t, err)
 
-	l, err := peertls.NewCert(lT, caT, k)
+	lk, err := peertls.NewKey()
+	assert.NoError(t, err)
+
+	lp, _ := lk.(*ecdsa.PrivateKey)
+	l, err := peertls.NewCert(lT, caT, &lp.PublicKey, k)
 	assert.NoError(t, err)
 
 	pi, err := PeerIdentityFromCerts(l, c)
@@ -49,7 +55,8 @@ func TestFullIdentityFromPEM(t *testing.T) {
 	caT, err := peertls.CATemplate()
 	assert.NoError(t, err)
 
-	c, err := peertls.NewCert(caT, nil, ck)
+	cp, _ := ck.(*ecdsa.PrivateKey)
+	c, err := peertls.NewCert(caT, nil, &cp.PublicKey, ck)
 	assert.NoError(t, err)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, c)
@@ -57,16 +64,17 @@ func TestFullIdentityFromPEM(t *testing.T) {
 	lT, err := peertls.LeafTemplate()
 	assert.NoError(t, err)
 
-	l, err := peertls.NewCert(lT, caT, ck)
+	lk, err := peertls.NewKey()
+	assert.NoError(t, err)
+
+	lp, _ := lk.(*ecdsa.PrivateKey)
+	l, err := peertls.NewCert(lT, caT, &lp.PublicKey, ck)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, l)
 
 	chainPEM := bytes.NewBuffer([]byte{})
 	pem.Encode(chainPEM, peertls.NewCertBlock(l.Raw))
 	pem.Encode(chainPEM, peertls.NewCertBlock(c.Raw))
-
-	lk, err := peertls.NewKey()
-	assert.NoError(t, err)
 
 	lkE, ok := lk.(*ecdsa.PrivateKey)
 	assert.True(t, ok)
@@ -207,4 +215,20 @@ func TestNodeID_Difficulty(t *testing.T) {
 
 	difficulty := fi.ID.Difficulty()
 	assert.True(t, difficulty >= knownDifficulty)
+}
+
+func TestVerifyPeer(t *testing.T) {
+	check := func(e error) {
+		if !assert.NoError(t, e) {
+			t.Fail()
+		}
+	}
+
+	ca, err := NewCA(context.Background(), 12, 4)
+	check(err)
+	fi, err := ca.NewIdentity()
+	check(err)
+
+	err = peertls.VerifyPeerFunc(peertls.VerifyPeerCertChains)([][]byte{fi.Leaf.Raw, fi.CA.Raw}, nil)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
+ fix `peertls.NewCert` public key issue
+ fix `peertls.verfiyChain` issue
+ fix identity dial option
+ rename `GenerateCA` to `NewCA` and `generateCAWorker` to `newCAWorker` for better consistency/convention

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/270)
<!-- Reviewable:end -->
