### PR TITLE
Clean up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-.PHONY: test lint proto check-copyrights build-dev-deps
-
-
 GO_VERSION ?= 1.11
 GOOS ?= linux
 GOARCH ?= amd64
@@ -21,58 +18,67 @@ endif
 DOCKER_BUILD := docker build \
 	--build-arg GO_VERSION=${GO_VERSION}
 
-lint: check-copyrights
-	@echo "Running ${@}"
-	@golangci-lint run
+.DEFAULT_GOAL := help
+.PHONY: help
+help:
+	@awk 'BEGIN { \
+		FS = ":.*##"; \
+		printf "\nUsage:\n  make \033[36m<target>\033[0m\n"\
+	} \
+	/^[a-zA-Z_-]+:.*?##/ { \
+		printf "  \033[36m%-17s\033[0m %s\n", $$1, $$2 \
+	} \
+	/^##@/ { \
+		printf "\n\033[1m%s\033[0m\n", substr($$0, 5) \
+	} ' $(MAKEFILE_LIST)
 
-check-copyrights:
-	@echo "Running ${@}"
-	@./scripts/check-for-header.sh
+##@ Dependencies
 
-# Applies goimports to every go file (excluding vendored files)
-goimports-fix:
-	goimports -w $$(find . -type f -name '*.go' -not -path "*/vendor/*")
-
-proto:
-	@echo "Running ${@}"
-	./scripts/build-protos.sh
-
-build-dev-deps:
+.PHONY: build-dev-deps
+build-dev-deps: ## Install dependencies for builds
 	go get github.com/mattn/goveralls
 	go get golang.org/x/tools/cover
 	go get github.com/modocache/gover
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ${GOPATH}/bin v1.10.2
 
-test:
+.PHONY: lint
+lint: check-copyrights ## Analyze and find programs in source code
+	@echo "Running ${@}"
+	@golangci-lint run
+
+.PHONY: check-copyrights
+check-copyrights: ## Check source files for copyright headers
+	@echo "Running ${@}"
+	@./scripts/check-for-header.sh
+
+.PHONY: goimports-fix
+goimports-fix: ## Applies goimports to every go file (excluding vendored files)
+	goimports -w $$(find . -type f -name '*.go' -not -path "*/vendor/*")
+
+.PHONY: proto
+proto: ## Rebuild protobuf files
+	@echo "Running ${@}"
+	./scripts/build-protos.sh
+
+##@ Test
+
+.PHONY: test
+test: ## Run tests on source code (travis)
 	go test -race -v -cover -coverprofile=.coverprofile ./...
 	@echo done
 
-test-captplanet:
+.PHONY: test-captplanet
+test-captplanet: ## Test source with captain planet (travis)
 	@echo "Running ${@}"
 	@./scripts/test-captplanet.sh
 
-test-docker:
+.PHONY: test-docker
+test-docker: ## Run tests in Docker
 	docker-compose up -d --remove-orphans test
 	docker-compose run test make test
 
-test-docker-clean:
-	-docker-compose down --rmi all
-
-images: satellite-image storagenode-image uplink-image
-	echo Built version: ${TAG}
-
-.PHONY: satellite-image
-satellite-image:
-	${DOCKER_BUILD} -t storjlabs/satellite:${TAG}${CUSTOMTAG} -f cmd/satellite/Dockerfile .
-.PHONY: storagenode-image
-storagenode-image:
-	${DOCKER_BUILD} -t storjlabs/storagenode:${TAG}${CUSTOMTAG} -f cmd/storagenode/Dockerfile .
-.PHONY: uplink-image
-uplink-image:
-	${DOCKER_BUILD} -t storjlabs/uplink:${TAG}${CUSTOMTAG} -f cmd/uplink/Dockerfile .
-
 .PHONY: all-in-one
-all-in-one:
+all-in-one: ## Deploy docker images with one storagenode locally
 	if [ -z "${VERSION}" ]; then \
 		$(MAKE) images -j 3 \
 		&& export VERSION="${TAG}"; \
@@ -81,39 +87,21 @@ all-in-one:
 	&& scripts/fix-mock-overlay \
 	&& docker-compose up storagenode satellite uplink
 
-push-images:
-	docker tag storjlabs/satellite:${TAG} storjlabs/satellite:latest
-	docker push storjlabs/satellite:${TAG}
-	docker push storjlabs/satellite:latest
-	docker tag storjlabs/storagenode:${TAG} storjlabs/storagenode:latest
-	docker push storjlabs/storagenode:${TAG}
-	docker push storjlabs/storagenode:latest
-	docker tag storjlabs/uplink:${TAG} storjlabs/uplink:latest
-	docker push storjlabs/uplink:${TAG}
-	docker push storjlabs/uplink:latest
+##@ Build
 
-ifeq (${BRANCH},master)
-clean-images:
-	-docker rmi storjlabs/satellite:${TAG} storjlabs/satellite:latest
-	-docker rmi storjlabs/storagenode:${TAG} storjlabs/storagenode:latest
-	-docker rmi storjlabs/uplink:${TAG} storjlabs/uplink:latest
-else
-clean-images:
-	-docker rmi storjlabs/satellite:${TAG}
-	-docker rmi storjlabs/storagenode:${TAG}
-	-docker rmi storjlabs/uplink:${TAG}
-endif
+.PHONY: images
+images: satellite-image storagenode-image uplink-image ## Build satellite, storagenode, and uplink Docker images
+	echo Built version: ${TAG}
 
-install-deps:
-	go get -u -v golang.org/x/vgo
-	cd vgo install ./...
-
-.PHONY: deploy
-deploy:
-	for deployment in $$(kubectl --context nonprod -n v3 get deployment -l app=storagenode --output=jsonpath='{.items..metadata.name}'); do \
-		kubectl --context nonprod --namespace v3 patch deployment $$deployment -p"{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"storagenode\",\"image\":\"storjlabs/storagenode:${TAG}\"}]}}}}" ; \
-	done
-	kubectl --context nonprod --namespace v3 patch deployment satellite -p"{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"satellite\",\"image\":\"storjlabs/satellite:${TAG}\"}]}}}}"
+.PHONY: satellite-image
+satellite-image: ## Build satellite Docker image
+	${DOCKER_BUILD} -t storjlabs/satellite:${TAG}${CUSTOMTAG} -f cmd/satellite/Dockerfile .
+.PHONY: storagenode-image
+storagenode-image: ## Build storagenode Docker image
+	${DOCKER_BUILD} -t storjlabs/storagenode:${TAG}${CUSTOMTAG} -f cmd/storagenode/Dockerfile .
+.PHONY: uplink-image
+uplink-image: ## Build uplink Docker image
+	${DOCKER_BUILD} -t storjlabs/uplink:${TAG}${CUSTOMTAG} -f cmd/uplink/Dockerfile .
 
 .PHONY: binary
 binary: CUSTOMTAG = -${GOOS}-${GOARCH}
@@ -145,14 +133,56 @@ COMPONENTLIST := uplink satellite storagenode
 OSARCHLIST    := linux_amd64 windows_amd64 darwin_amd64
 BINARIES      := $(foreach C,$(COMPONENTLIST),$(foreach O,$(OSARCHLIST),$C_$O))
 .PHONY: binaries
-binaries: ${BINARIES}
+binaries: ${BINARIES} ## Build uplink, satellite, and storagenode binaries (jenkins)
+
+##@ Deploy
+
+.PHONY: deploy
+deploy: ## Update Kubernetes deployments in staging (jenkins)
+	for deployment in $$(kubectl --context nonprod -n v3 get deployment -l app=storagenode --output=jsonpath='{.items..metadata.name}'); do \
+		kubectl --context nonprod --namespace v3 patch deployment $$deployment -p"{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"storagenode\",\"image\":\"storjlabs/storagenode:${TAG}\"}]}}}}" ; \
+	done
+	kubectl --context nonprod --namespace v3 patch deployment satellite -p"{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"satellite\",\"image\":\"storjlabs/satellite:${TAG}\"}]}}}}"
+
+.PHONY: push-images
+push-images: ## Push Docker images to Docker Hub (jenkins)
+	docker tag storjlabs/satellite:${TAG} storjlabs/satellite:latest
+	docker push storjlabs/satellite:${TAG}
+	docker push storjlabs/satellite:latest
+	docker tag storjlabs/storagenode:${TAG} storjlabs/storagenode:latest
+	docker push storjlabs/storagenode:${TAG}
+	docker push storjlabs/storagenode:latest
+	docker tag storjlabs/uplink:${TAG} storjlabs/uplink:latest
+	docker push storjlabs/uplink:${TAG}
+	docker push storjlabs/uplink:latest
 
 .PHONY: binaries-upload
-binaries-upload:
+binaries-upload: ## Upload binaries to Google Storage (jenkins)
 	cd release; gsutil -m cp -r . gs://storj-v3-alpha-builds
 
+##@ Clean
+
+.PHONY: clean
+clean: test-docker-clean binaries-clean clean-images ## Clean docker test environment, local release binaries, and local Docker images
+
 .PHONY: binaries-clean
-binaries-clean:
+binaries-clean: ## Remove all local release binaries (jenkins)
 	rm -rf release
 
-clean: test-docker-clean binaries-clean clean-images
+.PHONY: clean-images
+ifeq (${BRANCH},master)
+clean-images: ## Remove Docker images from local engine
+	-docker rmi storjlabs/satellite:${TAG} storjlabs/satellite:latest
+	-docker rmi storjlabs/storagenode:${TAG} storjlabs/storagenode:latest
+	-docker rmi storjlabs/uplink:${TAG} storjlabs/uplink:latest
+else
+clean-images:
+	-docker rmi storjlabs/satellite:${TAG}
+	-docker rmi storjlabs/storagenode:${TAG}
+	-docker rmi storjlabs/uplink:${TAG}
+endif
+
+.PHONY: test-docker-clean
+test-docker-clean: ## Clean up Docker environment used in test-docker target
+	-docker-compose down --rmi all
+


### PR DESCRIPTION
Also display fancy help output as default:
```
Usage:
  make <target>

Dependencies
  build-dev-deps     Install dependencies for builds
  lint               Analyze and find programs in source code
  check-copyrights   Check source files for copyright headers
  goimports-fix      Applies goimports to every go file (excluding vendored files)
  proto              Rebuild protobuf files

Test
  test               Run tests on source code (travis)
  test-captplanet    Test source with captain planet (travis)
  test-docker        Run tests in Docker
  all-in-one         Deploy docker images with one storagenode locally

Build
  images             Build satellite, storagenode, and uplink Docker images
  satellite-image    Build satellite Docker image
  storagenode-image  Build storagenode Docker image
  uplink-image       Build uplink Docker image
  binaries           Build uplink, satellite, and storagenode binaries (jenkins)

Deploy
  deploy             Update Kubernetes deployments in staging (jenkins)
  push-images        Push Docker images to Docker Hub (jenkins)
  binaries-upload    Upload binaries to Google Storage (jenkins)

Clean
  clean              Clean docker test environment, local release binaries, and local Docker images
  binaries-clean     Remove all local release binaries (jenkins)
  clean-images       Remove Docker images from local engine
  test-docker-clean  Clean up Docker environment used in test-docker target
```