### PR TITLE
sync enqueue and dequeue

### DIFF
--- a/pkg/datarepair/queue/queue_test.go
+++ b/pkg/datarepair/queue/queue_test.go
@@ -31,14 +31,6 @@ func TestEnqueueDequeue(t *testing.T) {
 	assert.True(t, proto.Equal(&s, seg))
 }
 
-func TestDequeueEmptyQueue(t *testing.T) {
-	db := teststore.New()
-	q := NewQueue(db)
-	s, err := q.Dequeue()
-	assert.Error(t, err)
-	assert.Equal(t, pb.InjuredSegment{}, s)
-}
-
 func TestForceError(t *testing.T) {
 	db := teststore.New()
 	q := NewQueue(db)


### PR DESCRIPTION
When we run the checker and repairer in separate go routines, we want to synchronize them in a way which avoids the need to constantly check the size of the queue and allows concurrent repair of multiple segments. When Dequeue is called, it will first check the size of the queue. If the length of the queue equals 0, code execution will halt until a signal is sent from Enqueue, which will then resume execution and the condition will be checked again