### PR TITLE
metainfo database: add interfaces and types

### DIFF
--- a/pkg/storj/encryption.go
+++ b/pkg/storj/encryption.go
@@ -5,8 +5,7 @@ package storj
 
 // EncryptionScheme is the scheme and parameters used for encryption
 type EncryptionScheme struct {
-	Algorithm    EncryptionAlgorithm
-	EncryptedKey EncryptedPrivateKey
+	Algorithm EncryptionAlgorithm
 }
 
 // EncryptionAlgorithm specifies an encryption algorithm
@@ -22,6 +21,3 @@ const (
 
 // EncryptedPrivateKey is a private key that has been encrypted
 type EncryptedPrivateKey []byte
-
-// EncryptedNonce is a nonce that has been encrypted
-type EncryptedNonce []byte

--- a/pkg/storj/encryption.go
+++ b/pkg/storj/encryption.go
@@ -5,9 +5,8 @@ package storj
 
 // EncryptionScheme is the scheme and parameters used for encryption
 type EncryptionScheme struct {
-	Algorithm      EncryptionAlgorithm
-	EncryptedKey   EncryptedPrivateKey
-	EncryptedNonce EncryptedNonce
+	Algorithm    EncryptionAlgorithm
+	EncryptedKey EncryptedPrivateKey
 }
 
 // EncryptionAlgorithm specifies an encryption algorithm

--- a/pkg/storj/encryption.go
+++ b/pkg/storj/encryption.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
 package storj
 
 // EncryptionScheme is the scheme and parameters used for encryption

--- a/pkg/storj/encryption.go
+++ b/pkg/storj/encryption.go
@@ -1,0 +1,25 @@
+package storj
+
+// EncryptionScheme is the scheme and parameters used for encryption
+type EncryptionScheme struct {
+	Algorithm      EncryptionAlgorithm
+	EncryptedKey   EncryptedPrivateKey
+	EncryptedNonce EncryptedNonce
+}
+
+// EncryptionAlgorithm specifies an encryption algorithm
+type EncryptionAlgorithm byte
+
+// List of supported encryption algorithms
+const (
+	InvalidEncryptionAlgorithm = EncryptionAlgorithm(iota)
+	Unencrypted
+	AESGCM
+	Secretbox
+)
+
+// EncryptedPrivateKey is a private key that has been encrypted
+type EncryptedPrivateKey []byte
+
+// EncryptedNonce is a nonce that has been encrypted
+type EncryptedNonce []byte

--- a/pkg/storj/encryption.go
+++ b/pkg/storj/encryption.go
@@ -19,5 +19,8 @@ const (
 	Secretbox
 )
 
+// Nonce represents the largest nonce used by any encryption protocol
+type Nonce [24]byte // TODO: unify with eestream.Nonce
+
 // EncryptedPrivateKey is a private key that has been encrypted
 type EncryptedPrivateKey []byte

--- a/pkg/storj/metainfo.go
+++ b/pkg/storj/metainfo.go
@@ -71,11 +71,9 @@ type ReadonlyStream interface {
 
 	// SegmentsAt returns the segment that contains the byteOffset and following segments.
 	// Limit specifies how much to return at most.
-	// Returns io.EOF, when there aren't more segments.
 	SegmentsAt(ctx context.Context, byteOffset int64, limit int64) (infos []Segment, more bool, err error)
 	// Segments returns the segment at index.
 	// Limit specifies how much to return at most.
-	// Returns io.EOF, when there aren't more segments.
 	Segments(ctx context.Context, index int64, limit int64) (infos []Segment, more bool, err error)
 }
 

--- a/pkg/storj/metainfo.go
+++ b/pkg/storj/metainfo.go
@@ -63,8 +63,8 @@ type MetainfoLimits struct {
 	// ListLimit specifies the maximum amount of items that can be listed at a time.
 	ListLimit int64
 
-	// MinimumRemoteSegemtSize specifies the minimum remote segment that is allowed to be stored.
-	MinimumRemoteSegemtSize int64
+	// MinimumRemoteSegmentSize specifies the minimum remote segment that is allowed to be stored.
+	MinimumRemoteSegmentSize int64
 	// MaximumInlineSegmentSize specifies the maximum inline segment that is allowed to be stored.
 	MaximumInlineSegmentSize int64
 }

--- a/pkg/storj/metainfo.go
+++ b/pkg/storj/metainfo.go
@@ -47,10 +47,11 @@ type CreateObject struct {
 // Object converts the CreateObject to an object with unitialized values
 func (create CreateObject) Object(bucket string, path Path) Object {
 	return Object{
-		Bucket:   bucket,
-		Path:     path,
-		Metadata: create.Metadata,
-		Expires:  create.Expires,
+		Bucket:      bucket,
+		Path:        path,
+		Metadata:    create.Metadata,
+		ContentType: create.ContentType,
+		Expires:     create.Expires,
 	}
 }
 

--- a/pkg/storj/metainfo.go
+++ b/pkg/storj/metainfo.go
@@ -1,0 +1,106 @@
+package storj
+
+import (
+	"context"
+)
+
+// Metainfo represents a database for storing meta-info about objects
+type Metainfo interface {
+	// MetainfoLimits returns limits for this metainfo database
+	Limits() (MetainfoLimits, error)
+
+	// CreateBucket creates a new bucket with the specified information
+	CreateBucket(ctx context.Context, bucket Bucket) (Bucket, error)
+	// DeleteBucket deletes bucket
+	DeleteBucket(ctx context.Context, bucket string) error
+	// GetBucket gets bucket information
+	GetBucket(ctx context.Context, bucket string) (Bucket, error)
+
+	// GetObject returns information about an object
+	GetObject(ctx context.Context, bucket string, path Path) (Object, error)
+	// GetObjectStream returns interface for reading the object stream
+	GetObjectStream(ctx context.Context, bucket string, path Path) (ReadonlyStream, error)
+
+	// CreateObject creates an uploading object and returns an interface for uploading Object information
+	CreateObject(ctx context.Context, bucket string, path Path, info Object) (MutableObject, error)
+	// ModifyObject creates an interface for modifying an existing object
+	ModifyObject(ctx context.Context, bucket string, path Path, info Object) (MutableObject, error)
+	// DeleteObject deletes an object from database
+	DeleteObject(ctx context.Context, bucket string, path Path) error
+
+	// TODO: add things for continuing existing objects
+	ListObjects(cctx context.Context, bucket string, options ListOptions) (ObjectList, error)
+}
+
+// ListOptions lists objects
+type ListOptions struct {
+	Prefix    Path
+	First     Path // First is relative to Prefix, full path is Prefix + First
+	Delimiter rune
+	Recursive bool
+	Limit     int
+
+	// Token used for the next listing.
+	Token string
+}
+
+// ObjectList is a list of objects
+type ObjectList struct {
+	Bucket string
+	Prefix Path
+	Token  string
+	More   bool
+
+	// Items paths are realtive to Prefix
+	// To get the full path use list.Prefix + list.Items[0].Path
+	Items []Object
+}
+
+// MetainfoLimits lists limits specified for the Metainfo database
+type MetainfoLimits struct {
+	// ListLimit specifies the maximum amount of items that can be listed at a time.
+	ListLimit int64
+
+	// MaximumInlineSegment specifies the maximum inline segment that is allowed to be stored.
+	MaximumInlineSegmentSize int64
+}
+
+// ReadonlyStream is an interface for reading segment information
+type ReadonlyStream interface {
+	Info() Object
+
+	// SegmentsAt returns the segment that contains the byteOffset and following segments.
+	// Limit specifies how much to return at most.
+	// Returns io.EOF, when there aren't more segments.
+	SegmentsAt(ctx context.Context, byteOffset int64, limit int64) ([]Segment, error)
+	// Segments returns the segment at index.
+	// Limit specifies how much to return at most.
+	// Returns io.EOF, when there aren't more segments.
+	Segments(ctx context.Context, index int64, limit int64) ([]Segment, error)
+}
+
+// MutableObject is an interface for manipulating creating/deleting object stream
+type MutableObject interface {
+	// Info gets the current information about the object
+	Info() (Object, error)
+
+	// CreateStream creates a new stream for the object
+	CreateStream() (MutableStream, error)
+	// ContinueStream starts to continue a partially uploaded stream.
+	// ContinueStream() (MutableStream, error)
+	// DeleteStream deletes any information about this objects stream
+	DeleteStream() error
+
+	// Commit commits the changes to the database
+	Commit() error
+}
+
+// MutableStream is an interface for manipulating stream information
+type MutableStream interface {
+	ReadonlyStream
+
+	// AddSegments adds segments to the stream.
+	AddSegments(segments ...Segment) error
+	// UpdateSegments updates information about segments.
+	UpdateSegments(segments ...Segment) error
+}

--- a/pkg/storj/metainfo.go
+++ b/pkg/storj/metainfo.go
@@ -63,8 +63,8 @@ type MetainfoLimits struct {
 	// ListLimit specifies the maximum amount of items that can be listed at a time.
 	ListLimit int64
 
-	// MinimumInlineSegmentSize specifies the minimum inline segment that is allowed to be stored.
-	MinimumInlineSegmentSize int64
+	// MinimumRemoteSegemtSize specifies the minimum remote segment that is allowed to be stored.
+	MinimumRemoteSegemtSize int64
 	// MaximumInlineSegmentSize specifies the maximum inline segment that is allowed to be stored.
 	MaximumInlineSegmentSize int64
 }

--- a/pkg/storj/metainfo.go
+++ b/pkg/storj/metainfo.go
@@ -23,7 +23,7 @@ type Metainfo interface {
 	// GetObject returns information about an object
 	GetObject(ctx context.Context, bucket string, path Path) (Object, error)
 	// GetObjectStream returns interface for reading the object stream
-	GetObjectStream(ctx context.Context, bucket string, path Path) (ReadonlyStream, error)
+	GetObjectStream(ctx context.Context, bucket string, path Path) (ReadOnlyStream, error)
 
 	// CreateObject creates an uploading object and returns an interface for uploading Object information
 	CreateObject(ctx context.Context, bucket string, path Path, info Object) (MutableObject, error)
@@ -69,8 +69,8 @@ type MetainfoLimits struct {
 	MaximumInlineSegmentSize int64
 }
 
-// ReadonlyStream is an interface for reading segment information
-type ReadonlyStream interface {
+// ReadOnlyStream is an interface for reading segment information
+type ReadOnlyStream interface {
 	Info() Object
 
 	// SegmentsAt returns the segment that contains the byteOffset and following segments.
@@ -99,7 +99,7 @@ type MutableObject interface {
 
 // MutableStream is an interface for manipulating stream information
 type MutableStream interface {
-	ReadonlyStream
+	ReadOnlyStream
 
 	// AddSegments adds segments to the stream.
 	AddSegments(segments ...Segment) error

--- a/pkg/storj/metainfo.go
+++ b/pkg/storj/metainfo.go
@@ -72,11 +72,11 @@ type ReadonlyStream interface {
 	// SegmentsAt returns the segment that contains the byteOffset and following segments.
 	// Limit specifies how much to return at most.
 	// Returns io.EOF, when there aren't more segments.
-	SegmentsAt(ctx context.Context, byteOffset int64, limit int64) ([]Segment, error)
+	SegmentsAt(ctx context.Context, byteOffset int64, limit int64) (infos []Segment, more bool, err error)
 	// Segments returns the segment at index.
 	// Limit specifies how much to return at most.
 	// Returns io.EOF, when there aren't more segments.
-	Segments(ctx context.Context, index int64, limit int64) ([]Segment, error)
+	Segments(ctx context.Context, index int64, limit int64) (infos []Segment, more bool, err error)
 }
 
 // MutableObject is an interface for manipulating creating/deleting object stream

--- a/pkg/storj/metainfo.go
+++ b/pkg/storj/metainfo.go
@@ -5,6 +5,7 @@ package storj
 
 import (
 	"context"
+	"time"
 )
 
 // Metainfo represents a database for storing meta-info about objects
@@ -26,7 +27,7 @@ type Metainfo interface {
 	GetObjectStream(ctx context.Context, bucket string, path Path) (ReadOnlyStream, error)
 
 	// CreateObject creates an uploading object and returns an interface for uploading Object information
-	CreateObject(ctx context.Context, bucket string, path Path, info Object) (MutableObject, error)
+	CreateObject(ctx context.Context, bucket string, path Path, info *CreateObject) (MutableObject, error)
 	// ModifyObject creates an interface for modifying an existing object
 	ModifyObject(ctx context.Context, bucket string, path Path, info Object) (MutableObject, error)
 	// DeleteObject deletes an object from database
@@ -34,6 +35,23 @@ type Metainfo interface {
 
 	// ListObjects lists objects in bucket based on the ListOptions
 	ListObjects(ctx context.Context, bucket string, options ListOptions) (ObjectList, error)
+}
+
+// CreateObject has optional parameters that can be set
+type CreateObject struct {
+	Metadata    []byte
+	ContentType string
+	Expires     time.Time
+}
+
+// Object converts the CreateObject to an object with unitialized values
+func (create CreateObject) Object(bucket string, path Path) Object {
+	return Object{
+		Bucket:   bucket,
+		Path:     path,
+		Metadata: create.Metadata,
+		Expires:  create.Expires,
+	}
 }
 
 // ListOptions lists objects

--- a/pkg/storj/metainfo.go
+++ b/pkg/storj/metainfo.go
@@ -32,8 +32,8 @@ type Metainfo interface {
 	// DeleteObject deletes an object from database
 	DeleteObject(ctx context.Context, bucket string, path Path) error
 
-	// TODO: add things for continuing existing objects
-	ListObjects(cctx context.Context, bucket string, options ListOptions) (ObjectList, error)
+	// ListObjects lists objects in bucket based on the ListOptions
+	ListObjects(ctx context.Context, bucket string, options ListOptions) (ObjectList, error)
 }
 
 // ListOptions lists objects
@@ -49,7 +49,9 @@ type ListOptions struct {
 type ObjectList struct {
 	Bucket string
 	Prefix Path
-	More   bool
+
+	NextFirst Path // relative to Prefix, to get the full path use Prefix + NextFirst
+	More      bool
 
 	// Items paths are relative to Prefix
 	// To get the full path use list.Prefix + list.Items[0].Path
@@ -61,7 +63,9 @@ type MetainfoLimits struct {
 	// ListLimit specifies the maximum amount of items that can be listed at a time.
 	ListLimit int64
 
-	// MaximumInlineSegment specifies the maximum inline segment that is allowed to be stored.
+	// MinimumInlineSegmentSize specifies the minimum inline segment that is allowed to be stored.
+	MinimumInlineSegmentSize int64
+	// MaximumInlineSegmentSize specifies the maximum inline segment that is allowed to be stored.
 	MaximumInlineSegmentSize int64
 }
 

--- a/pkg/storj/metainfo.go
+++ b/pkg/storj/metainfo.go
@@ -54,7 +54,7 @@ type ObjectList struct {
 	Token  string
 	More   bool
 
-	// Items paths are realtive to Prefix
+	// Items paths are relative to Prefix
 	// To get the full path use list.Prefix + list.Items[0].Path
 	Items []Object
 }

--- a/pkg/storj/metainfo.go
+++ b/pkg/storj/metainfo.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
 package storj
 
 import (

--- a/pkg/storj/metainfo.go
+++ b/pkg/storj/metainfo.go
@@ -13,7 +13,8 @@ type Metainfo interface {
 	Limits() (MetainfoLimits, error)
 
 	// CreateBucket creates a new bucket with the specified information
-	CreateBucket(ctx context.Context, bucket Bucket) (Bucket, error)
+	// Database automatically sets different values in the information
+	CreateBucket(ctx context.Context, bucket string, info *Bucket) (Bucket, error)
 	// DeleteBucket deletes bucket
 	DeleteBucket(ctx context.Context, bucket string) error
 	// GetBucket gets bucket information
@@ -42,16 +43,12 @@ type ListOptions struct {
 	Delimiter rune
 	Recursive bool
 	Limit     int
-
-	// Token used for the next listing.
-	Token string
 }
 
 // ObjectList is a list of objects
 type ObjectList struct {
 	Bucket string
 	Prefix Path
-	Token  string
 	More   bool
 
 	// Items paths are relative to Prefix

--- a/pkg/storj/node.go
+++ b/pkg/storj/node.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
 package storj
 
 import "encoding/hex"

--- a/pkg/storj/node.go
+++ b/pkg/storj/node.go
@@ -1,0 +1,12 @@
+package storj
+
+import "encoding/hex"
+
+// NodeID is a unique node identifier
+type NodeID [32]byte
+
+// HexString returns NodeID as hex encoded string
+func (id *NodeID) HexString() string { return hex.EncodeToString(id[:]) }
+
+// Bytes returns raw bytes of the id
+func (id NodeID) Bytes() []byte { return id[:] }

--- a/pkg/storj/object.go
+++ b/pkg/storj/object.go
@@ -55,7 +55,7 @@ type Segment struct {
 	PieceID PieceID
 	Pieces  []Piece
 	// Encryption
-	EncryptedNonce EncryptedNonce
+	EncryptedKey EncryptedPrivateKey
 }
 
 // PieceID is an identificator for a piece

--- a/pkg/storj/object.go
+++ b/pkg/storj/object.go
@@ -60,6 +60,7 @@ type Segment struct {
 	PieceID PieceID
 	Pieces  []Piece
 	// Encryption
+	Nonce        Nonce
 	EncryptedKey EncryptedPrivateKey
 }
 

--- a/pkg/storj/object.go
+++ b/pkg/storj/object.go
@@ -32,6 +32,8 @@ type Object struct {
 type Stream struct {
 	// Size is the total size of the stream in bytes
 	Size int64
+	// Checksum is the checksum of the stream content
+	Checksum string
 
 	// SegmentCount is the number of segments
 	SegmentCount int64

--- a/pkg/storj/object.go
+++ b/pkg/storj/object.go
@@ -33,7 +33,7 @@ type Stream struct {
 	// Size is the total size of the stream in bytes
 	Size int64
 	// Checksum is the checksum of the stream content
-	Checksum string
+	Checksum []byte
 
 	// SegmentCount is the number of segments
 	SegmentCount int64

--- a/pkg/storj/object.go
+++ b/pkg/storj/object.go
@@ -60,8 +60,8 @@ type Segment struct {
 	PieceID PieceID
 	Pieces  []Piece
 	// Encryption
-	Nonce        Nonce
-	EncryptedKey EncryptedPrivateKey
+	EncryptedKeyNonce Nonce
+	EncryptedKey      EncryptedPrivateKey
 }
 
 // PieceID is an identificator for a piece

--- a/pkg/storj/object.go
+++ b/pkg/storj/object.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
 package storj
 
 import "time"

--- a/pkg/storj/object.go
+++ b/pkg/storj/object.go
@@ -1,0 +1,60 @@
+package storj
+
+import "time"
+
+// Bucket contains information about a specific bucket
+type Bucket struct {
+	Name    string
+	Created time.Time
+}
+
+// Object contains information about a specific object
+type Object struct {
+	Version  uint32
+	Bucket   string
+	Path     Path
+	IsPrefix bool
+
+	Metadata []byte
+	Created  time.Time
+	Modified time.Time
+
+	Stream
+}
+
+// Stream is information about an object stream
+type Stream struct {
+	// Size is the total size of the stream in bytes
+	Size int64
+
+	// SegmentCount is the number of segments
+	SegmentCount int64
+	// FixedSegmentSize is the size of each segment,
+	// when all segments have the same size. It is -1 otherwise.
+	FixedSegmentSize int64
+
+	// RedundancyScheme specifies redundancy strategy used for this stream
+	RedundancyScheme
+	// EncryptionScheme specifies encryption strategy used for this stream
+	EncryptionScheme
+}
+
+// Segment is full segment information
+type Segment struct {
+	Index int64
+	Size  int64
+	// Local data
+	Inline []byte
+	// Remote data
+	PieceID PieceID
+	Pieces  []Piece
+}
+
+// PieceID is an identificator for a piece
+type PieceID []byte
+
+// Piece is information where a piece is located
+type Piece struct {
+	Number   byte
+	Location NodeID
+}

--- a/pkg/storj/object.go
+++ b/pkg/storj/object.go
@@ -19,8 +19,11 @@ type Object struct {
 	IsPrefix bool
 
 	Metadata []byte
-	Created  time.Time
-	Modified time.Time
+
+	ContentType string
+	Created     time.Time
+	Modified    time.Time
+	Expires     time.Time
 
 	Stream
 }
@@ -51,6 +54,8 @@ type Segment struct {
 	// Remote data
 	PieceID PieceID
 	Pieces  []Piece
+	// Encryption
+	EncryptedNonce EncryptedNonce
 }
 
 // PieceID is an identificator for a piece

--- a/pkg/storj/object.go
+++ b/pkg/storj/object.go
@@ -32,7 +32,7 @@ type Object struct {
 type Stream struct {
 	// Size is the total size of the stream in bytes
 	Size int64
-	// Checksum is the checksum of the stream content
+	// Checksum is the checksum of the segment checksums
 	Checksum []byte
 
 	// SegmentCount is the number of segments
@@ -50,7 +50,10 @@ type Stream struct {
 // Segment is full segment information
 type Segment struct {
 	Index int64
-	Size  int64
+	// Size is the size of the content in bytes
+	Size int64
+	// Checksum is the checksum of the content
+	Checksum []byte
 	// Local data
 	Inline []byte
 	// Remote data

--- a/pkg/storj/path.go
+++ b/pkg/storj/path.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
 package storj
 
 // Path represents a object path

--- a/pkg/storj/path.go
+++ b/pkg/storj/path.go
@@ -1,0 +1,4 @@
+package storj
+
+// Path represents a object path
+type Path = string

--- a/pkg/storj/redundancy.go
+++ b/pkg/storj/redundancy.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
 package storj
 
 // RedundancyScheme specifies the parameters and the algorithm for redundancy

--- a/pkg/storj/redundancy.go
+++ b/pkg/storj/redundancy.go
@@ -20,7 +20,6 @@ type RedundancyAlgorithm byte
 
 // List of supported redundancy algorithms
 const (
-	Invalid = RedundancyAlgorithm(iota)
-	Duplication
+	InvalidRedundancyAlgorithm = RedundancyAlgorithm(iota)
 	ReedSolomon
 )

--- a/pkg/storj/redundancy.go
+++ b/pkg/storj/redundancy.go
@@ -1,0 +1,23 @@
+package storj
+
+// RedundancyScheme specifies the parameters and the algorithm for redundancy
+type RedundancyScheme struct {
+	Algorithm RedundancyAlgorithm
+
+	ShareSize int64
+
+	RequiredShares int16
+	RepairShares   int16
+	OptimalShares  int16
+	TotalShares    int16
+}
+
+// RedundancyAlgorithm is the algorithm used for redundancy
+type RedundancyAlgorithm byte
+
+// List of supported redundancy algorithms
+const (
+	Invalid = RedundancyAlgorithm(iota)
+	Duplication
+	ReedSolomon
+)


### PR DESCRIPTION
This should contain the interfaces and types necessary to describe the metainfo database and information in it.

Currently in package `storj` since the other things will be moving, it's good to have this location as a stable place for interfaces and types used to wire things together.