### PR TITLE
Rename MinInlineSegmentSize to MinRemoteSegmentSize

### DIFF
--- a/pkg/pointerdb/config.go
+++ b/pkg/pointerdb/config.go
@@ -25,7 +25,7 @@ const (
 // PointerDB responsibility
 type Config struct {
 	DatabaseURL          string `help:"the database connection string to use" default:"bolt://$CONFDIR/pointerdb.db"`
-	MinInlineSegmentSize int64  `default:"1240" help:"minimum inline segment size"`
+	MinRemoteSegmentSize int    `default:"1240" help:"minimum remote segment size"`
 	MaxInlineSegmentSize int    `default:"8000" help:"maximum inline segment size"`
 	Overlay              bool   `default:"false" help:"toggle flag if overlay is enabled"`
 }

--- a/pkg/pointerdb/pointerdb.go
+++ b/pkg/pointerdb/pointerdb.go
@@ -53,14 +53,16 @@ func (s *Server) validateAuth(APIKey []byte) error {
 }
 
 func (s *Server) validateSegment(req *pb.PutRequest) error {
-	min := s.config.MinInlineSegmentSize
+	min := s.config.MinRemoteSegmentSize
+	remote := req.GetPointer().Remote
+	remoteSize := req.GetPointer().GetSize()
+
+	if remote != nil && remoteSize < int64(min) {
+		return segmentError.New("remote segment size %d less than minimum allowed %d", remoteSize, min)
+	}
+
 	max := s.config.MaxInlineSegmentSize
 	inlineSize := len(req.GetPointer().InlineSegment)
-	remote := req.GetPointer().Remote
-
-	if remote != nil && req.GetPointer().GetSize() < min {
-		return segmentError.New("inline segment size %d less than minimum allowed %d", inlineSize, min)
-	}
 
 	if inlineSize > max {
 		return segmentError.New("inline segment size %d greater than maximum allowed %d", inlineSize, max)


### PR DESCRIPTION
So it better reflects that we are comparing it against the remote segment size.