### PR TITLE
fix test-captplanet.sh script on MacOS/BSD

### DIFF
--- a/scripts/test-captplanet.sh
+++ b/scripts/test-captplanet.sh
@@ -3,7 +3,7 @@ set -ueo pipefail
 go install -v storj.io/storj/cmd/captplanet
 
 captplanet setup --overwrite
-sed -i 's/interval:.*/interval: 3s/g' $HOME/.storj/capt/config.yaml
+sed -i~ 's/interval:.*/interval: 3s/g' $HOME/.storj/capt/config.yaml
 
 # run captplanet for 5 seconds to reproduce kademlia problems. See V3-526
 captplanet run &
@@ -76,7 +76,7 @@ fi
 kill -9 $CAPT_PID
 
 captplanet setup --listen-host ::1 --overwrite
-sed -i 's/interval:.*/interval: 3s/g' $HOME/.storj/capt/config.yaml
+sed -i~ 's/interval:.*/interval: 3s/g' $HOME/.storj/capt/config.yaml
 captplanet run &
 CAPT_PID=$!
 


### PR DESCRIPTION
only GNU sed understands -i with no argument.