### PR TITLE
fixes Linux default base path for uplink

### DIFF
--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -48,6 +48,7 @@ func applicationDir(subdir ...string) string {
 		}
 	}
 	var appdir string
+	home := os.Getenv("HOME")
 
 	switch runtime.GOOS {
 	case "windows":
@@ -61,18 +62,15 @@ func applicationDir(subdir ...string) string {
 		}
 	case "darwin":
 		// Mac standards: https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/MacOSXDirectories/MacOSXDirectories.html
-		home := os.Getenv("HOME")
 		appdir = filepath.Join(home, "Library", "Application Support")
 	case "linux":
 		fallthrough
 	default:
 		// Linux standards: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-		home := os.Getenv("XDG_DATA_HOME")
-		if home == "" {
-			home = os.Getenv("HOME")
-			home = filepath.Join(home, ".local", "share")
+		appdir = os.Getenv("XDG_DATA_HOME")
+		if appdir == "" && home != "" {
+			appdir = filepath.Join(home, ".local", "share")
 		}
-		appdir = home
 	}
 	return filepath.Join(append([]string{appdir}, subdir...)...)
 }

--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -66,14 +66,13 @@ func applicationDir(subdir ...string) string {
 	case "linux":
 		fallthrough
 	default:
-		// XDG standards: https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
-		for _, env := range []string{"XDG_DATA_HOME", "HOME"} {
-			val := os.Getenv(env)
-			if val != "" {
-				appdir = val
-				break
-			}
+		// Linux standards: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+		home := os.Getenv("XDG_DATA_HOME")
+		if home == "" {
+			home = os.Getenv("HOME")
+			home = filepath.Join(home, ".local", "share")
 		}
+		appdir = home
 	}
 	return filepath.Join(append([]string{appdir}, subdir...)...)
 }


### PR DESCRIPTION
Changes the uplink directory base path following these standards:

> $XDG_DATA_HOME defines the base directory relative to which user specific data files should be stored. If $XDG_DATA_HOME is either not set or empty, a default equal to $HOME/.local/share should be used.
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html