### PR TITLE
Stop travis from making binaries for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   - make test
   - goveralls -coverprofile=.coverprofile -service=travis-ci
   - make test-captplanet
-  - make binaries
+#  - make binaries

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ git:
 
 services:
   - redis
-  - docker
 
 before_install:
   - source scripts/travis-deps.sh
@@ -22,4 +21,3 @@ script:
   - make test
   - goveralls -coverprofile=.coverprofile -service=travis-ci
   - make test-captplanet
-#  - make binaries


### PR DESCRIPTION
This gets PR checks in travis back down to ~6 minutes. I toyed with some basic optimizations to get checks < 5 minutes, but they didn't buy much. @egonelbre has some good ideas about switching to go 1.11 and caching the modules instead of using the storj-vendor repo, but that's not in this PR.