### PR TITLE
Use GOPROXY, if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ binary:
 	resources/versioninfo.json || echo "goversioninfo is not installed, metadata will not be created"
 	tar -c . | docker run --rm -i -e TAR=1 -e GO111MODULE=on \
 	-e GOOS=${GOOS} -e GOARCH=${GOARCH} -e CGO_ENABLED=1 \
-	-w /go/src/storj.io/storj storjlabs/golang \
+	-w /go/src/storj.io/storj -e GOPROXY storjlabs/golang \
 	-o app storj.io/storj/cmd/${COMPONENT} \
 	| tar -O -x ./app > release/${TAG}/$(COMPONENT)_${GOOS}_${GOARCH}${FILEEXT}
 	chmod 755 release/${TAG}/$(COMPONENT)_${GOOS}_${GOARCH}${FILEEXT}


### PR DESCRIPTION
This is mainly to increase reliability of Jenkins builds.