### PR TITLE
Don't count current channel when testing for slowness

### DIFF
--- a/pkg/eestream/encode.go
+++ b/pkg/eestream/encode.go
@@ -248,7 +248,7 @@ func (er *encodedReader) checkSlowChannel(num int) (closed bool) {
 	// check how many buffer channels are already empty
 	ec := 0
 	for i := range er.eps {
-		if !er.eps[i].closed && len(er.eps[i].ch) == 0 {
+		if i != num && !er.eps[i].closed && len(er.eps[i].ch) == 0 {
 			ec++
 		}
 	}


### PR DESCRIPTION
Fixes https://storjlabs.atlassian.net/browse/V3-577

While uploading 1 TB failed at some point it fails with:
> successful puts (34) less than repair threshold (35)

All 61 connections (95 - 34) were closed due to slowness. This means that the logic for determining if a channel should be closed due to slowness is not accurate in counting the live fast connections. It should avoid closing connection when we are already at the repair threshold.

I found that when counting the empty channels (fast connection keep their buffer channels empty), the `checkSlowChannel` also checks the channel of the current connection. It's not impossible that the full channel (before invoking `checkSlowChannel`) becomes empty while counting the empty channels. This way the current channel will be counted too and this would explain the drop below the repair threshold with just one connection.

The fix is to simply avoid counting the current channel in the `checkSlowChannel` method.