### PR TITLE
Abort trying to upload segments when reader fails

### DIFF
--- a/pkg/storage/streams/EOFAwareLimitReader.go
+++ b/pkg/storage/streams/EOFAwareLimitReader.go
@@ -9,11 +9,12 @@ import "io"
 type EOFAwareLimitReader struct {
 	reader io.Reader
 	eof    bool
+	err    error
 }
 
 // EOFAwareReader keeps track of the state, has the internal reader reached EOF
 func EOFAwareReader(r io.Reader) *EOFAwareLimitReader {
-	return &EOFAwareLimitReader{reader: r, eof: false}
+	return &EOFAwareLimitReader{reader: r}
 }
 
 func (r *EOFAwareLimitReader) Read(p []byte) (n int, err error) {
@@ -21,9 +22,16 @@ func (r *EOFAwareLimitReader) Read(p []byte) (n int, err error) {
 	if err == io.EOF {
 		r.eof = true
 	}
+	if err != nil && r.err == nil {
+		r.err = err
+	}
 	return n, err
 }
 
 func (r *EOFAwareLimitReader) isEOF() bool {
 	return r.eof
+}
+
+func (r *EOFAwareLimitReader) hasError() bool {
+	return r.err != nil
 }

--- a/pkg/storage/streams/EOFAwareLimitReader.go
+++ b/pkg/storage/streams/EOFAwareLimitReader.go
@@ -21,8 +21,7 @@ func (r *EOFAwareLimitReader) Read(p []byte) (n int, err error) {
 	n, err = r.reader.Read(p)
 	if err == io.EOF {
 		r.eof = true
-	}
-	if err != nil && r.err == nil {
+	} else if err != nil && r.err == nil {
 		r.err = err
 	}
 	return n, err

--- a/pkg/storage/streams/store.go
+++ b/pkg/storage/streams/store.go
@@ -85,12 +85,11 @@ func (s *streamStore) Put(ctx context.Context, path paths.Path, data io.Reader,
 
 	awareLimitReader := EOFAwareReader(data)
 
-	for !awareLimitReader.isEOF() {
+	for !awareLimitReader.isEOF() && !awareLimitReader.hasError() {
 		segmentPath := path.Prepend(fmt.Sprintf("s%d", totalSegments))
 		segmentData := io.LimitReader(awareLimitReader, s.segmentSize)
 
-		putMeta, err := s.segments.Put(ctx, segmentPath, segmentData,
-			nil, expiration)
+		putMeta, err := s.segments.Put(ctx, segmentPath, segmentData, nil, expiration)
 		if err != nil {
 			return Meta{}, err
 		}

--- a/pkg/storage/streams/store.go
+++ b/pkg/storage/streams/store.go
@@ -97,6 +97,9 @@ func (s *streamStore) Put(ctx context.Context, path paths.Path, data io.Reader,
 		totalSize = totalSize + putMeta.Size
 		totalSegments = totalSegments + 1
 	}
+	if awareLimitReader.hasError() {
+		return Meta{}, awareLimitReader.err
+	}
 
 	lastSegmentPath := path.Prepend("l")
 


### PR DESCRIPTION
For some reason the error doesn't propagate from `segments.Put`, so I added it into stream handling.

This should fix the IO problems when aborting the upload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storj/storj/326)
<!-- Reviewable:end -->
