### PR TITLE
Limit to only 1 ttl database write when storing data on storage nodes

### DIFF
--- a/pkg/piecestore/pstore.go
+++ b/pkg/piecestore/pstore.go
@@ -56,7 +56,7 @@ func StoreWriter(id string, dir string) (io.WriteCloser, error) {
 	}
 
 	// Create File on file system
-	return os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0755)
+	return os.OpenFile(dataPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0755)
 }
 
 // RetrieveReader retrieves data from pstore directory

--- a/pkg/piecestore/rpc/server/psdb/psdb.go
+++ b/pkg/piecestore/rpc/server/psdb/psdb.go
@@ -218,18 +218,6 @@ func (db *DB) GetTTLByID(id string) (expiration int64, err error) {
 	return expiration, err
 }
 
-// DoesTTLExist finds the TTL in the database by id and returns if it exists or not
-func (db *DB) DoesTTLExist(id string) (exists bool, err error) {
-	defer db.locked()()
-
-	err = db.DB.QueryRow(`SELECT EXISTS(SELECT 1 FROM ttl WHERE id=? LIMIT 1);`, id).Scan(&exists)
-	if err != nil && err != sql.ErrNoRows {
-		return exists, err
-	}
-
-	return exists, nil
-}
-
 // SumTTLSizes sums the size column on the ttl table
 func (db *DB) SumTTLSizes() (sum int64, err error) {
 	defer db.locked()()

--- a/pkg/piecestore/rpc/server/psdb/psdb.go
+++ b/pkg/piecestore/rpc/server/psdb/psdb.go
@@ -201,12 +201,12 @@ func (db *DB) GetBandwidthAllocationBySignature(signature []byte) ([][]byte, err
 	return agreements, nil
 }
 
-// AddTTLToDB adds TTL into database by id
-func (db *DB) AddTTLToDB(id string, expiration, size int64) error {
+// AddTTL adds TTL into database by id
+func (db *DB) AddTTL(id string, expiration, size int64) error {
 	defer db.locked()()
 
 	created := time.Now().Unix()
-	_, err := db.DB.Exec("INSERT or REPLACE INTO ttl (id, created, expires, size) VALUES (?, ?, ?, ?)", id, created, expiration, size)
+	_, err := db.DB.Exec("INSERT OR REPLACE INTO ttl (id, created, expires, size) VALUES (?, ?, ?, ?)", id, created, expiration, size)
 	return err
 }
 

--- a/pkg/piecestore/rpc/server/psdb/psdb_test.go
+++ b/pkg/piecestore/rpc/server/psdb/psdb_test.go
@@ -67,7 +67,7 @@ func TestHappyPath(t *testing.T) {
 			t.Run("#"+strconv.Itoa(P), func(t *testing.T) {
 				t.Parallel()
 				for _, ttl := range tests {
-					err := db.AddTTLToDB(ttl.ID, ttl.Expiration, 0)
+					err := db.AddTTL(ttl.ID, ttl.Expiration, 0)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/piecestore/rpc/server/psdb/psdb_test.go
+++ b/pkg/piecestore/rpc/server/psdb/psdb_test.go
@@ -67,7 +67,7 @@ func TestHappyPath(t *testing.T) {
 			t.Run("#"+strconv.Itoa(P), func(t *testing.T) {
 				t.Parallel()
 				for _, ttl := range tests {
-					err := db.AddTTLToDB(ttl.ID, ttl.Expiration)
+					err := db.AddTTLToDB(ttl.ID, ttl.Expiration, 0)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/piecestore/rpc/server/store.go
+++ b/pkg/piecestore/rpc/server/store.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log"
 
@@ -51,10 +50,8 @@ func (s *Server) Store(reqStream pb.PieceStoreRoutes_StoreServer) (err error) {
 	}
 
 	if err = s.DB.AddTTL(pd.GetId(), pd.GetExpirationUnixSec(), total); err != nil {
-		if deleteErr := s.deleteByID(pd.GetId()); deleteErr != nil {
-			return utils.CombineErrors(StoreError.Wrap(fmt.Errorf("Failed on deleteByID in Store: %s", deleteErr.Error())))
-		}
-		return StoreError.New("Failed to write piece meta data to database")
+		deleteErr := s.deleteByID(pd.GetId())
+		return StoreError.New("failed to write piece meta data to database: %v", utils.CombineErrors(err, deleteErr))
 	}
 
 	log.Printf("Successfully stored %s.", pd.GetId())

--- a/pkg/piecestore/rpc/server/store.go
+++ b/pkg/piecestore/rpc/server/store.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
 
@@ -51,7 +52,7 @@ func (s *Server) Store(reqStream pb.PieceStoreRoutes_StoreServer) (err error) {
 
 	if err = s.DB.AddTTL(pd.GetId(), pd.GetExpirationUnixSec(), total); err != nil {
 		if deleteErr := s.deleteByID(pd.GetId()); deleteErr != nil {
-			log.Printf("Failed on deleteByID in Store: %s", deleteErr.Error())
+			return utils.CombineErrors(StoreError.Wrap(fmt.Errorf("Failed on deleteByID in Store: %s", deleteErr.Error())))
 		}
 		return StoreError.New("Failed to write piece meta data to database")
 	}

--- a/pkg/piecestore/rpc/server/store.go
+++ b/pkg/piecestore/rpc/server/store.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"io"
 	"log"
-	"os"
 
 	"github.com/zeebo/errs"
 	"storj.io/storj/pkg/piecestore"
@@ -73,15 +72,6 @@ func (s *Server) storeData(ctx context.Context, stream pb.PieceStoreRoutes_Store
 			}
 		}
 	}()
-
-	dataPath, err := pstore.PathByID(id, s.DataDir)
-	if err != nil {
-		return 0, err
-	}
-
-	if _, err = os.Stat(dataPath); os.IsExist(err) {
-		return 0, StoreError.New("Piece already exists ")
-	}
 
 	// Initialize file for storing data
 	storeFile, err := pstore.StoreWriter(id, s.DataDir)

--- a/pkg/piecestore/rpc/server/store.go
+++ b/pkg/piecestore/rpc/server/store.go
@@ -45,15 +45,6 @@ func (s *Server) Store(reqStream pb.PieceStoreRoutes_StoreServer) (err error) {
 		return StoreError.New("Piece ID not specified")
 	}
 
-	dataPath, err := pstore.PathByID(pd.GetId(), s.DataDir)
-	if err != nil {
-		return err
-	}
-
-	if _, err = os.Stat(dataPath); os.IsExist(err) {
-		return StoreError.New("Piece already exists ")
-	}
-
 	total, err := s.storeData(ctx, reqStream, pd.GetId())
 	if err != nil {
 		return err
@@ -82,6 +73,15 @@ func (s *Server) storeData(ctx context.Context, stream pb.PieceStoreRoutes_Store
 			}
 		}
 	}()
+
+	dataPath, err := pstore.PathByID(id, s.DataDir)
+	if err != nil {
+		return 0, err
+	}
+
+	if _, err = os.Stat(dataPath); os.IsExist(err) {
+		return 0, StoreError.New("Piece already exists ")
+	}
 
 	// Initialize file for storing data
 	storeFile, err := pstore.StoreWriter(id, s.DataDir)


### PR DESCRIPTION
TTL database writes were originally before data had been saved and this would at the same time check if the id already exists. A second database write would occur after the data is stored to update the database to include the size of the data that has been stored

I created a function for checking if the id exists, and combined the size and id database writes to one function after storing the data