### PR TITLE
Partial uploads should not be stored successfully in the pointer DB

### DIFF
--- a/cmd/storj/cmd/cp.go
+++ b/cmd/storj/cmd/cp.go
@@ -4,10 +4,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
 	"github.com/minio/minio/pkg/hash"
 	"github.com/spf13/cobra"
@@ -34,6 +38,27 @@ func init() {
 
 func copy(cmd *cobra.Command, args []string) (err error) {
 	ctx := process.Ctx(cmd)
+
+	storjCtx, cancel := context.WithCancel(ctx)
+	/* create a signal of type os.Signal */
+	c := make(chan os.Signal, 0x01)
+
+	/* register for the os signals */
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+
+	defer func() {
+		signal.Stop(c)
+		cancel()
+	}()
+
+	go func() error {
+		select {
+		case <-c:
+			log.Printf("Handle any further clean up here...")
+			cancel()
+			return storjCtx.Err()
+		}
+	}()
 
 	if len(args) == 0 {
 		return errs.New("No file specified for copy")


### PR DESCRIPTION
Registered the OS's interrupts signals and upon receiving it handled the clean up using the context's package cancel() method.