### PR TITLE
Add repairer & checker to Satelite

### DIFF
--- a/cmd/captplanet/run.go
+++ b/cmd/captplanet/run.go
@@ -128,9 +128,8 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 			runCfg.Satellite.PointerDB,
 			runCfg.Satellite.Kademlia,
 			o,
-			// TODO(coyle): determine why checker and repairer are broken
-			// runCfg.Satellite.Checker,
-			// runCfg.Satellite.Repairer,
+			runCfg.Satellite.Checker,
+			runCfg.Satellite.Repairer,
 		)
 	}()
 

--- a/cmd/captplanet/run.go
+++ b/cmd/captplanet/run.go
@@ -118,6 +118,8 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 			runCfg.Satellite.PointerDB,
 			runCfg.Satellite.Kademlia,
 			o,
+			runCfg.Satellite.Checker,
+			runCfg.Satellite.Repairer,
 		)
 	}()
 
@@ -129,15 +131,6 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 		errch <- err
 	} else {
 		defer m.Close()
-
-		go func() {
-			errch <- runCfg.Satellite.Checker.Run(ctx, nil)
-		}()
-
-		go func() {
-			errch <- runCfg.Satellite.Repairer.Run(ctx, nil)
-		}()
-
 	}
 
 	// start s3 uplink

--- a/cmd/captplanet/run.go
+++ b/cmd/captplanet/run.go
@@ -104,6 +104,16 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 		}(i, storagenode)
 	}
 
+	// start mini redis
+	m := miniredis.NewMiniRedis()
+	m.RequireAuth("abc123")
+
+	if err = m.StartAddr(":6378"); err != nil {
+		errch <- err
+	} else {
+		defer m.Close()
+	}
+
 	// start satellite
 	go func() {
 		_, _ = fmt.Printf("starting satellite on %s\n",
@@ -118,20 +128,11 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 			runCfg.Satellite.PointerDB,
 			runCfg.Satellite.Kademlia,
 			o,
-			runCfg.Satellite.Checker,
-			runCfg.Satellite.Repairer,
+			// TODO(coyle): determine why checker and repairer are broken
+			// runCfg.Satellite.Checker,
+			// runCfg.Satellite.Repairer,
 		)
 	}()
-
-	// start Repair
-	m := miniredis.NewMiniRedis()
-	m.RequireAuth("abc123")
-
-	if err = m.StartAddr(":6378"); err != nil {
-		errch <- err
-	} else {
-		defer m.Close()
-	}
 
 	// start s3 uplink
 	go func() {

--- a/pkg/datarepair/checker/config.go
+++ b/pkg/datarepair/checker/config.go
@@ -40,5 +40,13 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) (err error) 
 	if err != nil {
 		return err
 	}
-	return check.Run(ctx)
+
+	// TODO(coyle): we need to figure out how to propogate the error up to cancel the service
+	go func() {
+		if err := check.Run(ctx); err != nil {
+			zap.L().Error("Error running checker", zap.Error(err))
+		}
+	}()
+
+	return server.Run(ctx)
 }

--- a/pkg/datarepair/checker/config.go
+++ b/pkg/datarepair/checker/config.go
@@ -41,7 +41,7 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) (err error) 
 		return err
 	}
 
-	// TODO(coyle): we need to figure out how to propogate the error up to cancel the service
+	// TODO(coyle): we need to figure out how to propagate the error up to cancel the service
 	go func() {
 		if err := check.Run(ctx); err != nil {
 			zap.L().Error("Error running checker", zap.Error(err))

--- a/pkg/datarepair/repairer/config.go
+++ b/pkg/datarepair/repairer/config.go
@@ -31,7 +31,7 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) (err error) 
 
 	repairer := newRepairer(queue, c.Interval, c.MaxRepair)
 
-	// TODO(coyle): we need to figure out how to propogate the error up to cancel the service
+	// TODO(coyle): we need to figure out how to propagate the error up to cancel the service
 	go func() {
 		if err := repairer.Run(ctx); err != nil {
 			zap.L().Error("Error running repairer", zap.Error(err))

--- a/pkg/pointerdb/config.go
+++ b/pkg/pointerdb/config.go
@@ -61,8 +61,10 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) error {
 
 	cache := overlay.LoadFromContext(ctx)
 	dblogged := storelogger.New(zap.L(), db)
-	pb.RegisterPointerDBServer(server.GRPC(), NewServer(dblogged, cache, zap.L(), c, server.Identity()))
-
+	s := NewServer(dblogged, cache, zap.L(), c, server.Identity())
+	pb.RegisterPointerDBServer(server.GRPC(), s)
+	// add the server to the context
+	ctx = context.WithValue(ctx, ctxKey, s)
 	return server.Run(ctx)
 }
 


### PR DESCRIPTION
Adds the repairer and checker to `Satellite.Identity.Run`

Adds the PointerDB server to the context