### PR TITLE
Fix default basepath location

### DIFF
--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -5,11 +5,8 @@ package cmd
 
 import (
 	"context"
-<<<<<<< HEAD
 	"fmt"
-=======
 	"os"
->>>>>>> replaces makeUplinkPath with applicationDir func
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -51,10 +48,11 @@ func applicationDir(subdir ...string) string {
 		}
 	}
 	home := os.Getenv("HOME")
-	appdir := filepath.Join(home, "Library", "Application Support")
+	var appdir string
 
 	switch runtime.GOOS {
 	case "windows":
+		// Windows standards: https://msdn.microsoft.com/en-us/library/windows/apps/hh465094.aspx?f=255&MSPPError=-2147217396
 		for _, env := range []string{"AppData", "AppDataLocal", "UserProfile", "Home"} {
 			val := os.Getenv(env)
 			if val != "" {

--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -47,7 +47,6 @@ func applicationDir(subdir ...string) string {
 			subdir[i] = strings.ToLower(subdir[i])
 		}
 	}
-	home := os.Getenv("HOME")
 	var appdir string
 
 	switch runtime.GOOS {
@@ -62,16 +61,18 @@ func applicationDir(subdir ...string) string {
 		}
 	case "darwin":
 		// Mac standards: https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html
+		home := os.Getenv("HOME")
 		appdir = filepath.Join(home, "Library", "Application Support")
 	case "linux":
 		fallthrough
 	default:
 		// XDG standards: https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
 		for _, env := range []string{"XDG_DATA_HOME", "HOME"} {
-			appdir = os.Getenv(env)
-		}
-		if appdir == "" {
-			appdir = home
+			val := os.Getenv(env)
+			if val != "" {
+				appdir = val
+				break
+			}
 		}
 	}
 	return filepath.Join(append([]string{appdir}, subdir...)...)

--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -67,7 +67,9 @@ func applicationDir(subdir ...string) string {
 		fallthrough
 	default:
 		// XDG standards: https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
-		appdir = os.Getenv("XDG_DATA_HOME")
+		for _, env := range []string{"XDG_DATA_HOME", "HOME"} {
+			appdir = os.Getenv(env)
+		}
 		if appdir == "" {
 			appdir = home
 		}

--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"path/filepath"
 
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 
 	"storj.io/storj/internal/fpath"
 	"storj.io/storj/pkg/cfgstruct"
@@ -16,8 +18,6 @@ import (
 	"storj.io/storj/pkg/storage/buckets"
 	"storj.io/storj/pkg/storj"
 )
-
-const defaultConfDir = "$HOME/.storj/uplink"
 
 // Config is miniogw.Config configuration
 type Config struct {
@@ -38,8 +38,19 @@ var GWCmd = &cobra.Command{
 	Short: "The Storj client-side S3 gateway",
 }
 
+func makeUplinkPath() (defaultConfDir string) {
+	base, err := homedir.Dir()
+	if err != nil {
+		zap.S().Errorf("error setting up uplink directory path: %s", err)
+		return ""
+	}
+	return filepath.Join(base, ".storj", "uplink")
+}
+
 func addCmd(cmd *cobra.Command, root *cobra.Command) *cobra.Command {
 	root.AddCommand(cmd)
+
+	defaultConfDir := makeUplinkPath()
 	cfgstruct.Bind(cmd.Flags(), &cfg, cfgstruct.ConfDir(defaultConfDir))
 	cmd.Flags().String("config", filepath.Join(defaultConfDir, "config.yaml"), "path to configuration")
 	return cmd

--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -36,6 +36,7 @@ var (
 )
 
 func init() {
+	defaultConfDir := makeUplinkPath()
 	CLICmd.AddCommand(setupCmd)
 	GWCmd.AddCommand(setupCmd)
 	cfgstruct.Bind(setupCmd.Flags(), &setupCfg, cfgstruct.ConfDir(defaultConfDir))
@@ -61,6 +62,7 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
+	defaultConfDir := makeUplinkPath()
 	// TODO: handle setting base path *and* identity file paths via args
 	// NB: if base path is set this overrides identity and CA path options
 	if setupCfg.BasePath != defaultConfDir {

--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -36,7 +36,7 @@ var (
 )
 
 func init() {
-	defaultConfDir := makeUplinkPath()
+	defaultConfDir := applicationDir("storj", "uplink")
 	CLICmd.AddCommand(setupCmd)
 	GWCmd.AddCommand(setupCmd)
 	cfgstruct.Bind(setupCmd.Flags(), &setupCfg, cfgstruct.ConfDir(defaultConfDir))
@@ -62,7 +62,7 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	defaultConfDir := makeUplinkPath()
+	defaultConfDir := applicationDir("storj", "uplink")
 	// TODO: handle setting base path *and* identity file paths via args
 	// NB: if base path is set this overrides identity and CA path options
 	if setupCfg.BasePath != defaultConfDir {

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/minio/minio-go v6.0.3+incompatible
 	github.com/minio/sha256-simd v0.0.0-20171213220625-ad98a36ba0da // indirect
 	github.com/minio/sio v0.0.0-20180327104954-6a41828a60f0 // indirect
-	github.com/mitchellh/go-homedir v0.0.0-20180801233206-58046073cbff // indirect
+	github.com/mitchellh/go-homedir v0.0.0-20180801233206-58046073cbff
 	github.com/mr-tron/base58 v0.0.0-20180922112544-9ad991d48a42
 	github.com/nats-io/gnatsd v1.3.0 // indirect
 	github.com/nats-io/go-nats v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/minio/minio-go v6.0.3+incompatible
 	github.com/minio/sha256-simd v0.0.0-20171213220625-ad98a36ba0da // indirect
 	github.com/minio/sio v0.0.0-20180327104954-6a41828a60f0 // indirect
-	github.com/mitchellh/go-homedir v0.0.0-20180801233206-58046073cbff
+	github.com/mitchellh/go-homedir v0.0.0-20180801233206-58046073cbff // indirect
 	github.com/mr-tron/base58 v0.0.0-20180922112544-9ad991d48a42
 	github.com/nats-io/gnatsd v1.3.0 // indirect
 	github.com/nats-io/go-nats v1.6.0 // indirect


### PR DESCRIPTION
This pr detects the user's home directory, so that the uplink's default config directory will be located according to the OS's standards.

One problem though is that some of these directory paths look inconsistent in the help text because of escaped strings, e.g. for ca.cert-path, ca.key-path, identity.cert-path, and identity.key-path, so those still need to be changed.

<img width="1171" alt="screen shot 2018-11-19 at 2 05 22 pm" src="https://user-images.githubusercontent.com/26885324/48730168-8f6cd280-ec07-11e8-9348-197806eba6ba.png">