### PR TITLE
Waitlist script

### DIFF
--- a/scripts/cert-gating.sh
+++ b/scripts/cert-gating.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+source $(dirname $0)/utils.sh
 basepath=$HOME/.storj/capt
 alpha_config=$basepath/config-alpha.yaml
 unauthorized_config=$basepath/config-unauthorized.yaml
@@ -8,80 +8,75 @@ ca_count=5
 ca_basepath=$basepath/ca-alpha-
 
 ca_i_basepath() {
-    echo ${ca_basepath}${1}
-}
-rand_ca_basepath() {
-  let i="($RANDOM % $ca_count) + 1"
-  echo $(ca_i_basepath ${i})
+	echo ${ca_basepath}${1}
 }
 
-build() {
-  source $(dirname $0)/utils.sh
-  tmp_dir=$(mktemp -d)
-  temp_build ${tmp_dir} $@
+rand_ca_basepath() {
+	let i="($RANDOM % $ca_count) + 1"
+	echo $(ca_i_basepath ${i})
 }
 
 case $1 in
-  --help)
-    echo "usage: $(basename $0) [setup|alpha|unauthorized]"
-    ;;
-  setup)
-	build captplanet identity
-	echo "setting up captplanet"
-	"$captplanet" setup --overwrite
-    echo "clearing whitelist"
-    echo > ${ca_whitelist}
-    echo -n "generating alpha certificate authorities.."
-    for i in $(seq 1 ${ca_count}); do
-      echo -n "$i.."
-      _basepath=$(ca_i_basepath ${i})
-      ${identity} ca new --ca.overwrite \
-                      --ca.cert-path ${_basepath}.cert \
-                      --ca.key-path ${_basepath}.key
-      cat ${_basepath}.cert >> ${ca_whitelist}
-    done
-    echo "done"
-    echo -n "generating alpha identities"
-    for dir in ${basepath}/{f*,sat*,up*}; do
-      echo -n "."
-      _ca_basepath=$(rand_ca_basepath)
-      _ca_cert=${dir}/ca-alpha.cert
-      _ca_key=${dir}/ca-alpha.key
-      ${identity} ca new --ca.overwrite \
-                      --ca.cert-path ${_ca_cert} \
-                      --ca.key-path ${_ca_key} \
-                      --ca.parent-cert-path ${_ca_basepath}.cert \
-                      --ca.parent-key-path ${_ca_basepath}.key
-      ${identity} id new --identity.overwrite \
-                      --identity.cert-path ${dir}/identity-alpha.cert \
-                      --identity.key-path ${dir}/identity-alpha.key \
-                      --ca.cert-path ${_ca_cert} \
-                      --ca.key-path ${_ca_key}
-    done
-    echo "done"
-    echo "writing alpha config"
-    cat ${basepath}/config.yaml | \
-		sed "s,peer-ca-whitelist-path: \"\",peer-ca-whitelist-path: $ca_whitelist,g" | \
-		sed -E 's,cert-path: (.+)\.cert,cert-path: \1-alpha.cert,g' | \
-		sed -E 's,key-path: (.+)\.key,key-path: \1-alpha.key,g' \
-		> ${alpha_config}
-    echo "writing unauthorized config"
-    cat ${basepath}/config.yaml | sed -E "s,peer-ca-whitelist-path: \"\",peer-ca-whitelist-path: $ca_whitelist,g" > "$unauthorized_config"
-    ;;
-  alpha)
-    build captplanet
-    ${captplanet} run --config ${alpha_config}
-    ;;
-  unauthorized)
-    build captplanet
-    ${captplanet} run --config ${unauthorized_config}
-    ;;
-  run)
-    ${captplanet} run
-    ;;
-  *)
-    $0 --help
-    ;;
+	--help)
+		echo "usage: $(basename $0) [setup|alpha|unauthorized]"
+	;;
+	setup)
+		temp_build captplanet identity
+		echo "setting up captplanet"
+		"$captplanet" setup --overwrite
+		echo "clearing whitelist"
+		echo > ${ca_whitelist}
+		echo -n "generating alpha certificate authorities.."
+		for i in $(seq 1 ${ca_count}); do
+			echo -n "$i.."
+			_basepath=$(ca_i_basepath ${i})
+			${identity} ca new --ca.overwrite \
+				--ca.cert-path ${_basepath}.cert \
+				--ca.key-path ${_basepath}.key
+			cat ${_basepath}.cert >> ${ca_whitelist}
+		done
+		echo "done"
+		echo -n "generating alpha identities"
+		for dir in ${basepath}/{f*,sat*,up*}; do
+			echo -n "."
+			_ca_basepath=$(rand_ca_basepath)
+			_ca_cert=${dir}/ca-alpha.cert
+			_ca_key=${dir}/ca-alpha.key
+			${identity} ca new --ca.overwrite \
+				--ca.cert-path ${_ca_cert} \
+				--ca.key-path ${_ca_key} \
+				--ca.parent-cert-path ${_ca_basepath}.cert \
+				--ca.parent-key-path ${_ca_basepath}.key
+			${identity} id new --identity.overwrite \
+				--identity.cert-path ${dir}/identity-alpha.cert \
+				--identity.key-path ${dir}/identity-alpha.key \
+				--ca.cert-path ${_ca_cert} \
+				--ca.key-path ${_ca_key}
+		done
+		echo "done"
+		echo "writing alpha config"
+		cat ${basepath}/config.yaml | \
+			sed "s,peer-ca-whitelist-path: \"\",peer-ca-whitelist-path: $ca_whitelist,g" | \
+			sed -E 's,cert-path: (.+)\.cert,cert-path: \1-alpha.cert,g' | \
+			sed -E 's,key-path: (.+)\.key,key-path: \1-alpha.key,g' \
+			> ${alpha_config}
+		echo "writing unauthorized config"
+		cat ${basepath}/config.yaml | sed -E "s,peer-ca-whitelist-path: \"\",peer-ca-whitelist-path: $ca_whitelist,g" >"$unauthorized_config"
+	;;
+	alpha)
+		build captplanet
+		${captplanet} run --config ${alpha_config}
+	;;
+	unauthorized)
+		build captplanet
+		${captplanet} run --config ${unauthorized_config}
+	;;
+	run)
+		${captplanet} run
+	;;
+	*)
+		$@ --help
+	;;
 esac
 
 rm -rf ${tmp_dir}

--- a/scripts/cert-gating.sh
+++ b/scripts/cert-gating.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 basepath=$HOME/.storj/capt
 alpha_config=$basepath/config-alpha.yaml
 unauthorized_config=$basepath/config-unauthorized.yaml
@@ -7,11 +8,17 @@ ca_count=5
 ca_basepath=$basepath/ca-alpha-
 
 ca_i_basepath() {
-    echo "$ca_basepath$1"
+    echo ${ca_basepath}${1}
 }
 rand_ca_basepath() {
   let i="($RANDOM % $ca_count) + 1"
-  echo $(ca_i_basepath $i)
+  echo $(ca_i_basepath ${i})
+}
+
+build() {
+  source $(dirname $0)/utils.sh
+  tmp_dir=$(mktemp -d)
+  temp_build ${tmp_dir} $@
 }
 
 case $1 in
@@ -19,57 +26,62 @@ case $1 in
     echo "usage: $(basename $0) [setup|alpha|unauthorized]"
     ;;
   setup)
+	build captplanet identity
 	echo "setting up captplanet"
-	captplanet setup --overwrite
+	"$captplanet" setup --overwrite
     echo "clearing whitelist"
-    echo > $ca_whitelist
+    echo > ${ca_whitelist}
     echo -n "generating alpha certificate authorities.."
-    for i in $(seq 1 $ca_count); do
+    for i in $(seq 1 ${ca_count}); do
       echo -n "$i.."
-      _basepath=$(ca_i_basepath $i)
-      identity ca new --ca.overwrite \
-                      --ca.cert-path $_basepath.cert \
-                      --ca.key-path $_basepath.key
-      cat $_basepath.cert >> $ca_whitelist
+      _basepath=$(ca_i_basepath ${i})
+      ${identity} ca new --ca.overwrite \
+                      --ca.cert-path ${_basepath}.cert \
+                      --ca.key-path ${_basepath}.key
+      cat ${_basepath}.cert >> ${ca_whitelist}
     done
     echo "done"
     echo -n "generating alpha identities"
-    for dir in $basepath/{f*,sat*,up*}; do
+    for dir in ${basepath}/{f*,sat*,up*}; do
       echo -n "."
       _ca_basepath=$(rand_ca_basepath)
-      _ca_cert=$dir/ca-alpha.cert
-      _ca_key=$dir/ca-alpha.key
-      identity ca new --ca.overwrite \
-                      --ca.cert-path $_ca_cert \
-                      --ca.key-path $_ca_key \
-                      --ca.parent-cert-path $_ca_basepath.cert \
-                      --ca.parent-key-path $_ca_basepath.key
-      identity id new --identity.overwrite \
-                      --identity.cert-path $dir/identity-alpha.cert \
-                      --identity.key-path $dir/identity-alpha.key \
-                      --ca.cert-path $_ca_cert \
-                      --ca.key-path $_ca_key
+      _ca_cert=${dir}/ca-alpha.cert
+      _ca_key=${dir}/ca-alpha.key
+      ${identity} ca new --ca.overwrite \
+                      --ca.cert-path ${_ca_cert} \
+                      --ca.key-path ${_ca_key} \
+                      --ca.parent-cert-path ${_ca_basepath}.cert \
+                      --ca.parent-key-path ${_ca_basepath}.key
+      ${identity} id new --identity.overwrite \
+                      --identity.cert-path ${dir}/identity-alpha.cert \
+                      --identity.key-path ${dir}/identity-alpha.key \
+                      --ca.cert-path ${_ca_cert} \
+                      --ca.key-path ${_ca_key}
     done
     echo "done"
     echo "writing alpha config"
-    cat $basepath/config.yaml | \
+    cat ${basepath}/config.yaml | \
 		sed "s,peer-ca-whitelist-path: \"\",peer-ca-whitelist-path: $ca_whitelist,g" | \
 		sed -E 's,cert-path: (.+)\.cert,cert-path: \1-alpha.cert,g' | \
 		sed -E 's,key-path: (.+)\.key,key-path: \1-alpha.key,g' \
-		> $alpha_config
+		> ${alpha_config}
     echo "writing unauthorized config"
-    cat $basepath/config.yaml | sed -E "s,peer-ca-whitelist-path: \"\",peer-ca-whitelist-path: $ca_whitelist,g" > "$unauthorized_config"
+    cat ${basepath}/config.yaml | sed -E "s,peer-ca-whitelist-path: \"\",peer-ca-whitelist-path: $ca_whitelist,g" > "$unauthorized_config"
     ;;
   alpha)
-    captplanet run --config $alpha_config
+    build captplanet
+    ${captplanet} run --config ${alpha_config}
     ;;
   unauthorized)
-    captplanet run --config $unauthorized_config
+    build captplanet
+    ${captplanet} run --config ${unauthorized_config}
     ;;
   run)
-    captplanet run
+    ${captplanet} run
     ;;
   *)
     $0 --help
     ;;
 esac
+
+rm -rf ${tmp_dir}

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -16,19 +16,49 @@ dots_off() {
 	kill "$dots_pid"
 }
 
-temp_build() {
+build() {
 	local tmp_dir=$1
 	shift
-	echo "building binaries:"
+	echo "building temp binaries:"
 	for cmd in $@; do
-		echo -n "  buliding $cmd..."
+		echo -n "	buliding $cmd..."
 		dots_on
 		local path=${tmp_dir}/${cmd}
 		declare -g ${cmd}=${path}
 		go build -o ${path} storj.io/storj/cmd/${cmd}
-		#				sleep .5
 		dots_off
 		echo "done"
 	done
-	echo "binaries built in $tmp_dir"
+	echo "	binaries built in $tmp_dir"
+}
+
+temp_build() {
+	tmp_dir=$(mktemp -d)
+	build ${tmp_dir} $@
+}
+
+check_help() {
+	if [ $1 == "--help" ] || [ $1 == "-h" ]; then
+		echo $2
+		exit 0
+	fi
+}
+
+ensure_dir() {
+	if [ ! -d $1 ]; then
+		mkdir $1
+	fi
+}
+
+no_overwrite() {
+	if [ -e $1 ]; then
+	echo "Error: $1 already exists; refusing to overwrite"
+		exit 10
+	fi
+}
+
+log_list() {
+	for f in $@; do
+		echo ${f}
+	done
 }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -21,7 +21,7 @@ build() {
 	shift
 	echo "building temp binaries:"
 	for cmd in $@; do
-		echo -n "	buliding $cmd..."
+		echo -n "	building $cmd..."
 		dots_on
 		local path=${tmp_dir}/${cmd}
 		declare -g ${cmd}=${path}

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+dots() {
+	echo -n "."
+	sleep 1
+	dots
+}
+
+dots_on() {
+	dots &
+	dots_pid=$!
+}
+
+dots_off() {
+	disown $dots_pid
+	kill "$dots_pid"
+}
+
+temp_build() {
+	local tmp_dir=$1
+	shift
+	echo "building binaries:"
+	for cmd in $@; do
+		echo -n "  buliding $cmd..."
+		dots_on
+		local path=${tmp_dir}/${cmd}
+		declare -g ${cmd}=${path}
+		go build -o ${path} storj.io/storj/cmd/${cmd}
+		#				sleep .5
+		dots_off
+		echo "done"
+	done
+	echo "binaries built in $tmp_dir"
+}

--- a/scripts/waitlist/storj.sh
+++ b/scripts/waitlist/storj.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+source $(dirname $0)/../utils.sh
+
+comment() {
+	cat << EOF
+-----BEGIN COMMENT-----
+Label: $1
+Description: $2
+-----END COMMENT-----
+EOF
+}
+
+case $1 in
+	--help)
+		echo "usage: $0 new"
+	;;
+	new)
+		shift
+		check_help $1 	"usage: storj.sh new <label> <output dir> [<whitelist path>]"
+		temp_build identity
+		label=$1
+		out_dir=$2
+		whitelist=$3
+		cert_path=${out_dir}/${label}.cert
+		key_path=${out_dir}/${label}.key
+
+		ensure_dir ${out_dir}
+		no_overwrite ${cert_path}
+		no_overwrite ${key_path}
+		${identity} ca new \
+			--ca.cert-path ${cert_path} \
+			--ca.key-path ${key_path}
+
+		echo "wrote:"
+		log_list ${cert_path} ${key_path}
+
+		if [ $# -gt 2 ]; then
+			comment ${label} >> ${whitelist}
+			cat ${cert_path} >> ${whitelist}
+		echo "appended to whitelist at $whitelist"
+		fi
+	;;
+	*)
+		$0 --help
+	;;
+esac

--- a/scripts/waitlist/storj.sh
+++ b/scripts/waitlist/storj.sh
@@ -37,7 +37,7 @@ case $1 in
 		if [ $# -gt 2 ]; then
 			comment ${label} >> ${whitelist}
 			cat ${cert_path} >> ${whitelist}
-		echo "appended to whitelist at $whitelist"
+			echo "appended to whitelist at $whitelist"
 		fi
 	;;
 	*)

--- a/scripts/waitlist/user.sh
+++ b/scripts/waitlist/user.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+source $(dirname $0)/../utils.sh
+
+new_ca() {
+	${identity} ca new \
+		--ca.cert-path ${ca_cert_path} \
+		--ca.key-path ${ca_key_path} \
+		--ca.parent-cert-path ${parent_cert_path} \
+		--ca.parent-key-path ${parent_key_path}
+}
+
+case $1 in
+	--help)
+		echo "usage: user.sh new|batch"
+	;;
+	new)
+		shift
+		check_help $1 "usage: identity.sh new <parent dir> <parent label> <label> <output dir>"
+		temp_build identity
+		parent_cert_path=${1}/${2}.cert
+		parent_key_path=${1}/${2}.key
+		ca_cert_path=${4}/${3}.cert
+		ca_key_path=${4}/${3}.key
+
+		ensure_dir $4
+		no_overwrite ${ca_cert_path}
+		no_overwrite ${ca_key_path}
+		new_ca
+
+		echo "wrote:"
+		log_list ${ca_cert_path} ${ca_key_path}
+		echo "certificate signed by cert:"
+		log_list ${parent_cert_path} ${parent_key_path}
+	;;
+	batch)
+		shift
+		check_help $1 "usage: user.sh batch <labels file> <parent dir> <parent label> <output dir>"
+		temp_build identity
+		labels=$(cat $1)
+
+		for label in ${labels}; do
+			parent_cert_path=${2}/${3}.cert
+			parent_key_path=${2}/${3}.key
+			ca_cert_path=${4}/${label}.cert
+			ca_key_path=${4}/${label}.key
+
+			ensure_dir $4
+			no_overwrite ${ca_cert_path}
+			no_overwrite ${ca_key_path}
+			new_ca
+
+			log_list ${ca_cert_path} ${ca_key_path}
+		done
+
+		echo "certificates signed by cert:"
+		log_list ${parent_cert_path} ${parent_key_path}
+	;;
+esac


### PR DESCRIPTION
_NB: requires bash 4+_
[Write a script to automatically create identities for storage nodes on the waitlist](https://storjlabs.atlassian.net/browse/V3-548)

## Example help
```
./scripts/waitlist/user.sh --help
./scripts/waitlist/user.sh batch --help
```

## Example usage:
```bash
# Generate a new Storj certificate authority
./scripts/waitlist/storj.sh new storj-alpha-main /path/to/storj-alpha-pems-output /path/to/storj-alpha-ca-whitelist

# Generate a single user certificate authority, signed by the Storj certificate authority
./scripts/waitlist/user.sh new /path/to/existing/storj-alpha-pems storj-alpha-main username@abc.example /path/to/user-pems-output

# Generate a batch of user certificate authorities, signed by the Storj certificate authority
#   (given a newline delimited list of emails at ./emails.txt)
./scripts/waitlist/user.sh batch ./emails.txt /path/to/existing/storj-alpha-pems storj-alpha-main /path/to/user-pems-output
```

## User instructions:
A user can then take their respective cert and key and use them for `--ca.cert-path` and `--ca.key-path` when generating an identity:
```bash
# assumes you've installed (or built) the identity binary
# (`go install ./cmd/identiity` or `go build -o /path/to/binary ./cmd/identity`)
identity id new \
  --ca.cert-path /path/to/ca.cert \
  --ca.key-path /path/to/ca.key \
  --identity.cert-path /path/to/write/identity.cert \
  --identity.key-path /path/to/write/identity.key
```

Afterwards you would use the identity with whatever command (see the `--help` option of a given command):
```bash
$ storagenode setup \
  --ca.cert-path /path/to/ca.cert \
  --identity.cert-path /path/to/identity.cert \
  --identity.key-path /path/to/identity.key
```
**(Users should be reminded that the certificate authority key can and should be stored safely in cold storage after generating an identity.)**