### PR TITLE
Rename: DecodedBlockSize>StripeSize, EncodedBlockSize>ErasureShareSize

### DIFF
--- a/examples/eestream/serve-collected/main.go
+++ b/examples/eestream/serve-collected/main.go
@@ -19,11 +19,11 @@ import (
 )
 
 var (
-	addr           = flag.String("addr", "localhost:8080", "address to serve from")
-	pieceBlockSize = flag.Int("piece_block_size", 4*1024, "block size of pieces")
-	key            = flag.String("key", "a key", "the secret key")
-	rsk            = flag.Int("required", 20, "rs required")
-	rsn            = flag.Int("total", 40, "rs total")
+	addr             = flag.String("addr", "localhost:8080", "address to serve from")
+	erasureShareSize = flag.Int("erasure_share_size", 4*1024, "block size of pieces")
+	key              = flag.String("key", "a key", "the secret key")
+	rsk              = flag.Int("required", 20, "rs required")
+	rsn              = flag.Int("total", 40, "rs total")
 )
 
 func main() {
@@ -41,11 +41,10 @@ func Main() error {
 	if err != nil {
 		return err
 	}
-	es := eestream.NewRSScheme(fc, *pieceBlockSize)
+	es := eestream.NewRSScheme(fc, *erasureShareSize)
 	var firstNonce eestream.Nonce
 	cipher := eestream.AESGCM
-	decrypter, err := cipher.NewDecrypter(
-		&encKey, &firstNonce, es.DecodedBlockSize())
+	decrypter, err := cipher.NewDecrypter(&encKey, &firstNonce, es.StripeSize())
 	if err != nil {
 		return err
 	}

--- a/examples/eestream/serve/main.go
+++ b/examples/eestream/serve/main.go
@@ -23,11 +23,11 @@ import (
 )
 
 var (
-	addr           = flag.String("addr", "localhost:8080", "address to serve from")
-	pieceBlockSize = flag.Int("piece_block_size", 4*1024, "block size of pieces")
-	key            = flag.String("key", "a key", "the secret key")
-	rsk            = flag.Int("required", 20, "rs required")
-	rsn            = flag.Int("total", 40, "rs total")
+	addr             = flag.String("addr", "localhost:8080", "address to serve from")
+	erasureShareSize = flag.Int("erasure_share_size", 4*1024, "block size of pieces")
+	key              = flag.String("key", "a key", "the secret key")
+	rsk              = flag.Int("required", 20, "rs required")
+	rsn              = flag.Int("total", 40, "rs total")
 )
 
 func main() {
@@ -50,10 +50,10 @@ func Main() error {
 	if err != nil {
 		return err
 	}
-	es := eestream.NewRSScheme(fc, *pieceBlockSize)
+	es := eestream.NewRSScheme(fc, *erasureShareSize)
 	var firstNonce eestream.Nonce
 	cipher := eestream.AESGCM
-	decrypter, err := cipher.NewDecrypter(&encKey, &firstNonce, es.DecodedBlockSize())
+	decrypter, err := cipher.NewDecrypter(&encKey, &firstNonce, es.StripeSize())
 	if err != nil {
 		return err
 	}

--- a/examples/eestream/store/main.go
+++ b/examples/eestream/store/main.go
@@ -18,10 +18,10 @@ import (
 )
 
 var (
-	pieceBlockSize = flag.Int("piece_block_size", 4*1024, "block size of pieces")
-	key            = flag.String("key", "a key", "the secret key")
-	rsk            = flag.Int("required", 20, "rs required")
-	rsn            = flag.Int("total", 40, "rs total")
+	erasureShareSize = flag.Int("erasure_share_size", 4*1024, "block size of pieces")
+	key              = flag.String("key", "a key", "the secret key")
+	rsk              = flag.Int("required", 20, "rs required")
+	rsn              = flag.Int("total", 40, "rs total")
 )
 
 func main() {
@@ -47,7 +47,7 @@ func Main() error {
 	if err != nil {
 		return err
 	}
-	es := eestream.NewRSScheme(fc, *pieceBlockSize)
+	es := eestream.NewRSScheme(fc, *erasureShareSize)
 	rs, err := eestream.NewRedundancyStrategy(es, 0, 0)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func Main() error {
 	encKey := eestream.Key(sha256.Sum256([]byte(*key)))
 	var firstNonce eestream.Nonce
 	cipher := eestream.AESGCM
-	encrypter, err := cipher.NewEncrypter(&encKey, &firstNonce, es.DecodedBlockSize())
+	encrypter, err := cipher.NewEncrypter(&encKey, &firstNonce, es.StripeSize())
 	if err != nil {
 		return err
 	}

--- a/pkg/eestream/mocks/mock_client.go
+++ b/pkg/eestream/mocks/mock_client.go
@@ -46,18 +46,6 @@ func (mr *MockErasureSchemeMockRecorder) Decode(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Decode", reflect.TypeOf((*MockErasureScheme)(nil).Decode), arg0, arg1)
 }
 
-// DecodedBlockSize mocks base method
-func (m *MockErasureScheme) DecodedBlockSize() int {
-	ret := m.ctrl.Call(m, "DecodedBlockSize")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// DecodedBlockSize indicates an expected call of DecodedBlockSize
-func (mr *MockErasureSchemeMockRecorder) DecodedBlockSize() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodedBlockSize", reflect.TypeOf((*MockErasureScheme)(nil).DecodedBlockSize))
-}
-
 // Encode mocks base method
 func (m *MockErasureScheme) Encode(arg0 []byte, arg1 func(int, []byte)) error {
 	ret := m.ctrl.Call(m, "Encode", arg0, arg1)
@@ -70,16 +58,16 @@ func (mr *MockErasureSchemeMockRecorder) Encode(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Encode", reflect.TypeOf((*MockErasureScheme)(nil).Encode), arg0, arg1)
 }
 
-// EncodedBlockSize mocks base method
-func (m *MockErasureScheme) EncodedBlockSize() int {
-	ret := m.ctrl.Call(m, "EncodedBlockSize")
+// ErasureShareSize mocks base method
+func (m *MockErasureScheme) ErasureShareSize() int {
+	ret := m.ctrl.Call(m, "ErasureShareSize")
 	ret0, _ := ret[0].(int)
 	return ret0
 }
 
-// EncodedBlockSize indicates an expected call of EncodedBlockSize
-func (mr *MockErasureSchemeMockRecorder) EncodedBlockSize() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncodedBlockSize", reflect.TypeOf((*MockErasureScheme)(nil).EncodedBlockSize))
+// ErasureShareSize indicates an expected call of ErasureShareSize
+func (mr *MockErasureSchemeMockRecorder) ErasureShareSize() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ErasureShareSize", reflect.TypeOf((*MockErasureScheme)(nil).ErasureShareSize))
 }
 
 // RequiredCount mocks base method
@@ -92,6 +80,18 @@ func (m *MockErasureScheme) RequiredCount() int {
 // RequiredCount indicates an expected call of RequiredCount
 func (mr *MockErasureSchemeMockRecorder) RequiredCount() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequiredCount", reflect.TypeOf((*MockErasureScheme)(nil).RequiredCount))
+}
+
+// StripeSize mocks base method
+func (m *MockErasureScheme) StripeSize() int {
+	ret := m.ctrl.Call(m, "StripeSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// StripeSize indicates an expected call of StripeSize
+func (mr *MockErasureSchemeMockRecorder) StripeSize() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StripeSize", reflect.TypeOf((*MockErasureScheme)(nil).StripeSize))
 }
 
 // TotalCount mocks base method

--- a/pkg/eestream/rs.go
+++ b/pkg/eestream/rs.go
@@ -8,13 +8,13 @@ import (
 )
 
 type rsScheme struct {
-	fc        *infectious.FEC
-	blockSize int
+	fc               *infectious.FEC
+	erasureShareSize int
 }
 
 // NewRSScheme returns a Reed-Solomon-based ErasureScheme.
-func NewRSScheme(fc *infectious.FEC, blockSize int) ErasureScheme {
-	return &rsScheme{fc: fc, blockSize: blockSize}
+func NewRSScheme(fc *infectious.FEC, erasureShareSize int) ErasureScheme {
+	return &rsScheme{fc: fc, erasureShareSize: erasureShareSize}
 }
 
 func (s *rsScheme) Encode(input []byte, output func(num int, data []byte)) (
@@ -32,12 +32,12 @@ func (s *rsScheme) Decode(out []byte, in map[int][]byte) ([]byte, error) {
 	return s.fc.Decode(out, shares)
 }
 
-func (s *rsScheme) EncodedBlockSize() int {
-	return s.blockSize
+func (s *rsScheme) ErasureShareSize() int {
+	return s.erasureShareSize
 }
 
-func (s *rsScheme) DecodedBlockSize() int {
-	return s.blockSize * s.fc.Required()
+func (s *rsScheme) StripeSize() int {
+	return s.erasureShareSize * s.fc.Required()
 }
 
 func (s *rsScheme) TotalCount() int {

--- a/pkg/eestream/rs_test.go
+++ b/pkg/eestream/rs_test.go
@@ -96,7 +96,7 @@ func TestRSRanger(t *testing.T) {
 	encKey := Key(sha256.Sum256([]byte("the secret key")))
 	var firstNonce Nonce
 	cipher := AESGCM
-	encrypter, err := cipher.NewEncrypter(&encKey, &firstNonce, rs.DecodedBlockSize())
+	encrypter, err := cipher.NewEncrypter(&encKey, &firstNonce, rs.StripeSize())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestRSRanger(t *testing.T) {
 	for i, piece := range pieces {
 		rrs[i] = ranger.ByteRanger(piece)
 	}
-	decrypter, err := cipher.NewDecrypter(&encKey, &firstNonce, rs.DecodedBlockSize())
+	decrypter, err := cipher.NewDecrypter(&encKey, &firstNonce, rs.StripeSize())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/eestream/stripe.go
+++ b/pkg/eestream/stripe.go
@@ -27,9 +27,9 @@ type StripeReader struct {
 // scheme and max buffer memory.
 func NewStripeReader(rs map[int]io.ReadCloser, es ErasureScheme, mbm int) *StripeReader {
 	bufSize := mbm / es.TotalCount()
-	bufSize -= bufSize % es.EncodedBlockSize()
-	if bufSize < es.EncodedBlockSize() {
-		bufSize = es.EncodedBlockSize()
+	bufSize -= bufSize % es.ErasureShareSize()
+	if bufSize < es.ErasureShareSize() {
+		bufSize = es.ErasureShareSize()
 	}
 
 	r := &StripeReader{
@@ -42,8 +42,8 @@ func NewStripeReader(rs map[int]io.ReadCloser, es ErasureScheme, mbm int) *Strip
 	}
 
 	for i := range rs {
-		r.inbufs[i] = make([]byte, es.EncodedBlockSize())
-		r.bufs[i] = NewPieceBuffer(make([]byte, bufSize), es.EncodedBlockSize(), r.cond)
+		r.inbufs[i] = make([]byte, es.ErasureShareSize())
+		r.bufs[i] = NewPieceBuffer(make([]byte, bufSize), es.ErasureShareSize(), r.cond)
 		// Kick off a goroutine each reader to be copied into a PieceBuffer.
 		go func(r io.Reader, buf *PieceBuffer) {
 			_, err := io.Copy(buf, r)

--- a/pkg/storage/ec/client.go
+++ b/pkg/storage/ec/client.go
@@ -75,7 +75,7 @@ func (ec *ecClient) Put(ctx context.Context, nodes []*pb.Node, rs eestream.Redun
 		return nil, Error.New("duplicated nodes are not allowed")
 	}
 
-	padded := eestream.PadReader(ioutil.NopCloser(data), rs.DecodedBlockSize())
+	padded := eestream.PadReader(ioutil.NopCloser(data), rs.StripeSize())
 	readers, err := eestream.EncodeReader(ctx, padded, rs, ec.mbm)
 	if err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ func (ec *ecClient) Get(ctx context.Context, nodes []*pb.Node, es eestream.Erasu
 		return nil, Error.New("number of nodes (%v) do not match total count (%v) of erasure scheme", len(nodes), es.TotalCount())
 	}
 
-	paddedSize := calcPadded(size, es.DecodedBlockSize())
+	paddedSize := calcPadded(size, es.StripeSize())
 	pieceSize := paddedSize / int64(es.RequiredCount())
 	rrs := map[int]ranger.Ranger{}
 

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -167,7 +167,7 @@ func (s *segmentStore) makeRemotePointer(nodes []*pb.Node, pieceID client.PieceI
 				Total:            int32(s.rs.TotalCount()),
 				RepairThreshold:  int32(s.rs.RepairThreshold()),
 				SuccessThreshold: int32(s.rs.OptimalThreshold()),
-				ErasureShareSize: int32(s.rs.EncodedBlockSize()),
+				ErasureShareSize: int32(s.rs.ErasureShareSize()),
 			},
 			PieceId:      string(pieceID),
 			RemotePieces: remotePieces,

--- a/pkg/storage/segments/store_test.go
+++ b/pkg/storage/segments/store_test.go
@@ -122,7 +122,7 @@ func TestSegmentStorePutRemote(t *testing.T) {
 			),
 			mockES.EXPECT().RequiredCount().Return(1),
 			mockES.EXPECT().TotalCount().Return(1),
-			mockES.EXPECT().EncodedBlockSize().Return(1),
+			mockES.EXPECT().ErasureShareSize().Return(1),
 			mockPDB.EXPECT().Put(
 				gomock.Any(), gomock.Any(), gomock.Any(),
 			).Return(nil),


### PR DESCRIPTION
Renames the following methods of the ErasureScheme interface to make them clearer and avoid confusion:
- `EncodedBlockSize()` is renamed to `ErasureShareSize()`
- `DecodedBlockSize()` is renamed to `StripeSize()`