### PR TITLE
eestream avoids waiting for pending readers if lots of errors

### DIFF
--- a/pkg/eestream/stripe.go
+++ b/pkg/eestream/stripe.go
@@ -132,7 +132,8 @@ func (r *StripeReader) readAvailableShares(num int64) (n int) {
 
 // pendingReaders checks if there are any pending readers to get a share from.
 func (r *StripeReader) pendingReaders() bool {
-	return len(r.inmap)+len(r.errmap) < r.readerCount
+	goodReaders := r.readerCount - len(r.errmap)
+	return goodReaders >= r.scheme.RequiredCount() && goodReaders > len(r.inmap)
 }
 
 // hasEnoughShares check if there are enough erasure shares read to attempt


### PR DESCRIPTION
Fixes https://storjlabs.atlassian.net/browse/V3-551

If enough readers have already failed with error (so that there is no chance to reconstruct the stripe), the StripeReader should return an error immediately instead of waiting for the rest (potentially stalled) readers to return their erasure shares.