### PR TITLE
Wait-list gating

### DIFF
--- a/pkg/peertls/peertls.go
+++ b/pkg/peertls/peertls.go
@@ -13,6 +13,7 @@ import (
 	"io"
 
 	"github.com/zeebo/errs"
+	"fmt"
 )
 
 const (
@@ -118,6 +119,7 @@ func VerifyPeerCertChains(_ [][]byte, parsedChains [][]*x509.Certificate) error 
 }
 
 func VerifyCAWhitelist(cas []*x509.Certificate) PeerCertVerificationFunc {
+	fmt.Printf("len(cas): %d\n", len(cas))
 	if cas == nil {
 		return nil
 	}

--- a/pkg/peertls/peertls.go
+++ b/pkg/peertls/peertls.go
@@ -44,7 +44,7 @@ var (
 	// (i.e.: each cert in the chain should be signed by the preceding cert and the root should be self-signed)
 	ErrVerifyCertificateChain = errs.Class("certificate chain signature verification failed")
 	// ErrVerifyCAWhitelist is used when the leaf of a peer certificate isn't signed by any CA in the whitelist
-	ErrVerfiyCAWhitelist = errs.Class("certificate isn't signed by any CA in the whitelist")
+	ErrVerifyCAWhitelist = errs.Class("certificate isn't signed by any CA in the whitelist")
 )
 
 // PeerCertVerificationFunc is the signature for a `*tls.Config{}`'s
@@ -135,7 +135,7 @@ func VerifyCAWhitelist(cas []*x509.Certificate) PeerCertVerificationFunc {
 				return nil
 			}
 		}
-		return ErrVerfiyCAWhitelist.Wrap(err)
+		return ErrVerifyCAWhitelist.Wrap(err)
 	}
 }
 

--- a/pkg/peertls/peertls.go
+++ b/pkg/peertls/peertls.go
@@ -125,7 +125,7 @@ func VerifyCAWhitelist(cas []*x509.Certificate) PeerCertVerificationFunc {
 	}
 
 	return func(_ [][]byte, parsedChains [][]*x509.Certificate) error {
-		var err   error
+		var err error
 		for _, ca := range cas {
 			err = verifyCertSignature(ca, parsedChains[0][0])
 			if err == nil {

--- a/pkg/peertls/peertls.go
+++ b/pkg/peertls/peertls.go
@@ -13,7 +13,6 @@ import (
 	"io"
 
 	"github.com/zeebo/errs"
-	"fmt"
 )
 
 const (
@@ -44,7 +43,7 @@ var (
 	// ErrVerifyCertificateChain is used when a certificate chain can't be verified from leaf to root
 	// (i.e.: each cert in the chain should be signed by the preceding cert and the root should be self-signed)
 	ErrVerifyCertificateChain = errs.Class("certificate chain signature verification failed")
-	// ErrVerifyCAWhitelsit is used when the leaf of a peer certificate isn't signed by any CA in the whitelist
+	// ErrVerifyCAWhitelist is used when the leaf of a peer certificate isn't signed by any CA in the whitelist
 	ErrVerfiyCAWhitelist = errs.Class("certificate isn't signed by any CA in the whitelist")
 )
 
@@ -118,8 +117,9 @@ func VerifyPeerCertChains(_ [][]byte, parsedChains [][]*x509.Certificate) error 
 	return verifyChainSignatures(parsedChains[0])
 }
 
+// VerifyCAWhitelist verifies that the peer identity's leaf was signed by any one of the
+// (certificate authority) certificates in the provided whitelist
 func VerifyCAWhitelist(cas []*x509.Certificate) PeerCertVerificationFunc {
-	fmt.Printf("len(cas): %d\n", len(cas))
 	if cas == nil {
 		return nil
 	}

--- a/pkg/peertls/peertls.go
+++ b/pkg/peertls/peertls.go
@@ -125,13 +125,10 @@ func VerifyCAWhitelist(cas []*x509.Certificate) PeerCertVerificationFunc {
 	}
 
 	return func(_ [][]byte, parsedChains [][]*x509.Certificate) error {
-		var (
-			err   error
-			valid bool
-		)
+		var err   error
 		for _, ca := range cas {
 			err = verifyCertSignature(ca, parsedChains[0][0])
-			if valid {
+			if err == nil {
 				return nil
 			}
 		}

--- a/pkg/peertls/peertls_test.go
+++ b/pkg/peertls/peertls_test.go
@@ -180,9 +180,9 @@ func TestVerifyCAWhitelist(t *testing.T) {
 	assert.True(t, ErrVerifyCAWhitelist.Has(err))
 	assert.True(t, ErrVerifySignature.Has(err))
 
-	err = VerifyPeerFunc(VerifyCAWhitelist([]*x509.Certificate{z,c}))([][]byte{l.Raw, c.Raw}, nil)
+	err = VerifyPeerFunc(VerifyCAWhitelist([]*x509.Certificate{z, c}))([][]byte{l.Raw, c.Raw}, nil)
 	assert.NoError(t, err)
 
-	err = VerifyPeerFunc(VerifyCAWhitelist([]*x509.Certificate{c,z}))([][]byte{l.Raw, c.Raw}, nil)
+	err = VerifyPeerFunc(VerifyCAWhitelist([]*x509.Certificate{c, z}))([][]byte{l.Raw, c.Raw}, nil)
 	assert.NoError(t, err)
 }

--- a/pkg/peertls/peertls_test.go
+++ b/pkg/peertls/peertls_test.go
@@ -179,4 +179,10 @@ func TestVerifyCAWhitelist(t *testing.T) {
 	err = VerifyPeerFunc(VerifyCAWhitelist([]*x509.Certificate{z}))([][]byte{l.Raw, c.Raw}, nil)
 	assert.True(t, ErrVerifyCAWhitelist.Has(err))
 	assert.True(t, ErrVerifySignature.Has(err))
+
+	err = VerifyPeerFunc(VerifyCAWhitelist([]*x509.Certificate{z,c}))([][]byte{l.Raw, c.Raw}, nil)
+	assert.NoError(t, err)
+
+	err = VerifyPeerFunc(VerifyCAWhitelist([]*x509.Certificate{c,z}))([][]byte{l.Raw, c.Raw}, nil)
+	assert.NoError(t, err)
 }

--- a/pkg/peertls/peertls_test.go
+++ b/pkg/peertls/peertls_test.go
@@ -124,4 +124,59 @@ func TestVerifyPeerCertChains(t *testing.T) {
 
 	err = VerifyPeerFunc(VerifyPeerCertChains)([][]byte{l.Raw, c.Raw}, nil)
 	assert.NoError(t, err)
+
+	c, err = NewCert(ct, nil, &cp.PublicKey, k)
+	assert.NoError(t, err)
+
+	k2, err := NewKey()
+	assert.NoError(t, err)
+
+	l, err = NewCert(lt, nil, &lp.PublicKey, k2)
+	assert.NoError(t, err)
+
+	err = VerifyPeerFunc(VerifyPeerCertChains)([][]byte{l.Raw, c.Raw}, nil)
+	assert.True(t, ErrVerifyPeerCert.Has(err))
+	assert.True(t, ErrVerifyCertificateChain.Has(err))
+}
+
+func TestVerifyCAWhitelist(t *testing.T) {
+	k, err := NewKey()
+	assert.NoError(t, err)
+
+	ct, err := CATemplate()
+	assert.NoError(t, err)
+
+	cp, ok := k.(*ecdsa.PrivateKey)
+	assert.True(t, ok)
+	c, err := NewCert(ct, nil, &cp.PublicKey, k)
+	assert.NoError(t, err)
+
+	lt, err := LeafTemplate()
+	assert.NoError(t, err)
+
+	lp, ok := k.(*ecdsa.PrivateKey)
+	assert.True(t, ok)
+	l, err := NewCert(lt, ct, &lp.PublicKey, k)
+	assert.NoError(t, err)
+
+	err = VerifyPeerFunc(VerifyCAWhitelist(nil))([][]byte{l.Raw, c.Raw}, nil)
+	assert.NoError(t, err)
+
+	err = VerifyPeerFunc(VerifyCAWhitelist([]*x509.Certificate{c}))([][]byte{l.Raw, c.Raw}, nil)
+	assert.NoError(t, err)
+
+	zk, err := NewKey()
+	assert.NoError(t, err)
+
+	zt, err := CATemplate()
+	assert.NoError(t, err)
+
+	zp, ok := zk.(*ecdsa.PrivateKey)
+	assert.True(t, ok)
+	z, err := NewCert(zt, nil, &zp.PublicKey, zk)
+	assert.NoError(t, err)
+
+	err = VerifyPeerFunc(VerifyCAWhitelist([]*x509.Certificate{z}))([][]byte{l.Raw, c.Raw}, nil)
+	assert.True(t, ErrVerfiyCAWhitelist.Has(err))
+	assert.True(t, ErrVerifySignature.Has(err))
 }

--- a/pkg/peertls/peertls_test.go
+++ b/pkg/peertls/peertls_test.go
@@ -177,6 +177,6 @@ func TestVerifyCAWhitelist(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = VerifyPeerFunc(VerifyCAWhitelist([]*x509.Certificate{z}))([][]byte{l.Raw, c.Raw}, nil)
-	assert.True(t, ErrVerfiyCAWhitelist.Has(err))
+	assert.True(t, ErrVerifyCAWhitelist.Has(err))
 	assert.True(t, ErrVerifySignature.Has(err))
 }

--- a/pkg/peertls/templates.go
+++ b/pkg/peertls/templates.go
@@ -20,8 +20,8 @@ func CATemplate() (*x509.Certificate, error) {
 		KeyUsage:              x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		IsCA:                  true,
-		Subject:               pkix.Name{Organization: []string{"Storj"}},
+		IsCA:    true,
+		Subject: pkix.Name{Organization: []string{"Storj"}},
 	}
 
 	return template, nil
@@ -39,8 +39,8 @@ func LeafTemplate() (*x509.Certificate, error) {
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
-		IsCA:                  false,
-		Subject:               pkix.Name{Organization: []string{"Storj"}},
+		IsCA:    false,
+		Subject: pkix.Name{Organization: []string{"Storj"}},
 	}
 
 	return template, nil

--- a/pkg/peertls/templates.go
+++ b/pkg/peertls/templates.go
@@ -20,8 +20,8 @@ func CATemplate() (*x509.Certificate, error) {
 		KeyUsage:              x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		IsCA:    true,
-		Subject: pkix.Name{Organization: []string{"Storj"}},
+		IsCA:                  true,
+		Subject:               pkix.Name{Organization: []string{"Storj"}},
 	}
 
 	return template, nil
@@ -39,8 +39,8 @@ func LeafTemplate() (*x509.Certificate, error) {
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
-		IsCA:    false,
-		Subject: pkix.Name{Organization: []string{"Storj"}},
+		IsCA:                  false,
+		Subject:               pkix.Name{Organization: []string{"Storj"}},
 	}
 
 	return template, nil

--- a/pkg/provider/identity.go
+++ b/pkg/provider/identity.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
-	"fmt"
 	"io/ioutil"
 	"math/bits"
 	"net"
@@ -23,6 +22,7 @@ import (
 
 	"storj.io/storj/pkg/peertls"
 	"storj.io/storj/pkg/utils"
+	"fmt"
 )
 
 const (
@@ -252,7 +252,6 @@ func (ic IdentityConfig) Run(ctx context.Context, interceptor grpc.UnaryServerIn
 	err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	fmt.Printf("ic.PeerCAWhitelistPath: %s\n", ic.PeerCAWhitelistPath)
 	pi, err := ic.Load()
 	if err != nil {
 		return err

--- a/pkg/provider/identity.go
+++ b/pkg/provider/identity.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"math/bits"
 	"net"
@@ -22,7 +23,6 @@ import (
 
 	"storj.io/storj/pkg/peertls"
 	"storj.io/storj/pkg/utils"
-	"fmt"
 )
 
 const (

--- a/pkg/provider/identity.go
+++ b/pkg/provider/identity.go
@@ -106,7 +106,7 @@ func FullIdentityFromPEM(chainPEM, keyPEM, CAWhitelistPEM []byte) (*FullIdentity
 	}
 
 	var (
-		wb [][]byte
+		wb        [][]byte
 		whitelist []*x509.Certificate
 	)
 	if CAWhitelistPEM != nil {
@@ -121,10 +121,10 @@ func FullIdentityFromPEM(chainPEM, keyPEM, CAWhitelistPEM []byte) (*FullIdentity
 	}
 
 	return &FullIdentity{
-		CA:   ch[1],
-		Leaf: ch[0],
-		Key:  k,
-		ID:   i,
+		CA:              ch[1],
+		Leaf:            ch[0],
+		Key:             k,
+		ID:              i,
 		PeerCAWhitelist: whitelist,
 	}, nil
 }
@@ -285,7 +285,7 @@ func (fi *FullIdentity) ServerOption(pcvFuncs ...peertls.PeerCertVerificationFun
 
 	pcvFuncs = append(
 		[]peertls.PeerCertVerificationFunc{peertls.VerifyPeerCertChains},
-		pcvFuncs...
+		pcvFuncs...,
 	)
 	tlsConfig := &tls.Config{
 		Certificates:       []tls.Certificate{*c},

--- a/pkg/provider/identity.go
+++ b/pkg/provider/identity.go
@@ -252,6 +252,7 @@ func (ic IdentityConfig) Run(ctx context.Context, interceptor grpc.UnaryServerIn
 	err error) {
 	defer mon.Task()(&ctx)(&err)
 
+	fmt.Printf("ic.PeerCAWhitelistPath: %s\n", ic.PeerCAWhitelistPath)
 	pi, err := ic.Load()
 	if err != nil {
 		return err

--- a/pkg/provider/identity.go
+++ b/pkg/provider/identity.go
@@ -53,6 +53,9 @@ type FullIdentity struct {
 	ID nodeID
 	// Key is the key this identity uses with the leaf for communication.
 	Key crypto.PrivateKey
+	// PeerCAWhitelist is a whitelist of CA certs which, if present, restricts which peers this identity will verify as valid;
+	// peer certs must be signed by a CA in this list to pass peer certificate verification.
+	PeerCAWhitelist []*x509.Certificate
 }
 
 // IdentitySetupConfig allows you to run a set of Responsibilities with the given
@@ -67,14 +70,15 @@ type IdentitySetupConfig struct {
 // IdentityConfig allows you to run a set of Responsibilities with the given
 // identity. You can also just load an Identity from disk.
 type IdentityConfig struct {
-	CertPath string `help:"path to the certificate chain for this identity" default:"$CONFDIR/identity.cert"`
-	KeyPath  string `help:"path to the private key for this identity" default:"$CONFDIR/identity.key"`
-	Address  string `help:"address to listen on" default:":7777"`
+	CertPath            string `help:"path to the certificate chain for this identity" default:"$CONFDIR/identity.cert"`
+	KeyPath             string `help:"path to the private key for this identity" default:"$CONFDIR/identity.key"`
+	PeerCAWhitelistPath string `help:"path to the CA cert whitelist (peer identities must be signed by one these to be verified)"`
+	Address             string `help:"address to listen on" default:":7777"`
 }
 
 // FullIdentityFromPEM loads a FullIdentity from a certificate chain and
 // private key file
-func FullIdentityFromPEM(chainPEM, keyPEM []byte) (*FullIdentity, error) {
+func FullIdentityFromPEM(chainPEM, keyPEM, CAWhitelistPEM []byte) (*FullIdentity, error) {
 	cb, err := decodePEM(chainPEM)
 	if err != nil {
 		return nil, errs.Wrap(err)
@@ -101,11 +105,27 @@ func FullIdentityFromPEM(chainPEM, keyPEM []byte) (*FullIdentity, error) {
 		return nil, err
 	}
 
+	var (
+		wb [][]byte
+		whitelist []*x509.Certificate
+	)
+	if CAWhitelistPEM != nil {
+		wb, err = decodePEM(CAWhitelistPEM)
+		if err != nil {
+			return nil, errs.Wrap(err)
+		}
+		whitelist, err = ParseCertChain(wb)
+		if err != nil {
+			return nil, errs.Wrap(err)
+		}
+	}
+
 	return &FullIdentity{
 		CA:   ch[1],
 		Leaf: ch[0],
 		Key:  k,
 		ID:   i,
+		PeerCAWhitelist: whitelist,
 	}, nil
 }
 
@@ -190,8 +210,12 @@ func (ic IdentityConfig) Load() (*FullIdentity, error) {
 	if err != nil {
 		return nil, peertls.ErrNotExist.Wrap(err)
 	}
+	w, err := ioutil.ReadFile(ic.PeerCAWhitelistPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
 
-	fi, err := FullIdentityFromPEM(c, k)
+	fi, err := FullIdentityFromPEM(c, k, w)
 	if err != nil {
 		return nil, errs.New("failed to load identity %#v, %#v: %v",
 			ic.CertPath, ic.KeyPath, err)
@@ -251,19 +275,23 @@ func (ic IdentityConfig) Run(ctx context.Context, interceptor grpc.UnaryServerIn
 
 // ServerOption returns a grpc `ServerOption` for incoming connections
 // to the node with this full identity
-func (fi *FullIdentity) ServerOption() (grpc.ServerOption, error) {
+func (fi *FullIdentity) ServerOption(pcvFuncs ...peertls.PeerCertVerificationFunc) (grpc.ServerOption, error) {
 	ch := [][]byte{fi.Leaf.Raw, fi.CA.Raw}
 	c, err := peertls.TLSCert(ch, fi.Leaf, fi.Key)
 	if err != nil {
 		return nil, err
 	}
 
+	pcvFuncs = append(
+		[]peertls.PeerCertVerificationFunc{peertls.VerifyPeerCertChains},
+		pcvFuncs...
+	)
 	tlsConfig := &tls.Config{
 		Certificates:       []tls.Certificate{*c},
 		InsecureSkipVerify: true,
 		ClientAuth:         tls.RequireAnyClientCert,
 		VerifyPeerCertificate: peertls.VerifyPeerFunc(
-			peertls.VerifyPeerCertChains,
+			pcvFuncs...,
 		),
 	}
 

--- a/pkg/provider/identity_test.go
+++ b/pkg/provider/identity_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -18,8 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"storj.io/storj/pkg/peertls"
-	"path"
-	"fmt"
 )
 
 func TestPeerIdentityFromCertChain(t *testing.T) {
@@ -200,7 +199,6 @@ func TestIdentityConfig_LoadIdentity(t *testing.T) {
 
 	fi, err := ic.Load()
 	assert.NoError(t, err)
-	fmt.Println(fi.PeerCAWhitelist)
 	assert.Nil(t, fi.PeerCAWhitelist)
 	assert.NotEmpty(t, fi)
 	assert.NotEmpty(t, fi.Key)
@@ -223,7 +221,6 @@ func TestIdentityConfig_LoadIdentity(t *testing.T) {
 
 	ic.PeerCAWhitelistPath = tmp
 	fi, err = ic.Load()
-	fmt.Println(fi.PeerCAWhitelist)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, fi.PeerCAWhitelist)
 }

--- a/pkg/provider/identity_test.go
+++ b/pkg/provider/identity_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -19,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"storj.io/storj/pkg/peertls"
-	"fmt"
 )
 
 func TestPeerIdentityFromCertChain(t *testing.T) {
@@ -215,10 +215,10 @@ func TestIdentityConfig_LoadIdentity(t *testing.T) {
 	tmp := path.Join(os.TempDir(), "temp-ca-whitelist.pem")
 	w, err := os.Create(tmp)
 	assert.NoError(t, err)
-	defer func(){
+	defer func() {
 		err := os.RemoveAll(tmp)
 		if err != nil {
-			fmt.Errorf("unable to cleanup temp ca whitelist at \"%s\": %s", tmp, err.Error())
+			fmt.Printf("unable to cleanup temp ca whitelist at \"%s\": %s", tmp, err.Error())
 		}
 	}()
 

--- a/pkg/provider/identity_test.go
+++ b/pkg/provider/identity_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"storj.io/storj/pkg/peertls"
+	"path"
+	"fmt"
 )
 
 func TestPeerIdentityFromCertChain(t *testing.T) {
@@ -198,6 +200,8 @@ func TestIdentityConfig_LoadIdentity(t *testing.T) {
 
 	fi, err := ic.Load()
 	assert.NoError(t, err)
+	fmt.Println(fi.PeerCAWhitelist)
+	assert.Nil(t, fi.PeerCAWhitelist)
 	assert.NotEmpty(t, fi)
 	assert.NotEmpty(t, fi.Key)
 	assert.NotEmpty(t, fi.Leaf)
@@ -208,6 +212,20 @@ func TestIdentityConfig_LoadIdentity(t *testing.T) {
 	assert.Equal(t, expectedFI.Leaf, fi.Leaf)
 	assert.Equal(t, expectedFI.CA, fi.CA)
 	assert.Equal(t, expectedFI.ID.Bytes(), fi.ID.Bytes())
+
+	tmp := path.Join(os.TempDir(), "temp-ca-whitelist.pem")
+	w, err := os.Create(tmp)
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmp)
+
+	err = peertls.WriteChain(w, fi.CA)
+	assert.NoError(t, err)
+
+	ic.PeerCAWhitelistPath = tmp
+	fi, err = ic.Load()
+	fmt.Println(fi.PeerCAWhitelist)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, fi.PeerCAWhitelist)
 }
 
 func TestNodeID_Difficulty(t *testing.T) {

--- a/pkg/provider/identity_test.go
+++ b/pkg/provider/identity_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"storj.io/storj/pkg/peertls"
+	"fmt"
 )
 
 func TestPeerIdentityFromCertChain(t *testing.T) {
@@ -214,7 +215,12 @@ func TestIdentityConfig_LoadIdentity(t *testing.T) {
 	tmp := path.Join(os.TempDir(), "temp-ca-whitelist.pem")
 	w, err := os.Create(tmp)
 	assert.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	defer func(){
+		err := os.RemoveAll(tmp)
+		if err != nil {
+			fmt.Errorf("unable to cleanup temp ca whitelist at \"%s\": %s", tmp, err.Error())
+		}
+	}()
 
 	err = peertls.WriteChain(w, fi.CA)
 	assert.NoError(t, err)

--- a/pkg/provider/identity_test.go
+++ b/pkg/provider/identity_test.go
@@ -87,7 +87,7 @@ func TestFullIdentityFromPEM(t *testing.T) {
 	keyPEM := bytes.NewBuffer([]byte{})
 	assert.NoError(t, pem.Encode(keyPEM, peertls.NewKeyBlock(lkB)))
 
-	fi, err := FullIdentityFromPEM(chainPEM.Bytes(), keyPEM.Bytes())
+	fi, err := FullIdentityFromPEM(chainPEM.Bytes(), keyPEM.Bytes(), nil)
 	assert.NoError(t, err)
 	assert.Equal(t, l.Raw, fi.Leaf.Raw)
 	assert.Equal(t, c.Raw, fi.CA.Raw)
@@ -183,7 +183,7 @@ AwEHoUQDQgAEoLy/0hs5deTXZunRumsMkiHpF0g8wAc58aXANmr7Mxx9tzoIYFnx
 	ic, cleanup, err := tempIdentityConfig()
 	assert.NoError(t, err)
 
-	fi, err := FullIdentityFromPEM([]byte(chain), []byte(key))
+	fi, err := FullIdentityFromPEM([]byte(chain), []byte(key), nil)
 	assert.NoError(t, err)
 
 	return cleanup, ic, fi, difficulty

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -15,9 +15,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"storj.io/storj/storage"
 	"storj.io/storj/pkg/peertls"
-	"fmt"
+	"storj.io/storj/storage"
 )
 
 var (
@@ -46,7 +45,6 @@ type Provider struct {
 func NewProvider(identity *FullIdentity, lis net.Listener, interceptor grpc.UnaryServerInterceptor,
 	responsibilities ...Responsibility) (*Provider, error) {
 	// NB: talk to anyone with an identity
-	fmt.Printf("len(identity.PeerCAWhitelist): %d\n", len(identity.PeerCAWhitelist))
 	ident, err := identity.ServerOption(peertls.VerifyCAWhitelist(identity.PeerCAWhitelist))
 	if err != nil {
 		return nil, err

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"storj.io/storj/storage"
+	"storj.io/storj/pkg/peertls"
 )
 
 var (
@@ -44,7 +45,7 @@ type Provider struct {
 func NewProvider(identity *FullIdentity, lis net.Listener, interceptor grpc.UnaryServerInterceptor,
 	responsibilities ...Responsibility) (*Provider, error) {
 	// NB: talk to anyone with an identity
-	ident, err := identity.ServerOption()
+	ident, err := identity.ServerOption(peertls.VerifyCAWhitelist(identity.PeerCAWhitelist))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -17,6 +17,7 @@ import (
 
 	"storj.io/storj/storage"
 	"storj.io/storj/pkg/peertls"
+	"fmt"
 )
 
 var (
@@ -45,6 +46,7 @@ type Provider struct {
 func NewProvider(identity *FullIdentity, lis net.Listener, interceptor grpc.UnaryServerInterceptor,
 	responsibilities ...Responsibility) (*Provider, error) {
 	// NB: talk to anyone with an identity
+	fmt.Printf("len(identity.PeerCAWhitelist): %d\n", len(identity.PeerCAWhitelist))
 	ident, err := identity.ServerOption(peertls.VerifyCAWhitelist(identity.PeerCAWhitelist))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adds `--identity.peer-ca-whitelist-path` flag to the identity responsibility; If provided, responsibilities using that identity instance will only successfully verify peers whose identity leaf cert is signed by any of the certs in the file found at the whitelist path.

The CA whitelist is PEM-encoded just like other identity files (certs and keys) and can contain multiple cert blocks. 