### PR TITLE
Fix Redis Iterators

### DIFF
--- a/storage/redis/client.go
+++ b/storage/redis/client.go
@@ -157,17 +157,17 @@ func (client *Client) allPrefixedItems(prefix, first, last storage.Key) (storage
 	it := client.db.Scan(0, match, 0).Iterator()
 	for it.Next() {
 		key := it.Val()
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-
 		if first != nil && storage.Key(key).Less(first) {
 			continue
 		}
 		if last != nil && last.Less(storage.Key(key)) {
 			continue
 		}
+
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
 
 		value, err := client.db.Get(key).Bytes()
 		if err != nil {

--- a/storage/redis/client.go
+++ b/storage/redis/client.go
@@ -151,11 +151,16 @@ func (client *Client) Iterate(opts storage.IterateOptions, fn func(it storage.It
 
 func (client *Client) allPrefixedItems(prefix, first, last storage.Key) (storage.Items, error) {
 	var all storage.Items
+	seen := map[string]struct{}{}
 
 	match := string(escapeMatch([]byte(prefix))) + "*"
 	it := client.db.Scan(0, match, 0).Iterator()
 	for it.Next() {
 		key := it.Val()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
 
 		if first != nil && storage.Key(key).Less(first) {
 			continue


### PR DESCRIPTION
Redis SCAN may return same item multiple times, add a basic check to avoid issues with.

From https://redis.io/commands/scan#scan-guarantees

> A given element may be returned multiple times. It is up to the application to handle the case of duplicated elements, for example only using the returned elements in order to perform operations that are safe when re-applied multiple times.

Causes very infrequent failures such as  https://travis-ci.org/storj/storj/builds/425316540#L1971

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/318)
<!-- Reviewable:end -->
