### PR TITLE
ConcatRanger closes segment readers as soon as data is read

### DIFF
--- a/cmd/uplink/cmd/cp.go
+++ b/cmd/uplink/cmd/cp.go
@@ -100,7 +100,6 @@ func download(ctx context.Context, bs buckets.Store, srcObj *url.URL, destFile s
 	if err != nil {
 		return err
 	}
-	defer utils.LogClose(rr)
 
 	r, err := rr.Range(ctx, 0, rr.Size())
 	if err != nil {
@@ -129,7 +128,6 @@ func copy(ctx context.Context, bs buckets.Store, srcObj *url.URL, destObj *url.U
 	if err != nil {
 		return err
 	}
-	defer utils.LogClose(rr)
 
 	r, err := rr.Range(ctx, 0, rr.Size())
 	if err != nil {

--- a/examples/eestream/serve-collected/main.go
+++ b/examples/eestream/serve-collected/main.go
@@ -49,10 +49,10 @@ func Main() error {
 		return err
 	}
 	// initialize http rangers in parallel to save from network latency
-	rrs := map[int]ranger.RangeCloser{}
+	rrs := map[int]ranger.Ranger{}
 	type indexRangerError struct {
 		i   int
-		rr  ranger.RangeCloser
+		rr  ranger.Ranger
 		err error
 	}
 	result := make(chan indexRangerError, *rsn)
@@ -60,7 +60,7 @@ func Main() error {
 		go func(i int) {
 			url := fmt.Sprintf("http://18.184.133.99:%d", 10000+i)
 			rr, err := ranger.HTTPRanger(url)
-			result <- indexRangerError{i: i, rr: ranger.NopCloser(rr), err: err}
+			result <- indexRangerError{i: i, rr: rr, err: err}
 		}(i)
 	}
 	// wait for all goroutines to finish and save result in rrs map
@@ -76,7 +76,6 @@ func Main() error {
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
 	rr, err := eestream.Transform(rc, decrypter)
 	if err != nil {
 		return err

--- a/examples/eestream/serve/main.go
+++ b/examples/eestream/serve/main.go
@@ -61,7 +61,7 @@ func Main() error {
 	if err != nil {
 		return err
 	}
-	rrs := map[int]ranger.RangeCloser{}
+	rrs := map[int]ranger.Ranger{}
 	for _, piece := range pieces {
 		piecenum, err := strconv.Atoi(strings.TrimSuffix(piece.Name(), ".piece"))
 		if err != nil {
@@ -77,7 +77,6 @@ func Main() error {
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
 	rr, err := eestream.Transform(rc, decrypter)
 	if err != nil {
 		return err

--- a/pkg/eestream/crc_test.go
+++ b/pkg/eestream/crc_test.go
@@ -78,12 +78,12 @@ func (c *crcChecker) Transform(out, in []byte, blockOffset int64) (
 
 // addCRC is a Ranger constructor, given a specific crc table and an existing
 // un-crced Ranger
-func addCRC(data ranger.RangeCloser, tab *crc32.Table) (ranger.RangeCloser, error) {
+func addCRC(data ranger.Ranger, tab *crc32.Table) (ranger.Ranger, error) {
 	return Transform(data, newCRCAdder(tab))
 }
 
 // checkCRC is a Ranger constructor, given a specific crc table and an existing
 // crced Ranger
-func checkCRC(data ranger.RangeCloser, tab *crc32.Table) (ranger.RangeCloser, error) {
+func checkCRC(data ranger.Ranger, tab *crc32.Table) (ranger.Ranger, error) {
 	return Transform(data, newCRCChecker(tab))
 }

--- a/pkg/eestream/pad.go
+++ b/pkg/eestream/pad.go
@@ -33,7 +33,7 @@ func makePadding(dataLen int64, blockSize int) []byte {
 // Pad takes a Ranger and returns another Ranger that is a multiple of
 // blockSize in length. The return value padding is a convenience to report how
 // much padding was added.
-func Pad(data ranger.RangeCloser, blockSize int) (
+func Pad(data ranger.Ranger, blockSize int) (
 	rr ranger.Ranger, padding int) {
 	paddingBytes := makePadding(data.Size(), blockSize)
 	return ranger.Concat(data, ranger.ByteRanger(paddingBytes)), len(paddingBytes)
@@ -42,13 +42,13 @@ func Pad(data ranger.RangeCloser, blockSize int) (
 // Unpad takes a previously padded Ranger data source and returns an unpadded
 // ranger, given the amount of padding. This is preferable to UnpadSlow if you
 // can swing it.
-func Unpad(data ranger.RangeCloser, padding int) (ranger.RangeCloser, error) {
+func Unpad(data ranger.Ranger, padding int) (ranger.Ranger, error) {
 	return ranger.Subrange(data, 0, data.Size()-int64(padding))
 }
 
 // UnpadSlow is like Unpad, but does not require the amount of padding.
 // UnpadSlow will have to do extra work to make up for this missing information.
-func UnpadSlow(ctx context.Context, data ranger.RangeCloser) (ranger.RangeCloser, error) {
+func UnpadSlow(ctx context.Context, data ranger.Ranger) (ranger.Ranger, error) {
 	r, err := data.Range(ctx, data.Size()-uint32Size, uint32Size)
 	if err != nil {
 		return nil, Error.Wrap(err)

--- a/pkg/eestream/pad_test.go
+++ b/pkg/eestream/pad_test.go
@@ -44,7 +44,7 @@ func TestPad(t *testing.T) {
 		if int64(padding+len(example.data)) != padded.Size() {
 			t.Fatalf("invalid padding")
 		}
-		unpadded, err := Unpad(ranger.NopCloser(padded), padding)
+		unpadded, err := Unpad(padded, padding)
 		if err != nil {
 			t.Fatalf("unexpected error")
 		}
@@ -59,7 +59,7 @@ func TestPad(t *testing.T) {
 		if !bytes.Equal(data, []byte(example.data)) {
 			t.Fatalf("mismatch")
 		}
-		unpadded, err = UnpadSlow(ctx, ranger.NopCloser(padded))
+		unpadded, err = UnpadSlow(ctx, padded)
 		if err != nil {
 			t.Fatalf("unexpected error")
 		}

--- a/pkg/eestream/rs_test.go
+++ b/pkg/eestream/rs_test.go
@@ -109,9 +109,9 @@ func TestRSRanger(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rrs := map[int]ranger.RangeCloser{}
+	rrs := map[int]ranger.Ranger{}
 	for i, piece := range pieces {
-		rrs[i] = ranger.ByteRangeCloser(piece)
+		rrs[i] = ranger.ByteRanger(piece)
 	}
 	decrypter, err := NewAESGCMDecrypter(&encKey, &firstNonce, rs.DecodedBlockSize())
 	if err != nil {
@@ -121,11 +121,6 @@ func TestRSRanger(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		if err := rc.Close(); err != nil {
-			t.Fatal(err)
-		}
-	}()
 	rr, err := Transform(rc, decrypter)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/eestream/transform.go
+++ b/pkg/eestream/transform.go
@@ -92,12 +92,12 @@ func (t *transformedReader) Close() error {
 }
 
 type transformedRanger struct {
-	rr ranger.RangeCloser
+	rr ranger.Ranger
 	t  Transformer
 }
 
 // Transform will apply a Transformer to a Ranger.
-func Transform(rr ranger.RangeCloser, t Transformer) (ranger.RangeCloser, error) {
+func Transform(rr ranger.Ranger, t Transformer) (ranger.Ranger, error) {
 	if rr.Size()%int64(t.InBlockSize()) != 0 {
 		return nil, Error.New("invalid transformer and range reader combination." +
 			"the range reader size is not a multiple of the block size")
@@ -158,8 +158,4 @@ func (t *transformedRanger) Range(ctx context.Context, offset, length int64) (io
 	}
 	// the range might have been too long. only return what was requested
 	return readcloser.LimitReadCloser(tr, length), nil
-}
-
-func (t *transformedRanger) Close() error {
-	return t.rr.Close()
 }

--- a/pkg/eestream/transform_test.go
+++ b/pkg/eestream/transform_test.go
@@ -69,7 +69,7 @@ func TestCalcEncompassingBlocks(t *testing.T) {
 
 func TestCRC(t *testing.T) {
 	const blocks = 3
-	rr, err := addCRC(ranger.ByteRangeCloser(bytes.Repeat([]byte{0}, blocks*64)),
+	rr, err := addCRC(ranger.ByteRanger(bytes.Repeat([]byte{0}, blocks*64)),
 		crc32.IEEETable)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
@@ -87,7 +87,7 @@ func TestCRC(t *testing.T) {
 		t.Fatalf("unexpected: %v", err)
 	}
 
-	rr, err = checkCRC(ranger.ByteRangeCloser(data), crc32.IEEETable)
+	rr, err = checkCRC(ranger.ByteRanger(data), crc32.IEEETable)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestCRC(t *testing.T) {
 func TestCRCSubranges(t *testing.T) {
 	const blocks = 3
 	data := bytes.Repeat([]byte{0, 1, 2}, blocks*64)
-	internal, err := addCRC(ranger.ByteRangeCloser(data), crc32.IEEETable)
+	internal, err := addCRC(ranger.ByteRanger(data), crc32.IEEETable)
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}

--- a/pkg/miniogw/gateway-storj.go
+++ b/pkg/miniogw/gateway-storj.go
@@ -107,7 +107,7 @@ func (s *storjObjects) GetBucketInfo(ctx context.Context, bucket string) (
 	return minio.BucketInfo{Name: bucket, Created: meta.Created}, nil
 }
 
-func (s *storjObjects) getObject(ctx context.Context, bucket, object string) (rr ranger.RangeCloser, err error) {
+func (s *storjObjects) getObject(ctx context.Context, bucket, object string) (rr ranger.Ranger, err error) {
 	defer mon.Task()(&ctx)(&err)
 	o, err := s.storj.bs.GetObjectStore(ctx, bucket)
 	if err != nil {
@@ -128,7 +128,6 @@ func (s *storjObjects) GetObject(ctx context.Context, bucket, object string,
 		return err
 	}
 
-	defer utils.LogClose(rr)
 	if length == -1 {
 		length = rr.Size() - startOffset
 	}
@@ -283,8 +282,6 @@ func (s *storjObjects) CopyObject(ctx context.Context, srcBucket, srcObject, des
 	if err != nil {
 		return objInfo, err
 	}
-
-	defer utils.LogClose(rr)
 
 	r, err := rr.Range(ctx, 0, rr.Size())
 	if err != nil {

--- a/pkg/miniogw/gateway-storj_test.go
+++ b/pkg/miniogw/gateway-storj_test.go
@@ -90,7 +90,7 @@ func TestCopyObject(t *testing.T) {
 			UserDefined: serMeta.UserDefined,
 		}
 
-		rr := ranger.NopCloser(ranger.ByteRanger([]byte(example.data)))
+		rr := ranger.ByteRanger([]byte(example.data))
 		r, err := rr.Range(ctx, 0, rr.Size())
 		if err != nil {
 			t.Fatal(err)
@@ -156,7 +156,7 @@ func TestGetObject(t *testing.T) {
 	} {
 		errTag := fmt.Sprintf("Test case #%d", i)
 
-		rr := ranger.NopCloser(ranger.ByteRanger([]byte(example.data)))
+		rr := ranger.ByteRanger([]byte(example.data))
 
 		mockBS.EXPECT().GetObjectStore(gomock.Any(), example.bucket).Return(mockOS, nil)
 		mockOS.EXPECT().Get(gomock.Any(), paths.New(example.object)).Return(rr, meta, example.err)

--- a/pkg/miniogw/objstore_mock_test.go
+++ b/pkg/miniogw/objstore_mock_test.go
@@ -56,9 +56,9 @@ func (mr *MockStoreMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Get mocks base method
-func (m *MockStore) Get(arg0 context.Context, arg1 paths.Path) (ranger.RangeCloser, objects.Meta, error) {
+func (m *MockStore) Get(arg0 context.Context, arg1 paths.Path) (ranger.Ranger, objects.Meta, error) {
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
-	ret0, _ := ret[0].(ranger.RangeCloser)
+	ret0, _ := ret[0].(ranger.Ranger)
 	ret1, _ := ret[1].(objects.Meta)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2

--- a/pkg/piecestore/pstore.go
+++ b/pkg/piecestore/pstore.go
@@ -91,13 +91,8 @@ func RetrieveReader(ctx context.Context, id string, offset int64, length int64, 
 		length = fileInfo.Size() - offset
 	}
 
-	dataFile, err := os.OpenFile(dataPath, os.O_RDONLY, 0755)
-	if err != nil {
-		return nil, err
-	}
-
 	// Created a section reader so that we can concurrently retrieve the same file.
-	rr, err := ranger.FileHandleRanger(dataFile)
+	rr, err := ranger.FileRanger(dataPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/piecestore/rpc/client/client.go
+++ b/pkg/piecestore/rpc/client/client.go
@@ -40,7 +40,7 @@ var (
 type PSClient interface {
 	Meta(ctx context.Context, id PieceID) (*pb.PieceSummary, error)
 	Put(ctx context.Context, id PieceID, data io.Reader, ttl time.Time, ba *pb.PayerBandwidthAllocation) error
-	Get(ctx context.Context, id PieceID, size int64, ba *pb.PayerBandwidthAllocation) (ranger.RangeCloser, error)
+	Get(ctx context.Context, id PieceID, size int64, ba *pb.PayerBandwidthAllocation) (ranger.Ranger, error)
 	Delete(ctx context.Context, pieceID PieceID) error
 	Stats(ctx context.Context) error
 	io.Closer
@@ -139,7 +139,7 @@ func (client *Client) Put(ctx context.Context, id PieceID, data io.Reader, ttl t
 }
 
 // Get begins downloading a Piece from a piece store Server
-func (client *Client) Get(ctx context.Context, id PieceID, size int64, ba *pb.PayerBandwidthAllocation) (ranger.RangeCloser, error) {
+func (client *Client) Get(ctx context.Context, id PieceID, size int64, ba *pb.PayerBandwidthAllocation) (ranger.Ranger, error) {
 	stream, err := client.route.Retrieve(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/piecestore/rpc/client/pieceranger.go
+++ b/pkg/piecestore/rpc/client/pieceranger.go
@@ -26,8 +26,8 @@ type pieceRanger struct {
 	pba    *pb.PayerBandwidthAllocation
 }
 
-// PieceRanger PieceRanger returns a RangeCloser from a PieceID.
-func PieceRanger(ctx context.Context, c *Client, stream pb.PieceStoreRoutes_RetrieveClient, id PieceID, pba *pb.PayerBandwidthAllocation) (ranger.RangeCloser, error) {
+// PieceRanger PieceRanger returns a Ranger from a PieceID.
+func PieceRanger(ctx context.Context, c *Client, stream pb.PieceStoreRoutes_RetrieveClient, id PieceID, pba *pb.PayerBandwidthAllocation) (ranger.Ranger, error) {
 	piece, err := c.Meta(ctx, id)
 	if err != nil {
 		return nil, err
@@ -38,18 +38,13 @@ func PieceRanger(ctx context.Context, c *Client, stream pb.PieceStoreRoutes_Retr
 // PieceRangerSize creates a PieceRanger with known size.
 // Use it if you know the piece size. This will safe the extra request for
 // retrieving the piece size from the piece storage.
-func PieceRangerSize(c *Client, stream pb.PieceStoreRoutes_RetrieveClient, id PieceID, size int64, pba *pb.PayerBandwidthAllocation) ranger.RangeCloser {
+func PieceRangerSize(c *Client, stream pb.PieceStoreRoutes_RetrieveClient, id PieceID, size int64, pba *pb.PayerBandwidthAllocation) ranger.Ranger {
 	return &pieceRanger{c: c, id: id, size: size, stream: stream, pba: pba}
 }
 
 // Size implements Ranger.Size
 func (r *pieceRanger) Size() int64 {
 	return r.size
-}
-
-// Size implements Ranger.Size
-func (r *pieceRanger) Close() error {
-	return r.c.Close()
 }
 
 // Range implements Ranger.Range

--- a/pkg/piecestore/rpc/client/readerwriter.go
+++ b/pkg/piecestore/rpc/client/readerwriter.go
@@ -176,7 +176,8 @@ func (s *StreamReader) Read(b []byte) (int, error) {
 
 // Close the piece store server Read Stream
 func (s *StreamReader) Close() error {
-	err1 := s.stream.CloseSend()
-	err2 := s.client.Close()
-	return utils.CombineErrors(err1, err2)
+	return utils.CombineErrors(
+		s.stream.CloseSend(),
+		s.client.Close(),
+	)
 }

--- a/pkg/piecestore/rpc/client/readerwriter.go
+++ b/pkg/piecestore/rpc/client/readerwriter.go
@@ -72,6 +72,7 @@ func (s *StreamWriter) Close() error {
 // StreamReader is a struct for reading piece download stream from server
 type StreamReader struct {
 	pendingAllocs *sync2.Throttle
+	client        *Client
 	stream        pb.PieceStoreRoutes_RetrieveClient
 	src           *utils.ReaderSource
 	downloaded    int64
@@ -80,21 +81,22 @@ type StreamReader struct {
 }
 
 // NewStreamReader creates a StreamReader for reading data from the piece store server
-func NewStreamReader(signer *Client, stream pb.PieceStoreRoutes_RetrieveClient, pba *pb.PayerBandwidthAllocation, size int64) *StreamReader {
+func NewStreamReader(client *Client, stream pb.PieceStoreRoutes_RetrieveClient, pba *pb.PayerBandwidthAllocation, size int64) *StreamReader {
 	sr := &StreamReader{
 		pendingAllocs: sync2.NewThrottle(),
+		client:        client,
 		stream:        stream,
 		size:          size,
 	}
 
 	// TODO: make these flag/config-file configurable
-	trustLimit := int64(signer.bandwidthMsgSize * 64)
-	sendThreshold := int64(signer.bandwidthMsgSize * 8)
+	trustLimit := int64(client.bandwidthMsgSize * 64)
+	sendThreshold := int64(client.bandwidthMsgSize * 8)
 
 	// Send signed allocations to the piece store server
 	go func() {
 		// TODO: make this flag/config-file configurable
-		trustedSize := int64(signer.bandwidthMsgSize * 8)
+		trustedSize := int64(client.bandwidthMsgSize * 8)
 
 		// Allocate until we've reached the file size
 		for sr.allocated < size {
@@ -114,7 +116,7 @@ func NewStreamReader(signer *Client, stream pb.PieceStoreRoutes_RetrieveClient, 
 				return
 			}
 
-			sig, err := signer.sign(serializedAllocation)
+			sig, err := client.sign(serializedAllocation)
 			if err != nil {
 				sr.pendingAllocs.Fail(err)
 				return
@@ -174,5 +176,7 @@ func (s *StreamReader) Read(b []byte) (int, error) {
 
 // Close the piece store server Read Stream
 func (s *StreamReader) Close() error {
-	return s.stream.CloseSend()
+	err1 := s.stream.CloseSend()
+	err2 := s.client.Close()
+	return utils.CombineErrors(err1, err2)
 }

--- a/pkg/ranger/file.go
+++ b/pkg/ranger/file.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"io"
 	"os"
+
+	"storj.io/storj/pkg/utils"
 )
 
 type fileRanger struct {
@@ -34,7 +36,7 @@ func (rr *fileRanger) Range(ctx context.Context, offset, length int64) (io.ReadC
 	if length < 0 {
 		return nil, Error.New("negative length")
 	}
-	if offset+length > int64(rr.size) {
+	if offset+length > rr.size {
 		return nil, Error.New("range beyond end")
 	}
 
@@ -42,9 +44,9 @@ func (rr *fileRanger) Range(ctx context.Context, offset, length int64) (io.ReadC
 	if err != nil {
 		return nil, Error.Wrap(err)
 	}
-	_, err = fh.Seek(offset, os.SEEK_SET)
+	_, err = fh.Seek(offset, io.SeekStart)
 	if err != nil {
-		fh.Close()
+		err = utils.CombineErrors(err, fh.Close())
 		return nil, Error.Wrap(err)
 	}
 	return struct {

--- a/pkg/ranger/file.go
+++ b/pkg/ranger/file.go
@@ -4,42 +4,54 @@
 package ranger
 
 import (
+	"context"
 	"io"
 	"os"
-
-	"go.uber.org/zap"
 )
 
-// FileHandleRanger returns a RangeCloser from a file handle. The
-// Closer's Close method will call fh.Close().
-// Footgun: If FileHandleRanger fails, fh.Close will not have been called.
-func FileHandleRanger(fh *os.File) (RangeCloser, error) {
-	stat, err := fh.Stat()
+type fileRanger struct {
+	path string
+	size int64
+}
+
+// FileRanger returns a Ranger from a path.
+func FileRanger(path string) (Ranger, error) {
+	info, err := os.Stat(path)
 	if err != nil {
 		return nil, Error.Wrap(err)
 	}
-	return struct {
-		Ranger
-		io.Closer
-	}{
-		Ranger: ReaderAtRanger(fh, stat.Size()),
-		Closer: fh,
-	}, nil
+	return &fileRanger{path: path, size: info.Size()}, nil
 }
 
-// FileRanger returns a RangeCloser from a path.
-func FileRanger(path string) (RangeCloser, error) {
-	fh, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	r, err := FileHandleRanger(fh)
-	if err != nil {
-		if closeErr := fh.Close(); closeErr != nil {
-			zap.S().Error(closeErr)
-		}
+func (rr *fileRanger) Size() int64 {
+	return rr.size
+}
 
-		return nil, err
+func (rr *fileRanger) Range(ctx context.Context, offset, length int64) (io.ReadCloser, error) {
+	if offset < 0 {
+		return nil, Error.New("negative offset")
 	}
-	return r, nil
+	if length < 0 {
+		return nil, Error.New("negative length")
+	}
+	if offset+length > int64(rr.size) {
+		return nil, Error.New("range beyond end")
+	}
+
+	fh, err := os.Open(rr.path)
+	if err != nil {
+		return nil, Error.Wrap(err)
+	}
+	_, err = fh.Seek(offset, os.SEEK_SET)
+	if err != nil {
+		fh.Close()
+		return nil, Error.Wrap(err)
+	}
+	return struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: io.LimitReader(fh, length),
+		Closer: fh,
+	}, nil
 }

--- a/pkg/ranger/file_test.go
+++ b/pkg/ranger/file_test.go
@@ -89,7 +89,7 @@ func TestFileRanger(t *testing.T) {
 			t.Fatalf("invalid subrange: %#v != %#v", string(data), example.substr)
 		}
 
-		if err := rr.Close(); err != nil {
+		if err := r.Close(); err != nil {
 			t.Fatalf("unable to close file %q: %v", name, err)
 		}
 	}
@@ -97,16 +97,6 @@ func TestFileRanger(t *testing.T) {
 
 func TestFileRangerOpenFileError(t *testing.T) {
 	rr, err := FileRanger("")
-	if rr != nil {
-		t.Fatal("Ranger expected to be nil")
-	}
-	if err == nil {
-		t.Fatal("Error expected")
-	}
-}
-
-func TestFileRangerHandlerFileStatError(t *testing.T) {
-	rr, err := FileHandleRanger(nil)
 	if rr != nil {
 		t.Fatal("Ranger expected to be nil")
 	}

--- a/pkg/ranger/reader_test.go
+++ b/pkg/ranger/reader_test.go
@@ -76,7 +76,7 @@ func TestConcatReader(t *testing.T) {
 		{[]string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"},
 			12, 7, 3, "hij"},
 	} {
-		var readers []RangeCloser
+		var readers []Ranger
 		for _, data := range example.data {
 			readers = append(readers, ByteRanger([]byte(data)))
 		}
@@ -115,7 +115,7 @@ func TestSubranger(t *testing.T) {
 		{"abcdefghijkl", 8, 4, 0, 3, "ijk"},
 		{"abcdefghijkl", 8, 4, 1, 3, "jkl"},
 	} {
-		rr, err := Subrange(ByteRangeCloser([]byte(example.data)),
+		rr, err := Subrange(ByteRanger([]byte(example.data)),
 			example.offset1, example.length1)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
@@ -148,7 +148,7 @@ func TestSubrangerError(t *testing.T) {
 		{name: "Length and offset is bigger than DataSize", data: "abcd", offset: 4, length: 1},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			rr, err := Subrange(ByteRangeCloser([]byte(tt.data)), tt.offset, tt.length)
+			rr, err := Subrange(ByteRanger([]byte(tt.data)), tt.offset, tt.length)
 			assert.Nil(t, rr)
 			assert.NotNil(t, err)
 		})

--- a/pkg/storage/buckets/prefixed.go
+++ b/pkg/storage/buckets/prefixed.go
@@ -31,7 +31,7 @@ func (o *prefixedObjStore) Meta(ctx context.Context, path paths.Path) (meta obje
 }
 
 func (o *prefixedObjStore) Get(ctx context.Context, path paths.Path) (
-	rr ranger.RangeCloser, meta objects.Meta, err error) {
+	rr ranger.Ranger, meta objects.Meta, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	if len(path) == 0 {

--- a/pkg/storage/ec/client_test.go
+++ b/pkg/storage/ec/client_test.go
@@ -249,8 +249,7 @@ TestLoop:
 					continue TestLoop
 				}
 				ps := NewMockPSClient(ctrl)
-				ps.EXPECT().Get(gomock.Any(), derivedID, int64(size/k), gomock.Any()).Return(
-					ranger.NopCloser(ranger.ByteRanger(nil)), errs[n])
+				ps.EXPECT().Get(gomock.Any(), derivedID, int64(size/k), gomock.Any()).Return(ranger.ByteRanger(nil), errs[n])
 				m[n] = ps
 			}
 		}

--- a/pkg/storage/ec/mocks/mock_client.go
+++ b/pkg/storage/ec/mocks/mock_client.go
@@ -53,9 +53,9 @@ func (mr *MockClientMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.C
 }
 
 // Get mocks base method
-func (m *MockClient) Get(arg0 context.Context, arg1 []*overlay.Node, arg2 eestream.ErasureScheme, arg3 client.PieceID, arg4 int64) (ranger.RangeCloser, error) {
+func (m *MockClient) Get(arg0 context.Context, arg1 []*overlay.Node, arg2 eestream.ErasureScheme, arg3 client.PieceID, arg4 int64) (ranger.Ranger, error) {
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(ranger.RangeCloser)
+	ret0, _ := ret[0].(ranger.Ranger)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/storage/ec/psclient_mock_test.go
+++ b/pkg/storage/ec/psclient_mock_test.go
@@ -69,9 +69,9 @@ func (mr *MockPSClientMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // Get mocks base method
-func (m *MockPSClient) Get(arg0 context.Context, arg1 client.PieceID, arg2 int64, arg3 *piecestore.PayerBandwidthAllocation) (ranger.RangeCloser, error) {
+func (m *MockPSClient) Get(arg0 context.Context, arg1 client.PieceID, arg2 int64, arg3 *piecestore.PayerBandwidthAllocation) (ranger.Ranger, error) {
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(ranger.RangeCloser)
+	ret0, _ := ret[0].(ranger.Ranger)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/storage/objects/store.go
+++ b/pkg/storage/objects/store.go
@@ -43,7 +43,7 @@ type ListItem struct {
 // Store for objects
 type Store interface {
 	Meta(ctx context.Context, path paths.Path) (meta Meta, err error)
-	Get(ctx context.Context, path paths.Path) (rr ranger.RangeCloser,
+	Get(ctx context.Context, path paths.Path) (rr ranger.Ranger,
 		meta Meta, err error)
 	Put(ctx context.Context, path paths.Path, data io.Reader,
 		metadata SerializableMeta, expiration time.Time) (meta Meta, err error)
@@ -75,7 +75,7 @@ func (o *objStore) Meta(ctx context.Context, path paths.Path) (meta Meta,
 }
 
 func (o *objStore) Get(ctx context.Context, path paths.Path) (
-	rr ranger.RangeCloser, meta Meta, err error) {
+	rr ranger.Ranger, meta Meta, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	if len(path) == 0 {

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -49,7 +49,7 @@ type ListItem struct {
 // Store for segments
 type Store interface {
 	Meta(ctx context.Context, path paths.Path) (meta Meta, err error)
-	Get(ctx context.Context, path paths.Path) (rr ranger.RangeCloser,
+	Get(ctx context.Context, path paths.Path) (rr ranger.Ranger,
 		meta Meta, err error)
 	Put(ctx context.Context, path paths.Path, data io.Reader, metadata []byte,
 		expiration time.Time) (meta Meta, err error)
@@ -179,7 +179,7 @@ func (s *segmentStore) makeRemotePointer(nodes []*opb.Node, pieceID client.Piece
 
 // Get retrieves a segment using erasure code, overlay, and pointerdb clients
 func (s *segmentStore) Get(ctx context.Context, path paths.Path) (
-	rr ranger.RangeCloser, meta Meta, err error) {
+	rr ranger.Ranger, meta Meta, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	pr, err := s.pdb.Get(ctx, path)
@@ -205,7 +205,7 @@ func (s *segmentStore) Get(ctx context.Context, path paths.Path) (
 			return nil, Meta{}, Error.Wrap(err)
 		}
 	} else {
-		rr = ranger.ByteRangeCloser(pr.InlineSegment)
+		rr = ranger.ByteRanger(pr.InlineSegment)
 	}
 
 	return rr, convertMeta(pr), nil


### PR DESCRIPTION
This change resolves the issue with accumulating connections when downloading or streaming a large file composed of many segments. The connections for a certain segment will be closed as soon as the last byte of the segment is read.

This is achieved by two main changes:
1. The connection is not closed by RangeCloser.Close() anymore, but by the ReadCloser.Close().
2. The MultiReadCloser is modified, so the Read method close the respective reader after reading the last byte from it.