### PR TITLE
Include GCC Hint for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Download and install the latest release of Go, at least Go 1.11:
 https://golang.org/
 
 You will also need Git. (`brew install git`, `apt-get install git`, etc).
+If you're building on Windows, you also need to install and have gcc setup correctly (easiest way via mingw64).
 
 Install git and golang. We support Linux, Mac, and Windows operating
 systems. Other operating systems supported by Go are probably not much


### PR DESCRIPTION
GCC is required for building our repo.
On Windows GCC is not available by default and needs to be added in order to build.