### PR TITLE
testcontext: Add stack-trace and remove testcase with testing

### DIFF
--- a/internal/testcontext/context.go
+++ b/internal/testcontext/context.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+
+	"storj.io/storj/internal/memory"
 )
 
 const defaultTimeout = 3 * time.Minute
@@ -179,7 +181,13 @@ func (ctx *Context) reportRunning() {
 			fmt.Fprintf(&message, "\n%s:%d: %s", caller.file, caller.line, fnname)
 		}
 	}
+
 	ctx.test.Error(message.String())
+
+	stack := make([]byte, 1*memory.MB.Int())
+	n := runtime.Stack(stack, true)
+	stack = stack[:n]
+	ctx.test.Error("Full Stack Trace:\n", string(stack))
 }
 
 // deleteTemporary tries to delete temporary directory

--- a/internal/testcontext/context_test.go
+++ b/internal/testcontext/context_test.go
@@ -26,25 +26,6 @@ func TestBasic(t *testing.T) {
 	t.Log(ctx.File("a", "w", "c.txt"))
 }
 
-func TestTimeout(t *testing.T) {
-	ok := testing.RunTests(nil, []testing.InternalTest{{
-		Name: "TimeoutFailure",
-		F: func(t *testing.T) {
-			ctx := testcontext.NewWithTimeout(t, 50*time.Millisecond)
-			defer ctx.Cleanup()
-
-			ctx.Go(func() error {
-				time.Sleep(time.Second)
-				return nil
-			})
-		},
-	}})
-
-	if ok {
-		t.Error("test should have failed")
-	}
-}
-
 func TestMessage(t *testing.T) {
 	var subtest test
 
@@ -57,6 +38,8 @@ func TestMessage(t *testing.T) {
 
 	assert.Contains(t, subtest.errors[0], "Test exceeded timeout")
 	assert.Contains(t, subtest.errors[0], "some goroutines are still running")
+
+	assert.Contains(t, subtest.errors[1], "TestMessage")
 }
 
 type test struct {


### PR DESCRIPTION
1. Added full stack-trace to when test exceeds timeout for debugging.
2. Removed testcase which uses testing.T directly. There's no easy way to start a silent testing.T, so it still prints info to stdout, which makes the output in Travis confusing.