### PR TITLE
Option for generating sample TLS certs for Minio GW

### DIFF
--- a/cmd/captplanet/setup.go
+++ b/cmd/captplanet/setup.go
@@ -121,8 +121,12 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		if err := os.MkdirAll(minioCertsPath, 0744); err != nil {
 			return err
 		}
-		os.Link(setupCfg.ULIdentity.CertPath, filepath.Join(minioCertsPath, "public.crt"))
-		os.Link(setupCfg.ULIdentity.KeyPath, filepath.Join(minioCertsPath, "private.key"))
+		if err := os.Link(setupCfg.ULIdentity.CertPath, filepath.Join(minioCertsPath, "public.crt")); err != nil {
+			return err
+		}
+		if err := os.Link(setupCfg.ULIdentity.KeyPath, filepath.Join(minioCertsPath, "private.key")); err != nil {
+			return err
+		}
 	}
 
 	startingPort := setupCfg.StartingPort

--- a/cmd/captplanet/setup.go
+++ b/cmd/captplanet/setup.go
@@ -30,7 +30,7 @@ type Config struct {
 	APIKey              string `default:"abc123" help:"the api key to use for the satellite"`
 	EncKey              string `default:"highlydistributedridiculouslyresilient" help:"your root encryption key"`
 	Overwrite           bool   `help:"whether to overwrite pre-existing configuration files" default:"false"`
-	MinioTLS            bool   `default:"false" help:"generate sample TLS certs for Minio GW"`
+	GenerateMinioCerts  bool   `default:"false" help:"generate sample TLS certs for Minio GW"`
 }
 
 var (
@@ -116,7 +116,7 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	if setupCfg.MinioTLS {
+	if setupCfg.GenerateMinioCerts {
 		minioCertsPath := filepath.Join(uplinkPath, "minio", "certs")
 		if err := os.MkdirAll(minioCertsPath, 0744); err != nil {
 			return err

--- a/cmd/captplanet/setup.go
+++ b/cmd/captplanet/setup.go
@@ -30,6 +30,7 @@ type Config struct {
 	APIKey              string `default:"abc123" help:"the api key to use for the satellite"`
 	EncKey              string `default:"highlydistributedridiculouslyresilient" help:"your root encryption key"`
 	Overwrite           bool   `help:"whether to overwrite pre-existing configuration files" default:"false"`
+	MinioTLS            bool   `default:"false" help:"generate sample TLS certs for Minio GW"`
 }
 
 var (
@@ -113,6 +114,15 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 	err = provider.SetupIdentity(process.Ctx(cmd), setupCfg.ULCA, setupCfg.ULIdentity)
 	if err != nil {
 		return err
+	}
+
+	if setupCfg.MinioTLS {
+		minioCertsPath := filepath.Join(uplinkPath, "minio", "certs")
+		if err := os.MkdirAll(minioCertsPath, 0744); err != nil {
+			return err
+		}
+		os.Link(setupCfg.ULIdentity.CertPath, filepath.Join(minioCertsPath, "public.crt"))
+		os.Link(setupCfg.ULIdentity.KeyPath, filepath.Join(minioCertsPath, "private.key"))
 	}
 
 	startingPort := setupCfg.StartingPort

--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -31,6 +31,7 @@ var (
 		SatelliteAddr string `default:"localhost:7778" help:"the address to use for the satellite"`
 		APIKey        string `default:"" help:"the api key to use for the satellite"`
 		EncKey        string `default:"" help:"your root encryption key"`
+		MinioTLS      bool   `default:"false" help:"generate sample TLS certs for Minio GW"`
 	}
 )
 
@@ -70,6 +71,15 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 	err = provider.SetupIdentity(process.Ctx(cmd), setupCfg.CA, setupCfg.Identity)
 	if err != nil {
 		return err
+	}
+
+	if setupCfg.MinioTLS {
+		minioCerts := filepath.Join(setupCfg.BasePath, "minio", "certs")
+		if err := os.MkdirAll(minioCerts, 0744); err != nil {
+			return err
+		}
+		os.Link(setupCfg.Identity.CertPath, filepath.Join(minioCerts, "public.crt"))
+		os.Link(setupCfg.Identity.KeyPath, filepath.Join(minioCerts, "private.key"))
 	}
 
 	accessKey, err := generateAWSKey()

--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -24,14 +24,14 @@ var (
 		RunE:  cmdSetup,
 	}
 	setupCfg struct {
-		CA            provider.CASetupConfig
-		Identity      provider.IdentitySetupConfig
-		BasePath      string `default:"$CONFDIR" help:"base path for setup"`
-		Overwrite     bool   `default:"false" help:"whether to overwrite pre-existing configuration files"`
-		SatelliteAddr string `default:"localhost:7778" help:"the address to use for the satellite"`
-		APIKey        string `default:"" help:"the api key to use for the satellite"`
-		EncKey        string `default:"" help:"your root encryption key"`
-		MinioTLS      bool   `default:"false" help:"generate sample TLS certs for Minio GW"`
+		CA                 provider.CASetupConfig
+		Identity           provider.IdentitySetupConfig
+		BasePath           string `default:"$CONFDIR" help:"base path for setup"`
+		Overwrite          bool   `default:"false" help:"whether to overwrite pre-existing configuration files"`
+		SatelliteAddr      string `default:"localhost:7778" help:"the address to use for the satellite"`
+		APIKey             string `default:"" help:"the api key to use for the satellite"`
+		EncKey             string `default:"" help:"your root encryption key"`
+		GenerateMinioCerts bool   `default:"false" help:"generate sample TLS certs for Minio GW"`
 	}
 )
 
@@ -73,7 +73,7 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	if setupCfg.MinioTLS {
+	if setupCfg.GenerateMinioCerts {
 		minioCerts := filepath.Join(setupCfg.BasePath, "minio", "certs")
 		if err := os.MkdirAll(minioCerts, 0744); err != nil {
 			return err

--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -78,8 +78,12 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		if err := os.MkdirAll(minioCerts, 0744); err != nil {
 			return err
 		}
-		os.Link(setupCfg.Identity.CertPath, filepath.Join(minioCerts, "public.crt"))
-		os.Link(setupCfg.Identity.KeyPath, filepath.Join(minioCerts, "private.key"))
+		if err := os.Link(setupCfg.Identity.CertPath, filepath.Join(minioCerts, "public.crt")); err != nil {
+			return err
+		}
+		if err := os.Link(setupCfg.Identity.KeyPath, filepath.Join(minioCerts, "private.key")); err != nil {
+			return err
+		}
 	}
 
 	accessKey, err := generateAWSKey()

--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -49,7 +49,7 @@ type EncryptionConfig struct {
 type MinioConfig struct {
 	AccessKey string `help:"Minio Access Key to use" default:"insecure-dev-access-key"`
 	SecretKey string `help:"Minio Secret Key to use" default:"insecure-dev-secret-key"`
-	MinioDir  string `help:"Minio generic server config path" default:"$CONFDIR/miniogw"`
+	MinioDir  string `help:"Minio generic server config path" default:"$CONFDIR/minio"`
 }
 
 // ClientConfig is a configuration struct for the miniogw that controls how

--- a/pkg/peertls/templates.go
+++ b/pkg/peertls/templates.go
@@ -5,6 +5,7 @@ package peertls
 
 import (
 	"crypto/x509"
+	"crypto/x509/pkix"
 )
 
 // CATemplate returns x509.Certificate template for certificate authority
@@ -20,6 +21,7 @@ func CATemplate() (*x509.Certificate, error) {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		IsCA:                  true,
+		Subject:               pkix.Name{CommonName: "Storj"},
 	}
 
 	return template, nil
@@ -38,6 +40,7 @@ func LeafTemplate() (*x509.Certificate, error) {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
 		IsCA:                  false,
+		Subject:               pkix.Name{CommonName: "Storj"},
 	}
 
 	return template, nil

--- a/pkg/peertls/templates.go
+++ b/pkg/peertls/templates.go
@@ -21,7 +21,7 @@ func CATemplate() (*x509.Certificate, error) {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		IsCA:                  true,
-		Subject:               pkix.Name{CommonName: "Storj"},
+		Subject:               pkix.Name{Organization: []string{"Storj"}},
 	}
 
 	return template, nil
@@ -40,7 +40,7 @@ func LeafTemplate() (*x509.Certificate, error) {
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
 		IsCA:                  false,
-		Subject:               pkix.Name{CommonName: "Storj"},
+		Subject:               pkix.Name{Organization: []string{"Storj"}},
 	}
 
 	return template, nil


### PR DESCRIPTION
New option for captplanet/uplink setup will use uplink identity key and cert to provide sample TLS certs for Minio GW.

Jira: V3-392