### PR TITLE
Allow S3 clients to reupload stale parts

### DIFF
--- a/pkg/miniogw/multipart.go
+++ b/pkg/miniogw/multipart.go
@@ -433,6 +433,10 @@ func (stream *MultipartStream) AddPart(partID int, data *hash.Reader) (*StreamPa
 	stream.mu.Lock()
 	defer stream.mu.Unlock()
 
+	if partID < stream.nextID {
+		return nil, Error.New("Part %d already uploaded. Next part ID is %d.", partID, stream.nextID)
+	}
+
 	for _, p := range stream.parts {
 		if p.ID == partID {
 			// Replace the reader of this part with the new one.

--- a/pkg/miniogw/multipart.go
+++ b/pkg/miniogw/multipart.go
@@ -319,14 +319,15 @@ func (upload *MultipartUpload) complete(info minio.ObjectInfo) {
 
 // MultipartStream serializes multiple readers into a single reader
 type MultipartStream struct {
-	mu         sync.Mutex
-	moreParts  sync.Cond
-	err        error
-	closed     bool
-	finished   bool
-	nextID     int
-	nextNumber int
-	parts      []*StreamPart
+	mu          sync.Mutex
+	moreParts   sync.Cond
+	err         error
+	closed      bool
+	finished    bool
+	nextID      int
+	nextNumber  int
+	currentPart *StreamPart
+	parts       []*StreamPart
 }
 
 // StreamPart is a reader waiting in MultipartStream
@@ -381,7 +382,6 @@ func (stream *MultipartStream) Close() {
 
 // Read implements io.Reader interface, blocking when there's no part
 func (stream *MultipartStream) Read(data []byte) (n int, err error) {
-	var part *StreamPart
 	stream.mu.Lock()
 	for {
 		// has an error occurred?
@@ -389,9 +389,15 @@ func (stream *MultipartStream) Read(data []byte) (n int, err error) {
 			stream.mu.Unlock()
 			return 0, Error.Wrap(err)
 		}
+		// still uploading the current part?
+		if stream.currentPart != nil {
+			break
+		}
 		// do we have the next part?
 		if len(stream.parts) > 0 && stream.nextID == stream.parts[0].ID {
-			part = stream.parts[0]
+			stream.currentPart = stream.parts[0]
+			stream.parts = stream.parts[1:]
+			stream.nextID++
 			break
 		}
 		// we don't have the next part and are closed, hence we are complete
@@ -406,19 +412,14 @@ func (stream *MultipartStream) Read(data []byte) (n int, err error) {
 	stream.mu.Unlock()
 
 	// read as much as we can
-	n, err = part.Reader.Read(data)
-	atomic.AddInt64(&part.Size, int64(n))
+	n, err = stream.currentPart.Reader.Read(data)
+	atomic.AddInt64(&stream.currentPart.Size, int64(n))
 
 	if err == io.EOF {
 		// the part completed, hence advance to the next one
 		err = nil
-
-		stream.mu.Lock()
-		stream.parts = stream.parts[1:]
-		stream.nextID++
-		stream.mu.Unlock()
-
-		close(part.Done)
+		close(stream.currentPart.Done)
+		stream.currentPart = nil
 	} else if err != nil {
 		// something bad happened, abort the whole thing
 		stream.Abort(err)
@@ -434,7 +435,7 @@ func (stream *MultipartStream) AddPart(partID int, data *hash.Reader) (*StreamPa
 	defer stream.mu.Unlock()
 
 	if partID < stream.nextID {
-		return nil, Error.New("Part %d already uploaded. Next part ID is %d.", partID, stream.nextID)
+		return nil, Error.New("part %d already uploaded, next part ID is %d", partID, stream.nextID)
 	}
 
 	for _, p := range stream.parts {


### PR DESCRIPTION
Fixes https://storjlabs.atlassian.net/browse/V3-493

If the client has slow connection to the storage nodes, some parts that are added to and waiting in the multipart stream may not be read before the socket read timeout on the AWS CLI side is hit. In this case AWS CLI will make another request for these parts, which will result in "Part X already exists" error in the Minio Gateway. The upload will be also broken because the readers of these obsolete parts is already closed.

The solution in this patch is to replace the reader for the reuploaded parts with the new one instead of returning the "Part X already exists" error.