### PR TITLE
removes error when attempting to audit inline segment

### DIFF
--- a/pkg/audit/service.go
+++ b/pkg/audit/service.go
@@ -98,7 +98,7 @@ func (service *Service) process(ctx context.Context) error {
 		return err
 	}
 	if stripe == nil {
-		return Error.New("stripe was nil")
+		return nil
 	}
 
 	authorization := service.Cursor.pointers.SignedMessage()


### PR DESCRIPTION
small fix - there was an error when a returned stripe is nil even though there didn't have to be (just means that the auditor was attempting to audit an inline segment)