### PR TITLE
Optimize sortByXOR

### DIFF
--- a/pkg/kademlia/routing.go
+++ b/pkg/kademlia/routing.go
@@ -134,11 +134,11 @@ func (rt *RoutingTable) FindNear(id dht.NodeID, limit int) ([]*pb.Node, error) {
 		return []*pb.Node{}, RoutingErr.New("could not get node ids %s", err)
 	}
 
-	sortedIDs := sortByXOR(nodeIDs, id.Bytes())
-	if len(sortedIDs) >= limit {
-		sortedIDs = sortedIDs[:limit]
+	sortByXOR(nodeIDs, id.Bytes())
+	if len(nodeIDs) >= limit {
+		nodeIDs = nodeIDs[:limit]
 	}
-	ids, serializedNodes, err := rt.getNodesFromIDs(sortedIDs)
+	ids, serializedNodes, err := rt.getNodesFromIDs(nodeIDs)
 	if err != nil {
 		return []*pb.Node{}, RoutingErr.New("could not get nodes %s", err)
 	}

--- a/pkg/kademlia/routing_helpers.go
+++ b/pkg/kademlia/routing_helpers.go
@@ -192,8 +192,15 @@ func (rt *RoutingTable) getKBucketID(nodeID storage.Key) (storage.Key, error) {
 	return nil, RoutingErr.New("could not find k bucket")
 }
 
+// compareByXor compares left, right xorred by reference
 func compareByXor(left, right, reference storage.Key) int {
 	n := len(reference)
+	if n > len(left) {
+		n = len(left)
+	}
+	if n > len(right) {
+		n = len(right)
+	}
 	left = left[:n]
 	right = right[:n]
 	reference = reference[:n]

--- a/pkg/kademlia/routing_helpers.go
+++ b/pkg/kademlia/routing_helpers.go
@@ -203,9 +203,8 @@ func compareByXor(left, right, reference storage.Key) int {
 		if a != b {
 			if a < b {
 				return -1
-			} else {
-				return 1
 			}
+			return 1
 		}
 	}
 


### PR DESCRIPTION
This makes testplanet setup with 100 nodes ~1.4s faster.

```
Before:
BenchmarkSortByXOR-8         300           4319301 ns/op

After:
BenchmarkSortByXOR-8        5000            356867 ns/op
```