### PR TITLE
remove bad nodes from originalNodes list when repairing

### DIFF
--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -320,8 +320,8 @@ func (s *segmentStore) Repair(ctx context.Context, path storj.Path, lostPieces [
 	for j, v := range originalNodes {
 		if v != nil {
 			excludeNodeIDs = append(excludeNodeIDs, node.IDFromString(v.GetId()))
-			
-			// If node index exists in lostPieces skip adding it to healthyNodes
+
+			// If node index exists in lostPieces, skip adding it to healthyNodes
 			for i := range lostPieces {
 				if j == int(lostPieces[i]) {
 					totalNilNodes++
@@ -346,7 +346,7 @@ func (s *segmentStore) Repair(ctx context.Context, path storj.Path, lostPieces [
 	//make a repair nodes list just with new unique ids
 	repairNodesList := make([]*pb.Node, len(healthyNodes))
 	for j, vr := range healthyNodes {
-		// find the nil in the original node list
+		// find the nil in the node list
 		if vr == nil {
 			// replace the location with the newNode Node info
 			totalRepairCount--
@@ -383,7 +383,7 @@ func (s *segmentStore) Repair(ctx context.Context, path storj.Path, lostPieces [
 		return Error.Wrap(err)
 	}
 
-	// merge the successful nodes list into the originalNodes list
+	// merge the successful nodes list into the healthy nodes list
 	for i, v := range healthyNodes {
 		if v == nil {
 			// copy the successfuNode info

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -320,7 +320,8 @@ func (s *segmentStore) Repair(ctx context.Context, path storj.Path, lostPieces [
 	for j, v := range originalNodes {
 		if v != nil {
 			excludeNodeIDs = append(excludeNodeIDs, node.IDFromString(v.GetId()))
-			// if index of node is not in lostPieces, add it to healthyNodes at the same index
+			
+			// If node index exists in lostPieces skip adding it to healthyNodes
 			for i := range lostPieces {
 				if j == int(lostPieces[i]) {
 					totalNilNodes++

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -317,15 +317,15 @@ func (s *segmentStore) Repair(ctx context.Context, path storj.Path, lostPieces [
 	for j, v := range originalNodes {
 		if v != nil {
 			excludeNodeIDs = append(excludeNodeIDs, node.IDFromString(v.GetId()))
+			// remove all lost pieces from the list to have only healthy pieces
+			for i := range lostPieces {
+				if j == int(lostPieces[i]) {
+					v = nil
+					totalNilNodes++
+				}
+			}
 		} else {
 			totalNilNodes++
-		}
-
-		//remove all lost pieces from the list to have only healthy pieces
-		for i := range lostPieces {
-			if j == int(lostPieces[i]) {
-				totalNilNodes++
-			}
 		}
 	}
 


### PR DESCRIPTION
When repairing we don't want to add bad nodes back into the pointerDB entry. If the index of a node from the pointerDB entry is equal to a value in lostPieces, set that node equal to nil.