### PR TITLE
Configure path encryption in metainfo API

### DIFF
--- a/cmd/uplink/cmd/mb.go
+++ b/cmd/uplink/cmd/mb.go
@@ -10,6 +10,7 @@ import (
 
 	"storj.io/storj/internal/fpath"
 	"storj.io/storj/pkg/process"
+	"storj.io/storj/pkg/storj"
 	"storj.io/storj/storage"
 )
 
@@ -53,7 +54,7 @@ func makeBucket(cmd *cobra.Command, args []string) error {
 	if !storage.ErrKeyNotFound.Has(err) {
 		return err
 	}
-	_, err = bs.Put(ctx, dst.Bucket())
+	_, err = bs.Put(ctx, dst.Bucket(), storj.Cipher(cfg.PathEncType))
 	if err != nil {
 		return err
 	}

--- a/pkg/metainfo/kvmetainfo/buckets.go
+++ b/pkg/metainfo/kvmetainfo/buckets.go
@@ -10,21 +10,13 @@ import (
 	"storj.io/storj/pkg/storj"
 )
 
-// Buckets implements storj.Metainfo bucket handling
-type Buckets struct {
-	store buckets.Store
-}
-
-// NewBuckets creates Buckets
-func NewBuckets(store buckets.Store) *Buckets { return &Buckets{store} }
-
 // CreateBucket creates a new bucket with the specified information
-func (db *Buckets) CreateBucket(ctx context.Context, bucket string, info *storj.Bucket) (storj.Bucket, error) {
+func (db *DB) CreateBucket(ctx context.Context, bucket string, info *storj.Bucket) (storj.Bucket, error) {
 	if bucket == "" {
 		return storj.Bucket{}, storj.ErrNoBucket.New("")
 	}
 
-	meta, err := db.store.Put(ctx, bucket)
+	meta, err := db.buckets.Put(ctx, bucket, getPathCipher(info))
 	if err != nil {
 		return storj.Bucket{}, err
 	}
@@ -33,21 +25,21 @@ func (db *Buckets) CreateBucket(ctx context.Context, bucket string, info *storj.
 }
 
 // DeleteBucket deletes bucket
-func (db *Buckets) DeleteBucket(ctx context.Context, bucket string) error {
+func (db *DB) DeleteBucket(ctx context.Context, bucket string) error {
 	if bucket == "" {
 		return storj.ErrNoBucket.New("")
 	}
 
-	return db.store.Delete(ctx, bucket)
+	return db.buckets.Delete(ctx, bucket)
 }
 
 // GetBucket gets bucket information
-func (db *Buckets) GetBucket(ctx context.Context, bucket string) (storj.Bucket, error) {
+func (db *DB) GetBucket(ctx context.Context, bucket string) (storj.Bucket, error) {
 	if bucket == "" {
 		return storj.Bucket{}, storj.ErrNoBucket.New("")
 	}
 
-	meta, err := db.store.Get(ctx, bucket)
+	meta, err := db.buckets.Get(ctx, bucket)
 	if err != nil {
 		return storj.Bucket{}, err
 	}
@@ -56,7 +48,7 @@ func (db *Buckets) GetBucket(ctx context.Context, bucket string) (storj.Bucket, 
 }
 
 // ListBuckets lists buckets
-func (db *Buckets) ListBuckets(ctx context.Context, options storj.BucketListOptions) (storj.BucketList, error) {
+func (db *DB) ListBuckets(ctx context.Context, options storj.BucketListOptions) (storj.BucketList, error) {
 	var startAfter, endBefore string
 	switch options.Direction {
 	case storj.Before:
@@ -80,7 +72,7 @@ func (db *Buckets) ListBuckets(ctx context.Context, options storj.BucketListOpti
 		endBefore = "\x7f\x7f\x7f\x7f\x7f\x7f\x7f"
 	}
 
-	items, more, err := db.store.List(ctx, startAfter, endBefore, options.Limit)
+	items, more, err := db.buckets.List(ctx, startAfter, endBefore, options.Limit)
 	if err != nil {
 		return storj.BucketList{}, err
 	}
@@ -97,9 +89,17 @@ func (db *Buckets) ListBuckets(ctx context.Context, options storj.BucketListOpti
 	return list, nil
 }
 
+func getPathCipher(info *storj.Bucket) storj.Cipher {
+	if info == nil {
+		return storj.AESGCM
+	}
+	return info.PathCipher
+}
+
 func bucketFromMeta(bucket string, meta buckets.Meta) storj.Bucket {
 	return storj.Bucket{
-		Name:    bucket,
-		Created: meta.Created,
+		Name:       bucket,
+		Created:    meta.Created,
+		PathCipher: meta.PathEncryptionType,
 	}
 }

--- a/pkg/metainfo/kvmetainfo/buckets_test.go
+++ b/pkg/metainfo/kvmetainfo/buckets_test.go
@@ -32,17 +32,15 @@ const (
 )
 
 func TestBucketsBasic(t *testing.T) {
-	runTest(t, func(ctx context.Context, bucketStore buckets.Store) {
-		buckets := NewBuckets(bucketStore)
-
+	runTest(t, func(ctx context.Context, db *DB) {
 		// Create new bucket
-		bucket, err := buckets.CreateBucket(ctx, TestBucket, nil)
+		bucket, err := db.CreateBucket(ctx, TestBucket, nil)
 		if assert.NoError(t, err) {
 			assert.Equal(t, TestBucket, bucket.Name)
 		}
 
 		// Check that bucket list include the new bucket
-		bucketList, err := buckets.ListBuckets(ctx, storj.BucketListOptions{Direction: storj.After})
+		bucketList, err := db.ListBuckets(ctx, storj.BucketListOptions{Direction: storj.After})
 		if assert.NoError(t, err) {
 			assert.False(t, bucketList.More)
 			assert.Equal(t, 1, len(bucketList.Items))
@@ -50,38 +48,37 @@ func TestBucketsBasic(t *testing.T) {
 		}
 
 		// Check that we can get the new bucket explicitly
-		bucket, err = buckets.GetBucket(ctx, TestBucket)
+		bucket, err = db.GetBucket(ctx, TestBucket)
 		if assert.NoError(t, err) {
 			assert.Equal(t, TestBucket, bucket.Name)
+			assert.Equal(t, storj.AESGCM, bucket.PathCipher)
 		}
 
 		// Delete the bucket
-		err = buckets.DeleteBucket(ctx, TestBucket)
+		err = db.DeleteBucket(ctx, TestBucket)
 		assert.NoError(t, err)
 
 		// Check that the bucket list is empty
-		bucketList, err = buckets.ListBuckets(ctx, storj.BucketListOptions{Direction: storj.After})
+		bucketList, err = db.ListBuckets(ctx, storj.BucketListOptions{Direction: storj.After})
 		if assert.NoError(t, err) {
 			assert.False(t, bucketList.More)
 			assert.Equal(t, 0, len(bucketList.Items))
 		}
 
 		// Check that the bucket cannot be get explicitly
-		bucket, err = buckets.GetBucket(ctx, TestBucket)
+		bucket, err = db.GetBucket(ctx, TestBucket)
 		assert.True(t, storage.ErrKeyNotFound.Has(err))
 	})
 }
 
 func TestBucketsReadNewWayWriteOldWay(t *testing.T) {
-	runTest(t, func(ctx context.Context, bucketStore buckets.Store) {
-		buckets := NewBuckets(bucketStore)
-
+	runTest(t, func(ctx context.Context, db *DB) {
 		// (Old API) Create new bucket
-		_, err := bucketStore.Put(ctx, TestBucket)
+		_, err := db.buckets.Put(ctx, TestBucket, storj.AESGCM)
 		assert.NoError(t, err)
 
 		// (New API) Check that bucket list include the new bucket
-		bucketList, err := buckets.ListBuckets(ctx, storj.BucketListOptions{Direction: storj.After})
+		bucketList, err := db.ListBuckets(ctx, storj.BucketListOptions{Direction: storj.After})
 		if assert.NoError(t, err) {
 			assert.False(t, bucketList.More)
 			assert.Equal(t, 1, len(bucketList.Items))
@@ -89,40 +86,39 @@ func TestBucketsReadNewWayWriteOldWay(t *testing.T) {
 		}
 
 		// (New API) Check that we can get the new bucket explicitly
-		bucket, err := buckets.GetBucket(ctx, TestBucket)
+		bucket, err := db.GetBucket(ctx, TestBucket)
 		if assert.NoError(t, err) {
 			assert.Equal(t, TestBucket, bucket.Name)
+			assert.Equal(t, storj.AESGCM, bucket.PathCipher)
 		}
 
 		// (Old API) Delete the bucket
-		err = bucketStore.Delete(ctx, TestBucket)
+		err = db.buckets.Delete(ctx, TestBucket)
 		assert.NoError(t, err)
 
 		// (New API) Check that the bucket list is empty
-		bucketList, err = buckets.ListBuckets(ctx, storj.BucketListOptions{Direction: storj.After})
+		bucketList, err = db.ListBuckets(ctx, storj.BucketListOptions{Direction: storj.After})
 		if assert.NoError(t, err) {
 			assert.False(t, bucketList.More)
 			assert.Equal(t, 0, len(bucketList.Items))
 		}
 
 		// (New API) Check that the bucket cannot be get explicitly
-		bucket, err = buckets.GetBucket(ctx, TestBucket)
+		bucket, err = db.GetBucket(ctx, TestBucket)
 		assert.True(t, storage.ErrKeyNotFound.Has(err))
 	})
 }
 
 func TestBucketsReadOldWayWriteNewWay(t *testing.T) {
-	runTest(t, func(ctx context.Context, bucketStore buckets.Store) {
-		buckets := NewBuckets(bucketStore)
-
+	runTest(t, func(ctx context.Context, db *DB) {
 		// (New API) Create new bucket
-		bucket, err := buckets.CreateBucket(ctx, TestBucket, nil)
+		bucket, err := db.CreateBucket(ctx, TestBucket, nil)
 		if assert.NoError(t, err) {
 			assert.Equal(t, TestBucket, bucket.Name)
 		}
 
 		// (Old API) Check that bucket list include the new bucket
-		items, more, err := bucketStore.List(ctx, "", "", 0)
+		items, more, err := db.buckets.List(ctx, "", "", 0)
 		if assert.NoError(t, err) {
 			assert.False(t, more)
 			assert.Equal(t, 1, len(items))
@@ -130,46 +126,63 @@ func TestBucketsReadOldWayWriteNewWay(t *testing.T) {
 		}
 
 		// (Old API) Check that we can get the new bucket explicitly
-		_, err = bucketStore.Get(ctx, TestBucket)
-		assert.NoError(t, err)
+		meta, err := db.buckets.Get(ctx, TestBucket)
+		if assert.NoError(t, err) {
+			assert.Equal(t, storj.AESGCM, meta.PathEncryptionType)
+		}
 
 		// (New API) Delete the bucket
-		err = buckets.DeleteBucket(ctx, TestBucket)
+		err = db.DeleteBucket(ctx, TestBucket)
 		assert.NoError(t, err)
 
 		// (Old API) Check that the bucket list is empty
-		items, more, err = bucketStore.List(ctx, "", "", 0)
+		items, more, err = db.buckets.List(ctx, "", "", 0)
 		if assert.NoError(t, err) {
 			assert.False(t, more)
 			assert.Equal(t, 0, len(items))
 		}
 
 		// (Old API) Check that the bucket cannot be get explicitly
-		_, err = bucketStore.Get(ctx, TestBucket)
+		_, err = db.buckets.Get(ctx, TestBucket)
 		assert.True(t, storage.ErrKeyNotFound.Has(err))
 	})
 }
 
 func TestErrNoBucket(t *testing.T) {
-	runTest(t, func(ctx context.Context, bucketStore buckets.Store) {
-		buckets := NewBuckets(bucketStore)
-
-		_, err := buckets.CreateBucket(ctx, "", nil)
+	runTest(t, func(ctx context.Context, db *DB) {
+		_, err := db.CreateBucket(ctx, "", nil)
 		assert.True(t, storj.ErrNoBucket.Has(err))
 
-		_, err = buckets.GetBucket(ctx, "")
+		_, err = db.GetBucket(ctx, "")
 		assert.True(t, storj.ErrNoBucket.Has(err))
 
-		err = buckets.DeleteBucket(ctx, "")
+		err = db.DeleteBucket(ctx, "")
 		assert.True(t, storj.ErrNoBucket.Has(err))
 	})
 }
 
-func TestListBucketsEmpty(t *testing.T) {
-	runTest(t, func(ctx context.Context, bucketStore buckets.Store) {
-		buckets := NewBuckets(bucketStore)
+func TestBucketCreateCipher(t *testing.T) {
+	runTest(t, func(ctx context.Context, db *DB) {
+		forAllCiphers(func(cipher storj.Cipher) {
+			bucket, err := db.CreateBucket(ctx, "test", &storj.Bucket{PathCipher: cipher})
+			if assert.NoError(t, err) {
+				assert.Equal(t, cipher, bucket.PathCipher)
+			}
 
-		_, err := buckets.ListBuckets(ctx, storj.BucketListOptions{})
+			bucket, err = db.GetBucket(ctx, "test")
+			if assert.NoError(t, err) {
+				assert.Equal(t, cipher, bucket.PathCipher)
+			}
+
+			err = db.DeleteBucket(ctx, "test")
+			assert.NoError(t, err)
+		})
+	})
+}
+
+func TestListBucketsEmpty(t *testing.T) {
+	runTest(t, func(ctx context.Context, db *DB) {
+		_, err := db.ListBuckets(ctx, storj.BucketListOptions{})
 		assert.EqualError(t, err, "kvmetainfo: invalid direction 0")
 
 		for _, direction := range []storj.ListDirection{
@@ -178,7 +191,7 @@ func TestListBucketsEmpty(t *testing.T) {
 			storj.Forward,
 			storj.After,
 		} {
-			bucketList, err := buckets.ListBuckets(ctx, storj.BucketListOptions{Direction: direction})
+			bucketList, err := db.ListBuckets(ctx, storj.BucketListOptions{Direction: direction})
 			if assert.NoError(t, err) {
 				assert.False(t, bucketList.More)
 				assert.Equal(t, 0, len(bucketList.Items))
@@ -188,13 +201,11 @@ func TestListBucketsEmpty(t *testing.T) {
 }
 
 func TestListBuckets(t *testing.T) {
-	runTest(t, func(ctx context.Context, bucketStore buckets.Store) {
-		buckets := NewBuckets(bucketStore)
-
+	runTest(t, func(ctx context.Context, db *DB) {
 		bucketNames := []string{"a", "aa", "b", "bb", "c"}
 
 		for _, name := range bucketNames {
-			_, err := buckets.CreateBucket(ctx, name, nil)
+			_, err := db.CreateBucket(ctx, name, nil)
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -274,7 +285,7 @@ func TestListBuckets(t *testing.T) {
 		} {
 			errTag := fmt.Sprintf("%d. %+v", i, tt)
 
-			bucketList, err := buckets.ListBuckets(ctx, storj.BucketListOptions{
+			bucketList, err := db.ListBuckets(ctx, storj.BucketListOptions{
 				Cursor:    tt.cursor,
 				Direction: tt.dir,
 				Limit:     tt.limit,
@@ -298,7 +309,7 @@ func getBucketNames(bucketList storj.BucketList) []string {
 	return names
 }
 
-func runTest(t *testing.T, test func(context.Context, buckets.Store)) {
+func runTest(t *testing.T, test func(context.Context, *DB)) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
 
@@ -311,15 +322,15 @@ func runTest(t *testing.T, test func(context.Context, buckets.Store)) {
 
 	planet.Start(context.Background())
 
-	bucketStore, err := newBucketStore(planet)
+	db, err := newDB(planet)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	test(ctx, bucketStore)
+	test(ctx, db)
 }
 
-func newBucketStore(planet *testplanet.Planet) (buckets.Store, error) {
+func newDB(planet *testplanet.Planet) (*DB, error) {
 	// TODO(kaloyan): We should have a better way for configuring the Satellite's API Key
 	err := flag.Set("pointer-db.auth.api-key", TestAPIKey)
 	if err != nil {
@@ -352,10 +363,22 @@ func newBucketStore(planet *testplanet.Planet) (buckets.Store, error) {
 	key := new(storj.Key)
 	copy(key[:], TestEncKey)
 
-	stream, err := streams.NewStreamStore(segments, int64(64*memory.MB), key, int(1*memory.KB), storj.AESGCM)
+	streams, err := streams.NewStreamStore(segments, int64(64*memory.MB), key, int(1*memory.KB), storj.AESGCM)
 	if err != nil {
 		return nil, err
 	}
 
-	return buckets.NewStore(stream, storj.Unencrypted), nil
+	buckets := buckets.NewStore(streams)
+
+	return New(buckets, streams, segments, pdb, key), nil
+}
+
+func forAllCiphers(test func(cipher storj.Cipher)) {
+	for _, cipher := range []storj.Cipher{
+		storj.Unencrypted,
+		storj.AESGCM,
+		storj.SecretBox,
+	} {
+		test(cipher)
+	}
 }

--- a/pkg/metainfo/kvmetainfo/metainfo.go
+++ b/pkg/metainfo/kvmetainfo/metainfo.go
@@ -7,6 +7,10 @@ import (
 	"github.com/zeebo/errs"
 
 	"storj.io/storj/internal/memory"
+	"storj.io/storj/pkg/pointerdb/pdbclient"
+	"storj.io/storj/pkg/storage/buckets"
+	"storj.io/storj/pkg/storage/segments"
+	"storj.io/storj/pkg/storage/streams"
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/storage"
 )
@@ -19,19 +23,24 @@ var _ storj.Metainfo = (*DB)(nil)
 
 // DB implements metainfo database
 type DB struct {
-	*Buckets
-	*Objects
+	buckets  buckets.Store
+	streams  streams.Store
+	segments segments.Store
+	pointers pdbclient.Client
+
+	rootKey *storj.Key
 }
 
-/*
 // New creates a new metainfo database
-func New(client psclient.Client, rootKey *storj.Key) *DB {
+func New(buckets buckets.Store, streams streams.Store, segments segments.Store, pointers pdbclient.Client, rootKey *storj.Key) *DB {
 	return &DB{
-		// Buckets: NewBuckets(buckets),
-		// Objects: NewObjects(objects, streams, segments),
+		buckets:  buckets,
+		streams:  streams,
+		segments: segments,
+		pointers: pointers,
+		rootKey:  rootKey,
 	}
 }
-*/
 
 // Limits returns limits for this metainfo database
 func (db *DB) Limits() (storj.MetainfoLimits, error) {

--- a/pkg/metainfo/kvmetainfo/objects.go
+++ b/pkg/metainfo/kvmetainfo/objects.go
@@ -15,7 +15,6 @@ import (
 
 	"storj.io/storj/pkg/encryption"
 	"storj.io/storj/pkg/pb"
-	"storj.io/storj/pkg/pointerdb/pdbclient"
 	"storj.io/storj/pkg/storage/meta"
 	"storj.io/storj/pkg/storage/objects"
 	"storj.io/storj/pkg/storage/segments"
@@ -23,40 +22,19 @@ import (
 	"storj.io/storj/pkg/storj"
 )
 
-// Objects implements storj.Metainfo bucket handling
-type Objects struct {
-	objects  objects.Store
-	streams  streams.Store
-	segments segments.Store
-	pointers pdbclient.Client
-
-	rootKey *storj.Key
-}
-
 const (
 	// commitedPrefix is prefix where completed object info is stored
 	committedPrefix = "l/"
 )
 
-// NewObjects creates Objects
-func NewObjects(objects objects.Store, streams streams.Store, segments segments.Store, pointers pdbclient.Client, rootKey *storj.Key) *Objects {
-	return &Objects{
-		objects:  objects,
-		streams:  streams,
-		segments: segments,
-		pointers: pointers,
-		rootKey:  rootKey,
-	}
-}
-
 // GetObject returns information about an object
-func (db *Objects) GetObject(ctx context.Context, bucket string, path storj.Path) (storj.Object, error) {
+func (db *DB) GetObject(ctx context.Context, bucket string, path storj.Path) (storj.Object, error) {
 	_, info, err := db.getInfo(ctx, committedPrefix, bucket, path)
 	return info, err
 }
 
 // GetObjectStream returns interface for reading the object stream
-func (db *Objects) GetObjectStream(ctx context.Context, bucket string, path storj.Path) (storj.ReadOnlyStream, error) {
+func (db *DB) GetObjectStream(ctx context.Context, bucket string, path storj.Path) (storj.ReadOnlyStream, error) {
 	meta, info, err := db.getInfo(ctx, committedPrefix, bucket, path)
 	if err != nil {
 		return nil, err
@@ -76,32 +54,42 @@ func (db *Objects) GetObjectStream(ctx context.Context, bucket string, path stor
 }
 
 // CreateObject creates an uploading object and returns an interface for uploading Object information
-func (db *Objects) CreateObject(ctx context.Context, bucket string, path storj.Path, createInfo *storj.CreateObject) (storj.MutableObject, error) {
+func (db *DB) CreateObject(ctx context.Context, bucket string, path storj.Path, createInfo *storj.CreateObject) (storj.MutableObject, error) {
 	return nil, errors.New("not implemented")
 }
 
 // ModifyObject modifies a committed object
-func (db *Objects) ModifyObject(ctx context.Context, bucket string, path storj.Path) (storj.MutableObject, error) {
+func (db *DB) ModifyObject(ctx context.Context, bucket string, path storj.Path) (storj.MutableObject, error) {
 	return nil, errors.New("not implemented")
 }
 
 // DeleteObject deletes an object from database
-func (db *Objects) DeleteObject(ctx context.Context, bucket string, path storj.Path) error {
-	return db.objects.Delete(ctx, bucket+"/"+path)
+func (db *DB) DeleteObject(ctx context.Context, bucket string, path storj.Path) error {
+	objects, err := db.buckets.GetObjectStore(ctx, bucket)
+	if err != nil {
+		return err
+	}
+
+	return objects.Delete(ctx, path)
 }
 
 // ModifyPendingObject creates an interface for updating a partially uploaded object
-func (db *Objects) ModifyPendingObject(ctx context.Context, bucket string, path storj.Path) (storj.MutableObject, error) {
+func (db *DB) ModifyPendingObject(ctx context.Context, bucket string, path storj.Path) (storj.MutableObject, error) {
 	return nil, errors.New("not implemented")
 }
 
 // ListPendingObjects lists pending objects in bucket based on the ListOptions
-func (db *Objects) ListPendingObjects(ctx context.Context, bucket string, options storj.ListOptions) (storj.ObjectList, error) {
+func (db *DB) ListPendingObjects(ctx context.Context, bucket string, options storj.ListOptions) (storj.ObjectList, error) {
 	return storj.ObjectList{}, errors.New("not implemented")
 }
 
 // ListObjects lists objects in bucket based on the ListOptions
-func (db *Objects) ListObjects(ctx context.Context, bucket string, options storj.ListOptions) (storj.ObjectList, error) {
+func (db *DB) ListObjects(ctx context.Context, bucket string, options storj.ListOptions) (storj.ObjectList, error) {
+	objects, err := db.buckets.GetObjectStore(ctx, bucket)
+	if err != nil {
+		return storj.ObjectList{}, err
+	}
+
 	var startAfter, endBefore string
 	switch options.Direction {
 	case storj.Before:
@@ -120,7 +108,7 @@ func (db *Objects) ListObjects(ctx context.Context, bucket string, options storj
 		return storj.ObjectList{}, errClass.New("invalid direction %d", options.Direction)
 	}
 
-	items, more, err := db.objects.List(ctx, bucket+"/"+options.Prefix, startAfter, endBefore, options.Recursive, options.Limit, meta.All)
+	items, more, err := objects.List(ctx, options.Prefix, startAfter, endBefore, options.Recursive, options.Limit, meta.All)
 	if err != nil {
 		return storj.ObjectList{}, err
 	}
@@ -147,11 +135,15 @@ type object struct {
 	streamMeta      pb.StreamMeta
 }
 
-func (db *Objects) getInfo(ctx context.Context, prefix string, bucket string, path storj.Path) (object, storj.Object, error) {
+func (db *DB) getInfo(ctx context.Context, prefix string, bucket string, path storj.Path) (object, storj.Object, error) {
+	bucketInfo, err := db.GetBucket(ctx, bucket)
+	if err != nil {
+		return object{}, storj.Object{}, err
+	}
+
 	fullpath := bucket + "/" + path
 
-	// TODO: get path encryption cipher from bucket metadata
-	encryptedPath, err := streams.EncryptAfterBucket(fullpath, storj.AESGCM, db.rootKey)
+	encryptedPath, err := streams.EncryptAfterBucket(fullpath, bucketInfo.PathCipher, db.rootKey)
 	if err != nil {
 		return object{}, storj.Object{}, err
 	}

--- a/pkg/metainfo/kvmetainfo/stream.go
+++ b/pkg/metainfo/kvmetainfo/stream.go
@@ -17,7 +17,7 @@ import (
 var _ storj.ReadOnlyStream = (*readonlyStream)(nil)
 
 type readonlyStream struct {
-	db *Objects
+	db *DB
 
 	info          storj.Object
 	encryptedPath storj.Path

--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -161,7 +161,7 @@ func (c Config) GetBucketStore(ctx context.Context, identity *provider.FullIdent
 		return nil, err
 	}
 
-	return buckets.NewStore(stream, storj.Cipher(c.PathEncType)), nil
+	return buckets.NewStore(stream), nil
 }
 
 // NewGateway creates a new minio Gateway
@@ -173,5 +173,5 @@ func (c Config) NewGateway(ctx context.Context, identity *provider.FullIdentity)
 		return nil, err
 	}
 
-	return NewStorjGateway(bs), nil
+	return NewStorjGateway(bs, storj.Cipher(c.PathEncType)), nil
 }

--- a/pkg/miniogw/gateway-storj_test.go
+++ b/pkg/miniogw/gateway-storj_test.go
@@ -507,7 +507,7 @@ func TestMakeBucketWithLocation(t *testing.T) {
 		errTag := fmt.Sprintf("Test case #%d", i)
 		mockBS.EXPECT().Get(gomock.Any(), gomock.Any()).Return(buckets.Meta{Created: exp}, example.bucketStatus)
 		if storage.ErrKeyNotFound.Has(example.bucketStatus) {
-			mockBS.EXPECT().Put(gomock.Any(), example.bucket).Return(buckets.Meta{Created: example.meta}, nil)
+			mockBS.EXPECT().Put(gomock.Any(), example.bucket, gomock.Any()).Return(buckets.Meta{Created: example.meta}, nil)
 		}
 
 		err := storjObj.MakeBucketWithLocation(ctx, example.bucket, "location")

--- a/pkg/storage/buckets/mocks/mock_buckets.go
+++ b/pkg/storage/buckets/mocks/mock_buckets.go
@@ -6,12 +6,11 @@ package buckets
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
-
+	reflect "reflect"
 	buckets "storj.io/storj/pkg/storage/buckets"
 	objects "storj.io/storj/pkg/storage/objects"
+	storj "storj.io/storj/pkg/storj"
 )
 
 // MockStore is a mock of Store interface
@@ -90,14 +89,14 @@ func (mr *MockStoreMockRecorder) List(arg0, arg1, arg2, arg3 interface{}) *gomoc
 }
 
 // Put mocks base method
-func (m *MockStore) Put(arg0 context.Context, arg1 string) (buckets.Meta, error) {
-	ret := m.ctrl.Call(m, "Put", arg0, arg1)
+func (m *MockStore) Put(arg0 context.Context, arg1 string, arg2 storj.Cipher) (buckets.Meta, error) {
+	ret := m.ctrl.Call(m, "Put", arg0, arg1, arg2)
 	ret0, _ := ret[0].(buckets.Meta)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Put indicates an expected call of Put
-func (mr *MockStoreMockRecorder) Put(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockStore)(nil).Put), arg0, arg1)
+func (mr *MockStoreMockRecorder) Put(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockStore)(nil).Put), arg0, arg1, arg2)
 }

--- a/pkg/storj/object.go
+++ b/pkg/storj/object.go
@@ -14,8 +14,9 @@ var ErrNoBucket = errs.Class("no bucket specified")
 
 // Bucket contains information about a specific bucket
 type Bucket struct {
-	Name    string
-	Created time.Time
+	Name       string
+	Created    time.Time
+	PathCipher Cipher
 }
 
 // Object contains information about a specific object


### PR DESCRIPTION
This is improvement over #637.

- Adds the path encryption configuration feature to the new metainfo API
- Allows `uplink mb` command to override the default configuration in `config.yaml` by passing the `--path-enc-type` option in the CLI.