### PR TITLE
Adding a "Version: Alpha" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/storj/storj)](https://goreportcard.com/report/github.com/storj/storj)
 [![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](http://godoc.org/github.com/storj/storj)
 [![Coverage Status](https://coveralls.io/repos/github/storj/storj/badge.svg?branch=master)](https://coveralls.io/github/storj/storj?branch=master)
+![Alpha](https://img.shields.io/badge/version-alpha-green.svg)
 
 <img src="https://github.com/storj/storj/raw/master/resources/logo.png" width="100">
 


### PR DESCRIPTION
Because I think it will help. I wish I could link it to something that easily explains what the alpha is, but I am not sure if there is a specific resource that would answer that question - and only that question - more adequately than the rest of the README.