### PR TITLE
Configurable encryption type for paths

### DIFF
--- a/pkg/encryption/examples_test.go
+++ b/pkg/encryption/examples_test.go
@@ -22,7 +22,7 @@ func ExampleEncryptPath() {
 	fmt.Printf("root key (%d bytes): %s\n", len(seed), hex.EncodeToString(seed[:]))
 
 	// use the seed for encrypting the path
-	encryptedPath, err := encryption.EncryptPath(path, seed)
+	encryptedPath, err := encryption.EncryptPath(path, storj.AESGCM, seed)
 	if err != nil {
 		panic(err)
 	}
@@ -30,7 +30,7 @@ func ExampleEncryptPath() {
 	fmt.Println("encrypted path: ", encryptedPath)
 
 	// decrypting the path
-	decryptedPath, err := encryption.DecryptPath(encryptedPath, seed)
+	decryptedPath, err := encryption.DecryptPath(encryptedPath, storj.AESGCM, seed)
 	if err != nil {
 		panic(err)
 	}
@@ -45,7 +45,7 @@ func ExampleEncryptPath() {
 	}
 
 	fmt.Printf("derived key (%d bytes): %s\n", len(derivedKey), hex.EncodeToString(derivedKey[:]))
-	decryptedPath, err = encryption.DecryptPath(sharedPath, derivedKey)
+	decryptedPath, err = encryption.DecryptPath(sharedPath, storj.AESGCM, derivedKey)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/encryption/path_test.go
+++ b/pkg/encryption/path_test.go
@@ -13,75 +13,89 @@ import (
 )
 
 func TestEncryption(t *testing.T) {
-	for i, path := range []storj.Path{
-		"",
-		"/",
-		"//",
-		"file.txt",
-		"file.txt/",
-		"fold1/file.txt",
-		"fold1/fold2/file.txt",
-		"/fold1/fold2/fold3/file.txt",
-	} {
-		errTag := fmt.Sprintf("Test case #%d", i)
+	forAllCiphers(func(cipher storj.Cipher) {
+		for i, path := range []storj.Path{
+			"",
+			"/",
+			"//",
+			"file.txt",
+			"file.txt/",
+			"fold1/file.txt",
+			"fold1/fold2/file.txt",
+			"/fold1/fold2/fold3/file.txt",
+		} {
+			errTag := fmt.Sprintf("%d. %+v", i, path)
 
-		key := new(storj.Key)
-		copy(key[:], randData(storj.KeySize))
+			key := new(storj.Key)
+			copy(key[:], randData(storj.KeySize))
 
-		encrypted, err := EncryptPath(path, key)
-		if !assert.NoError(t, err, errTag) {
-			continue
+			encrypted, err := EncryptPath(path, cipher, key)
+			if !assert.NoError(t, err, errTag) {
+				continue
+			}
+
+			decrypted, err := DecryptPath(encrypted, cipher, key)
+			if !assert.NoError(t, err, errTag) {
+				continue
+			}
+
+			assert.Equal(t, path, decrypted, errTag)
 		}
-
-		decrypted, err := DecryptPath(encrypted, key)
-		if !assert.NoError(t, err, errTag) {
-			continue
-		}
-
-		assert.Equal(t, path, decrypted, errTag)
-	}
+	})
 }
 
 func TestDeriveKey(t *testing.T) {
-	for i, tt := range []struct {
-		path      storj.Path
-		depth     int
-		errString string
-	}{
-		{"fold1/fold2/fold3/file.txt", -1, "encryption error: negative depth"},
-		{"fold1/fold2/fold3/file.txt", 0, ""},
-		{"fold1/fold2/fold3/file.txt", 1, ""},
-		{"fold1/fold2/fold3/file.txt", 2, ""},
-		{"fold1/fold2/fold3/file.txt", 3, ""},
-		{"fold1/fold2/fold3/file.txt", 4, ""},
-		{"fold1/fold2/fold3/file.txt", 5, "encryption error: depth greater than path length"},
+	forAllCiphers(func(cipher storj.Cipher) {
+		for i, tt := range []struct {
+			path      storj.Path
+			depth     int
+			errString string
+		}{
+			{"fold1/fold2/fold3/file.txt", -1, "encryption error: negative depth"},
+			{"fold1/fold2/fold3/file.txt", 0, ""},
+			{"fold1/fold2/fold3/file.txt", 1, ""},
+			{"fold1/fold2/fold3/file.txt", 2, ""},
+			{"fold1/fold2/fold3/file.txt", 3, ""},
+			{"fold1/fold2/fold3/file.txt", 4, ""},
+			{"fold1/fold2/fold3/file.txt", 5, "encryption error: depth greater than path length"},
+		} {
+			errTag := fmt.Sprintf("%d. %+v", i, tt)
+
+			key := new(storj.Key)
+			copy(key[:], randData(storj.KeySize))
+
+			encrypted, err := EncryptPath(tt.path, cipher, key)
+			if !assert.NoError(t, err, errTag) {
+				continue
+			}
+
+			derivedKey, err := DerivePathKey(tt.path, key, tt.depth)
+			if tt.errString != "" {
+				assert.EqualError(t, err, tt.errString, errTag)
+				continue
+			}
+			if !assert.NoError(t, err, errTag) {
+				continue
+			}
+
+			shared := storj.JoinPaths(storj.SplitPath(encrypted)[tt.depth:]...)
+			decrypted, err := DecryptPath(shared, cipher, derivedKey)
+			if !assert.NoError(t, err, errTag) {
+				continue
+			}
+
+			expected := storj.JoinPaths(storj.SplitPath(tt.path)[tt.depth:]...)
+			assert.Equal(t, expected, decrypted, errTag)
+		}
+	})
+}
+
+func forAllCiphers(test func(cipher storj.Cipher)) {
+	for _, cipher := range []storj.Cipher{
+		storj.Unencrypted,
+		storj.AESGCM,
+		storj.SecretBox,
 	} {
-		errTag := fmt.Sprintf("Test case #%d", i)
-
-		key := new(storj.Key)
-		copy(key[:], randData(storj.KeySize))
-
-		encrypted, err := EncryptPath(tt.path, key)
-		if !assert.NoError(t, err, errTag) {
-			continue
-		}
-
-		derivedKey, err := DerivePathKey(tt.path, key, tt.depth)
-		if tt.errString != "" {
-			assert.EqualError(t, err, tt.errString, errTag)
-			continue
-		}
-		if !assert.NoError(t, err, errTag) {
-			continue
-		}
-
-		shared := storj.JoinPaths(storj.SplitPath(encrypted)[tt.depth:]...)
-		decrypted, err := DecryptPath(shared, derivedKey)
-		if !assert.NoError(t, err, errTag) {
-			continue
-		}
-
-		expected := storj.JoinPaths(storj.SplitPath(tt.path)[tt.depth:]...)
-		assert.Equal(t, expected, decrypted, errTag)
+		test(cipher)
 	}
 }

--- a/pkg/metainfo/kvmetainfo/buckets_test.go
+++ b/pkg/metainfo/kvmetainfo/buckets_test.go
@@ -19,7 +19,6 @@ import (
 	"storj.io/storj/pkg/overlay"
 	"storj.io/storj/pkg/storage/buckets"
 	"storj.io/storj/pkg/storage/ec"
-	"storj.io/storj/pkg/storage/objects"
 	"storj.io/storj/pkg/storage/segments"
 	"storj.io/storj/pkg/storage/streams"
 	"storj.io/storj/pkg/storj"
@@ -358,7 +357,5 @@ func newBucketStore(planet *testplanet.Planet) (buckets.Store, error) {
 		return nil, err
 	}
 
-	obj := objects.NewStore(stream)
-
-	return buckets.NewStore(obj), nil
+	return buckets.NewStore(stream, storj.Unencrypted), nil
 }

--- a/pkg/metainfo/kvmetainfo/objects.go
+++ b/pkg/metainfo/kvmetainfo/objects.go
@@ -150,7 +150,8 @@ type object struct {
 func (db *Objects) getInfo(ctx context.Context, prefix string, bucket string, path storj.Path) (object, storj.Object, error) {
 	fullpath := bucket + "/" + path
 
-	encryptedPath, err := streams.EncryptAfterBucket(fullpath, db.rootKey)
+	// TODO: get path encryption cipher from bucket metadata
+	encryptedPath, err := streams.EncryptAfterBucket(fullpath, storj.AESGCM, db.rootKey)
 	if err != nil {
 		return object{}, storj.Object{}, err
 	}

--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -18,7 +18,6 @@ import (
 	"storj.io/storj/pkg/provider"
 	"storj.io/storj/pkg/storage/buckets"
 	"storj.io/storj/pkg/storage/ec"
-	"storj.io/storj/pkg/storage/objects"
 	segment "storj.io/storj/pkg/storage/segments"
 	"storj.io/storj/pkg/storage/streams"
 	"storj.io/storj/pkg/storj"
@@ -40,7 +39,8 @@ type RSConfig struct {
 type EncryptionConfig struct {
 	EncKey       string `help:"root key for encrypting the data"`
 	EncBlockSize int    `help:"size (in bytes) of encrypted blocks" default:"1024"`
-	EncType      int    `help:"Type of encryption to use (1=AES-GCM, 2=SecretBox)" default:"1"`
+	EncType      int    `help:"Type of encryption to use for content and metadata (1=AES-GCM, 2=SecretBox)" default:"1"`
+	PathEncType  int    `help:"Type of encryption to use for paths (0=Unencrypted, 1=AES-GCM, 2=SecretBox)" default:"1"`
 }
 
 // MinioConfig is a configuration struct that keeps details about starting
@@ -161,9 +161,7 @@ func (c Config) GetBucketStore(ctx context.Context, identity *provider.FullIdent
 		return nil, err
 	}
 
-	obj := objects.NewStore(stream)
-
-	return buckets.NewStore(obj), nil
+	return buckets.NewStore(stream, storj.Cipher(c.PathEncType)), nil
 }
 
 // NewGateway creates a new minio Gateway

--- a/pkg/storage/buckets/prefixed.go
+++ b/pkg/storage/buckets/prefixed.go
@@ -14,7 +14,7 @@ import (
 )
 
 type prefixedObjStore struct {
-	o      objects.Store
+	store  objects.Store
 	prefix string
 }
 
@@ -25,8 +25,7 @@ func (o *prefixedObjStore) Meta(ctx context.Context, path storj.Path) (meta obje
 		return objects.Meta{}, objects.NoPathError.New("")
 	}
 
-	m, err := o.o.Meta(ctx, storj.JoinPaths(o.prefix, path))
-	return m, err
+	return o.store.Meta(ctx, storj.JoinPaths(o.prefix, path))
 }
 
 func (o *prefixedObjStore) Get(ctx context.Context, path storj.Path) (rr ranger.Ranger, meta objects.Meta, err error) {
@@ -36,8 +35,7 @@ func (o *prefixedObjStore) Get(ctx context.Context, path storj.Path) (rr ranger.
 		return nil, objects.Meta{}, objects.NoPathError.New("")
 	}
 
-	rr, m, err := o.o.Get(ctx, storj.JoinPaths(o.prefix, path))
-	return rr, m, err
+	return o.store.Get(ctx, storj.JoinPaths(o.prefix, path))
 }
 
 func (o *prefixedObjStore) Put(ctx context.Context, path storj.Path, data io.Reader, metadata objects.SerializableMeta, expiration time.Time) (meta objects.Meta, err error) {
@@ -47,8 +45,7 @@ func (o *prefixedObjStore) Put(ctx context.Context, path storj.Path, data io.Rea
 		return objects.Meta{}, objects.NoPathError.New("")
 	}
 
-	m, err := o.o.Put(ctx, storj.JoinPaths(o.prefix, path), data, metadata, expiration)
-	return m, err
+	return o.store.Put(ctx, storj.JoinPaths(o.prefix, path), data, metadata, expiration)
 }
 
 func (o *prefixedObjStore) Delete(ctx context.Context, path storj.Path) (err error) {
@@ -58,10 +55,11 @@ func (o *prefixedObjStore) Delete(ctx context.Context, path storj.Path) (err err
 		return objects.NoPathError.New("")
 	}
 
-	return o.o.Delete(ctx, storj.JoinPaths(o.prefix, path))
+	return o.store.Delete(ctx, storj.JoinPaths(o.prefix, path))
 }
 
 func (o *prefixedObjStore) List(ctx context.Context, prefix, startAfter, endBefore storj.Path, recursive bool, limit int, metaFlags uint32) (items []objects.ListItem, more bool, err error) {
 	defer mon.Task()(&ctx)(&err)
-	return o.o.List(ctx, storj.JoinPaths(o.prefix, prefix), startAfter, endBefore, recursive, limit, metaFlags)
+
+	return o.store.List(ctx, storj.JoinPaths(o.prefix, prefix), startAfter, endBefore, recursive, limit, metaFlags)
 }

--- a/pkg/storage/streams/store_test.go
+++ b/pkg/storage/streams/store_test.go
@@ -91,12 +91,12 @@ func TestStreamStoreMeta(t *testing.T) {
 			Meta(gomock.Any(), gomock.Any()).
 			Return(test.segmentMeta, test.segmentError)
 
-		streamStore, err := NewStreamStore(mockSegmentStore, 10, new(storj.Key), 10, 0)
+		streamStore, err := NewStreamStore(mockSegmentStore, 10, new(storj.Key), 10, storj.AESGCM)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		meta, err := streamStore.Meta(ctx, test.path)
+		meta, err := streamStore.Meta(ctx, test.path, storj.AESGCM)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -168,7 +168,7 @@ func TestStreamStorePut(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		meta, err := streamStore.Put(ctx, test.path, test.data, test.metadata, test.expiration)
+		meta, err := streamStore.Put(ctx, test.path, storj.AESGCM, test.data, test.metadata, test.expiration)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -268,7 +268,7 @@ func TestStreamStoreGet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ranger, meta, err := streamStore.Get(ctx, test.path)
+		ranger, meta, err := streamStore.Get(ctx, test.path, storj.AESGCM)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -317,7 +317,7 @@ func TestStreamStoreDelete(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = streamStore.Delete(ctx, test.path)
+		err = streamStore.Delete(ctx, test.path, storj.AESGCM)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -361,7 +361,7 @@ func TestStreamStoreList(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		items, more, err := streamStore.List(ctx, test.prefix, test.startAfter, test.endBefore, test.recursive, test.limit, test.metaFlags)
+		items, more, err := streamStore.List(ctx, test.prefix, test.startAfter, test.endBefore, storj.AESGCM, test.recursive, test.limit, test.metaFlags)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Implements https://storjlabs.atlassian.net/browse/V3-546

The path encryption type is now stored in the bucket's metadata - in the `PathEncryptionType` field. Whenever an operation on the object store is executed, this value is taken into account for the path encryption.

Users can configure the `path-enc-type` property in the config.yaml, similar to the `enc-type` property for the content encryption. The `path-enc-type` is used only for creating new buckets. From there on, any operation on the bucket uses the `PathEncryptionField` from the bucket's metadata.