### PR TITLE
Fix panic in Audit service

### DIFF
--- a/pkg/audit/verifier.go
+++ b/pkg/audit/verifier.go
@@ -38,7 +38,7 @@ type Verifier struct {
 }
 
 type downloader interface {
-	DownloadShares(ctx context.Context, pointer *pb.Pointer, stripeIndex int, authorization *pb.SignedMessage) (shares []share, nodes []*pb.Node, err error)
+	DownloadShares(ctx context.Context, pointer *pb.Pointer, stripeIndex int, authorization *pb.SignedMessage) (shares map[int]share, nodes map[int]*pb.Node, err error)
 }
 
 // defaultDownloader downloads shares from networked storage nodes
@@ -118,8 +118,9 @@ func (d *defaultDownloader) getShare(ctx context.Context, stripeIndex, shareSize
 
 // Download Shares downloads shares from the nodes where remote pieces are located
 func (d *defaultDownloader) DownloadShares(ctx context.Context, pointer *pb.Pointer,
-	stripeIndex int, authorization *pb.SignedMessage) (shares []share, nodes []*pb.Node, err error) {
+	stripeIndex int, authorization *pb.SignedMessage) (shares map[int]share, nodes map[int]*pb.Node, err error) {
 	defer mon.Task()(&ctx)(&err)
+
 	var nodeIds []dht.NodeID
 	pieces := pointer.Remote.GetRemotePieces()
 
@@ -127,17 +128,20 @@ func (d *defaultDownloader) DownloadShares(ctx context.Context, pointer *pb.Poin
 		nodeIds = append(nodeIds, node.IDFromString(p.GetNodeId()))
 	}
 
-	// TODO(moby) nodes will not include offline nodes, so overlay should update uptime for these nodes
-	nodes, err = d.overlay.BulkLookup(ctx, nodeIds)
+	// TODO(moby) nodeSlice will not include offline nodes, so overlay should update uptime for these nodes
+	nodeSlice, err := d.overlay.BulkLookup(ctx, nodeIds)
 	if err != nil {
 		return nil, nodes, err
 	}
+
+	shares = make(map[int]share, len(nodeSlice))
+	nodes = make(map[int]*pb.Node, len(nodeSlice))
 
 	shareSize := int(pointer.Remote.Redundancy.GetErasureShareSize())
 	pieceID := psclient.PieceID(pointer.Remote.GetPieceId())
 
 	// this downloads shares from nodes at the given stripe index
-	for i, node := range nodes {
+	for i, node := range nodeSlice {
 		paddedSize := calcPadded(pointer.GetSegmentSize(), shareSize)
 		pieceSize := paddedSize / int64(pointer.Remote.Redundancy.GetMinReq())
 
@@ -149,13 +153,15 @@ func (d *defaultDownloader) DownloadShares(ctx context.Context, pointer *pb.Poin
 				Data:        nil,
 			}
 		}
-		shares = append(shares, s)
+
+		shares[s.PieceNumber] = s
+		nodes[s.PieceNumber] = node
 	}
 
 	return shares, nodes, nil
 }
 
-func makeCopies(ctx context.Context, originals []share) (copies []infectious.Share, err error) {
+func makeCopies(ctx context.Context, originals map[int]share) (copies []infectious.Share, err error) {
 	defer mon.Task()(&ctx)(&err)
 	copies = make([]infectious.Share, 0, len(originals))
 	for _, original := range originals {
@@ -171,7 +177,7 @@ func makeCopies(ctx context.Context, originals []share) (copies []infectious.Sha
 
 // auditShares takes the downloaded shares and uses infectious's Correct function to check that they
 // haven't been altered. auditShares returns a slice containing the piece numbers of altered shares.
-func auditShares(ctx context.Context, required, total int, originals []share) (pieceNums []int, err error) {
+func auditShares(ctx context.Context, required, total int, originals map[int]share) (pieceNums []int, err error) {
 	defer mon.Task()(&ctx)(&err)
 	f, err := infectious.NewFEC(required, total)
 	if err != nil {
@@ -187,8 +193,8 @@ func auditShares(ctx context.Context, required, total int, originals []share) (p
 	if err != nil {
 		return nil, err
 	}
-	for i, share := range copies {
-		if !bytes.Equal(originals[i].Data, share.Data) {
+	for _, share := range copies {
+		if !bytes.Equal(originals[share.Number].Data, share.Data) {
 			pieceNums = append(pieceNums, share.Number)
 		}
 	}
@@ -213,9 +219,9 @@ func (verifier *Verifier) verify(ctx context.Context, stripeIndex int, pointer *
 	}
 
 	var offlineNodes []string
-	for i := range shares {
-		if shares[i].Error != nil {
-			offlineNodes = append(offlineNodes, nodes[i].GetId())
+	for pieceNum := range shares {
+		if shares[pieceNum].Error != nil {
+			offlineNodes = append(offlineNodes, nodes[pieceNum].GetId())
 		}
 	}
 
@@ -232,13 +238,13 @@ func (verifier *Verifier) verify(ctx context.Context, stripeIndex int, pointer *
 	}
 
 	successNodes := getSuccessNodes(ctx, nodes, failedNodes, offlineNodes)
-	verifiedNodes = setVerifiedNodes(ctx, nodes, offlineNodes, failedNodes, successNodes)
+	verifiedNodes = setVerifiedNodes(ctx, offlineNodes, failedNodes, successNodes)
 
 	return verifiedNodes, nil
 }
 
 // getSuccessNodes uses the failed nodes and offline nodes arrays to determine which nodes passed the audit
-func getSuccessNodes(ctx context.Context, nodes []*pb.Node, failedNodes, offlineNodes []string) (successNodes []string) {
+func getSuccessNodes(ctx context.Context, nodes map[int]*pb.Node, failedNodes, offlineNodes []string) (successNodes []string) {
 	fails := make(map[string]bool)
 	for _, fail := range failedNodes {
 		fails[fail] = true
@@ -256,7 +262,7 @@ func getSuccessNodes(ctx context.Context, nodes []*pb.Node, failedNodes, offline
 }
 
 // setVerifiedNodes creates a combined array of offline nodes, failed audit nodes, and success nodes with their stats set to the statdb proto Node type
-func setVerifiedNodes(ctx context.Context, nodes []*pb.Node, offlineNodes, failedNodes, successNodes []string) (verifiedNodes []*sdbproto.Node) {
+func setVerifiedNodes(ctx context.Context, offlineNodes, failedNodes, successNodes []string) (verifiedNodes []*sdbproto.Node) {
 	offlineStatusNodes := setOfflineStatus(ctx, offlineNodes)
 	failStatusNodes := setAuditFailStatus(ctx, failedNodes)
 	successStatusNodes := setSuccessStatus(ctx, successNodes)

--- a/pkg/audit/verifier_test.go
+++ b/pkg/audit/verifier_test.go
@@ -136,11 +136,12 @@ func TestFailingAudit(t *testing.T) {
 	badPieceNums := []int{0, 2, 3, 4}
 
 	ctx := context.Background()
-	auditPkgShares := make([]share, len(modifiedShares))
+	auditPkgShares := make(map[int]share, len(modifiedShares))
 	for i := range modifiedShares {
-		auditPkgShares[i].PieceNumber = modifiedShares[i].Number
-		auditPkgShares[i].Data = append([]byte(nil), modifiedShares[i].Data...)
-		auditPkgShares[i].Error = nil
+		auditPkgShares[modifiedShares[i].Number] = share{
+			PieceNumber: modifiedShares[i].Number,
+			Data:        append([]byte(nil), modifiedShares[i].Data...),
+		}
 	}
 	pieceNums, err := auditShares(ctx, 8, 14, auditPkgShares)
 	if err != nil {
@@ -177,11 +178,12 @@ func TestNotEnoughShares(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	auditPkgShares := make([]share, len(shares))
+	auditPkgShares := make(map[int]share, len(shares))
 	for i := range shares {
-		auditPkgShares[i].PieceNumber = shares[i].Number
-		auditPkgShares[i].Data = append([]byte(nil), shares[i].Data...)
-		auditPkgShares[i].Error = nil
+		auditPkgShares[shares[i].Number] = share{
+			PieceNumber: shares[i].Number,
+			Data:        append([]byte(nil), shares[i].Data...),
+		}
 	}
 	_, err = auditShares(ctx, 20, 40, auditPkgShares)
 	assert.Contains(t, err.Error(), "infectious: must specify at least the number of required shares")
@@ -202,20 +204,19 @@ func TestCalcPadded(t *testing.T) {
 }
 
 func (m *mockDownloader) DownloadShares(ctx context.Context, pointer *pb.Pointer,
-	stripeIndex int, authorization *pb.SignedMessage) (shares []share, nodes []*pb.Node, err error) {
-	for _, share := range m.shares {
-		shares = append(shares, share)
-	}
+	stripeIndex int, authorization *pb.SignedMessage) (shares map[int]share, nodes map[int]*pb.Node, err error) {
+
+	nodes = make(map[int]*pb.Node, 30)
+
 	for i := 0; i < 30; i++ {
-		node := &pb.Node{
+		nodes[i] = &pb.Node{
 			Id: strconv.Itoa(i),
 			Address: &pb.NodeAddress{
 				Address: strconv.Itoa(i),
 			},
 		}
-		nodes = append(nodes, node)
 	}
-	return shares, nodes, nil
+	return m.shares, nodes, nil
 }
 
 func makePointer(nodeAmt int) *pb.Pointer {


### PR DESCRIPTION
Fixes https://storjlabs.atlassian.net/browse/V3-841

There were two issues in the code:
1. Accessing a node in the `verify` method via `nodes[pieceNum]` may panic, because the `nodes` slice was not guaranteed to include a node for each piece. If a specific piece was not uploaded successfully to the respective node, then this node is not included in the segment pointer and hence won't be part in the `nodes` slice. The solution is to convert `nodes` from slice to a map with the piece number as its key.
1. The `auditShares` method assumed that the `copies` slice returned by the `makeCopies` method is the same size as the `originals` slice. This assumption is wrong when downloading a share failed with error. In such case `makeCopies` will return a shorter `copies` slice. Therefore, the `auditShares` may compare the data of original and copy share with different piece numbers, which result in false positive result. The solution was again to convert the `originals` slice to a map.