### PR TITLE
Pointer stores only nodes with successfully uploaded pieces

### DIFF
--- a/pkg/eestream/decode.go
+++ b/pkg/eestream/decode.go
@@ -98,13 +98,19 @@ func (dr *decodedReader) Close() error {
 	dr.cancel()
 	// avoid double close of readers
 	dr.close.Do(func() {
-		errs := make([]error, len(dr.readers)+1)
+		var errs []error
 		// close the readers
-		for i, r := range dr.readers {
-			errs[i] = r.Close()
+		for _, r := range dr.readers {
+			err := r.Close()
+			if err != nil {
+				errs = append(errs, err)
+			}
 		}
 		// close the stripe reader
-		errs[len(dr.readers)] = dr.stripeReader.Close()
+		err := dr.stripeReader.Close()
+		if err != nil {
+			errs = append(errs, err)
+		}
 		dr.closeErr = utils.CombineErrors(errs...)
 	})
 	return dr.closeErr

--- a/pkg/piecestore/rpc/client/client.go
+++ b/pkg/piecestore/rpc/client/client.go
@@ -129,7 +129,10 @@ func (client *Client) Put(ctx context.Context, id PieceID, data io.Reader, ttl t
 	if err == io.ErrUnexpectedEOF {
 		_ = writer.Close()
 		zap.S().Infof("Node cut from upload due to slow connection. Deleting piece %s...", id)
-		return client.Delete(ctx, id)
+		deleteErr := client.Delete(ctx, id)
+		if deleteErr != nil {
+			return deleteErr
+		}
 	}
 	if err != nil {
 		return err

--- a/pkg/storage/ec/client_test.go
+++ b/pkg/storage/ec/client_test.go
@@ -185,12 +185,20 @@ TestLoop:
 		}
 		r := io.LimitReader(rand.Reader, int64(size))
 		ec := ecClient{d: &mockDialer{m: m}, mbm: tt.mbm}
-		err = ec.Put(ctx, tt.nodes, rs, id, r, ttl)
+		successfulNodes, err := ec.Put(ctx, tt.nodes, rs, id, r, ttl)
 
 		if tt.errString != "" {
 			assert.EqualError(t, err, tt.errString, errTag)
 		} else {
 			assert.NoError(t, err, errTag)
+			assert.Equal(t, len(tt.nodes), len(successfulNodes), errTag)
+			for i := range tt.nodes {
+				if tt.errs[i] != nil {
+					assert.Nil(t, successfulNodes[i], errTag)
+				} else {
+					assert.Equal(t, tt.nodes[i], successfulNodes[i], errTag)
+				}
+			}
 		}
 	}
 }
@@ -231,6 +239,8 @@ TestLoop:
 			[]error{ErrOpFailed, ErrDialFailed, nil, ErrDialFailed}, ""},
 		{[]*pb.Node{node0, node1, node2, node3}, 0,
 			[]error{ErrDialFailed, ErrOpFailed, ErrOpFailed, ErrDialFailed}, ""},
+		{[]*pb.Node{nil, nil, node2, node3}, 0,
+			[]error{nil, nil, nil, nil}, ""},
 	} {
 		errTag := fmt.Sprintf("Test case #%d", i)
 
@@ -288,6 +298,8 @@ TestLoop:
 		{[]*pb.Node{node0, node1}, []error{nil, ErrOpFailed}, ""},
 		{[]*pb.Node{node0, node1}, []error{ErrDialFailed, ErrDialFailed}, dialFailed},
 		{[]*pb.Node{node0, node1}, []error{ErrOpFailed, ErrOpFailed}, opFailed},
+		{[]*pb.Node{nil, node1}, []error{nil, nil}, ""},
+		{[]*pb.Node{nil, nil}, []error{nil, nil}, ""},
 	} {
 		errTag := fmt.Sprintf("Test case #%d", i)
 
@@ -300,7 +312,7 @@ TestLoop:
 
 		m := make(map[*pb.Node]client.PSClient, len(tt.nodes))
 		for _, n := range tt.nodes {
-			if errs[n] != ErrDialFailed {
+			if n != nil && errs[n] != ErrDialFailed {
 				derivedID, err := id.Derive([]byte(n.GetId()))
 				if !assert.NoError(t, err, errTag) {
 					continue TestLoop

--- a/pkg/storage/ec/mocks/mock_client.go
+++ b/pkg/storage/ec/mocks/mock_client.go
@@ -11,8 +11,9 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+
 	eestream "storj.io/storj/pkg/eestream"
-	"storj.io/storj/pkg/pb"
+	pb "storj.io/storj/pkg/pb"
 	client "storj.io/storj/pkg/piecestore/rpc/client"
 	ranger "storj.io/storj/pkg/ranger"
 )
@@ -66,10 +67,11 @@ func (mr *MockClientMockRecorder) Get(arg0, arg1, arg2, arg3, arg4 interface{}) 
 }
 
 // Put mocks base method
-func (m *MockClient) Put(arg0 context.Context, arg1 []*pb.Node, arg2 eestream.RedundancyStrategy, arg3 client.PieceID, arg4 io.Reader, arg5 time.Time) error {
+func (m *MockClient) Put(arg0 context.Context, arg1 []*pb.Node, arg2 eestream.RedundancyStrategy, arg3 client.PieceID, arg4 io.Reader, arg5 time.Time) ([]*pb.Node, error) {
 	ret := m.ctrl.Call(m, "Put", arg0, arg1, arg2, arg3, arg4, arg5)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].([]*pb.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Put indicates an expected call of Put


### PR DESCRIPTION
Fixes https://storjlabs.atlassian.net/browse/V3-230

- ECClient.Put() now returns the list of nodes who successfully got a piece
- The Segment Store puts only these successful nodes into the segment's pointer
- ECClient.Get() and Delete() now tolerate `nil` nodes in the provided list of nodes. A `nil` node represents a piece number which is missing in the storage network, i.e. there is no node storing that piece.