### PR TITLE
added tally to capt run.go

### DIFF
--- a/cmd/captplanet/run.go
+++ b/cmd/captplanet/run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/zeebo/errs"
 
+	"storj.io/storj/pkg/accounting/tally"
 	"storj.io/storj/pkg/audit"
 	"storj.io/storj/pkg/auth/grpcauth"
 	"storj.io/storj/pkg/bwagreement"
@@ -50,6 +51,7 @@ type Satellite struct {
 	BwAgreement bwagreement.Config
 	Web         satelliteweb.Config
 	Database    string `help:"satellite database connection string" default:"sqlite3://$CONFDIR/master.db"`
+	Tally       tally.Config
 }
 
 // StorageNode is for configuring storage nodes
@@ -133,6 +135,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 			runCfg.Satellite.Repairer,
 			runCfg.Satellite.BwAgreement,
 			runCfg.Satellite.Web,
+			runCfg.Satellite.Tally,
 
 			// NB(dylan): Inspector is only used for local development and testing.
 			// It should not be added to the Satellite startup

--- a/pkg/accounting/db.go
+++ b/pkg/accounting/db.go
@@ -21,19 +21,19 @@ var (
 
 // NewDb - constructor for DB
 func NewDb(databaseURL string) (*dbx.DB, error) {
-	dbURL, err := utils.ParseURL(databaseURL)
+	driver, source, err := utils.SplitDBURL(databaseURL)
 	if err != nil {
-		return nil, err
+		return nil, Error.Wrap(err)
 	}
-	db, err := dbx.Open(dbURL.Scheme, dbURL.Path)
+	db, err := dbx.Open(driver, source)
 	if err != nil {
 		return nil, Error.New("failed opening database %q, %q: %v",
-			dbURL.Scheme, dbURL.Path, err)
+			driver, source, err)
 	}
 	err = migrate.Create("accounting", db)
 	if err != nil {
 		_ = db.Close()
-		return nil, err
+		return nil, Error.Wrap(err)
 	}
 	return db, nil
 }

--- a/pkg/accounting/rollup/config.go
+++ b/pkg/accounting/rollup/config.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-
 	"storj.io/storj/pkg/accounting"
 	"storj.io/storj/pkg/provider"
 )
@@ -23,7 +22,7 @@ type Config struct {
 func (c Config) initialize(ctx context.Context) (Rollup, error) {
 	db, err := accounting.NewDb(c.DatabaseURL)
 	if err != nil {
-		return nil, err
+		return nil, Error.Wrap(err)
 	}
 	return newRollup(zap.L(), db, c.Interval)
 }
@@ -32,7 +31,7 @@ func (c Config) initialize(ctx context.Context) (Rollup, error) {
 func (c Config) Run(ctx context.Context, server *provider.Provider) (err error) {
 	rollup, err := c.initialize(ctx)
 	if err != nil {
-		return err
+		return Error.Wrap(err)
 	}
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/pkg/accounting/tally/config.go
+++ b/pkg/accounting/tally/config.go
@@ -21,7 +21,7 @@ import (
 // Config contains configurable values for tally
 type Config struct {
 	Interval    time.Duration `help:"how frequently tally should run" default:"30s"`
-	DatabaseURL string        `help:"the database connection string to use" default:"sqlite3://$CONFDIR/stats.db"`
+	DatabaseURL string        `help:"the database connection string to use" default:"sqlite3://$CONFDIR/accounting.db"`
 }
 
 // Initialize a tally struct
@@ -31,7 +31,7 @@ func (c Config) initialize(ctx context.Context) (Tally, error) {
 	kademlia := kademlia.LoadFromContext(ctx)
 	db, err := accounting.NewDb(c.DatabaseURL)
 	if err != nil {
-		return nil, err
+		return nil, Error.Wrap(err)
 	}
 
 	masterDB, ok := ctx.Value("masterdb").(interface{ BandwidthAgreement() bwagreement.DB })
@@ -45,7 +45,7 @@ func (c Config) initialize(ctx context.Context) (Tally, error) {
 func (c Config) Run(ctx context.Context, server *provider.Provider) (err error) {
 	tally, err := c.initialize(ctx)
 	if err != nil {
-		return err
+		return Error.Wrap(err)
 	}
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/pkg/accounting/tally/tally.go
+++ b/pkg/accounting/tally/tally.go
@@ -98,9 +98,7 @@ func (t *tally) identifyActiveNodes(ctx context.Context) (err error) {
 				if err != nil {
 					return Error.Wrap(err)
 				}
-				if pointer.Remote == nil {
-					t.logger.Warn("MISSING pointer.Remote")
-				} else {
+				if pointer.Remote != nil {
 					pieces := pointer.Remote.RemotePieces
 					var nodeIDs storj.NodeIDList
 					for _, p := range pieces {

--- a/pkg/overlay/config.go
+++ b/pkg/overlay/config.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"
-
 	monkit "gopkg.in/spacemonkeygo/monkit.v2"
+
 	"storj.io/storj/pkg/kademlia"
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/provider"
@@ -66,16 +66,16 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) (
 		return Error.New("programmer error: statdb responsibility unstarted")
 	}
 
-	dburl, err := utils.ParseURL(c.DatabaseURL)
+	driver, source, err := utils.SplitDBURL(c.DatabaseURL)
 	if err != nil {
 		return Error.Wrap(err)
 	}
 
 	var db storage.KeyValueStore
 
-	switch dburl.Scheme {
+	switch driver {
 	case "bolt":
-		db, err = boltdb.New(dburl.Path, OverlayBucket)
+		db, err = boltdb.New(source, OverlayBucket)
 		if err != nil {
 			return err
 		}
@@ -87,7 +87,7 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) (
 		}
 		zap.S().Info("Starting overlay cache with Redis")
 	default:
-		return Error.New("database scheme not supported: %s", dburl.Scheme)
+		return Error.New("database scheme not supported: %s", driver)
 	}
 
 	cache := NewOverlayCache(db, kad, sdb)

--- a/pkg/overlay/config_test.go
+++ b/pkg/overlay/config_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"storj.io/storj/pkg/kademlia"
 	"storj.io/storj/pkg/statdb"
 )
@@ -31,7 +30,7 @@ func TestRun(t *testing.T) {
 	// run with nil, pass pointer to Kademlia in context
 	err = Config{}.Run(ctx, nil)
 	assert.Error(t, err)
-	assert.Equal(t, "overlay error: database scheme not supported: ", err.Error())
+	assert.Equal(t, "overlay error: Could not parse DB URL ", err.Error())
 
 	// db scheme redis conn fail
 	err = Config{DatabaseURL: "redis://somedir/overlay.db/?db=1"}.Run(ctx, nil)

--- a/pkg/pointerdb/config.go
+++ b/pkg/pointerdb/config.go
@@ -37,16 +37,16 @@ type Config struct {
 }
 
 func newKeyValueStore(dbURLString string) (db storage.KeyValueStore, err error) {
-	dburl, err := utils.ParseURL(dbURLString)
+	driver, source, err := utils.SplitDBURL(dbURLString)
 	if err != nil {
 		return nil, err
 	}
-	if dburl.Scheme == "bolt" {
-		db, err = boltdb.New(dburl.Path, BoltPointerBucket)
-	} else if dburl.Scheme == "postgresql" || dburl.Scheme == "postgres" {
-		db, err = postgreskv.New(dbURLString)
+	if driver == "bolt" {
+		db, err = boltdb.New(source, BoltPointerBucket)
+	} else if driver == "postgresql" || driver == "postgres" {
+		db, err = postgreskv.New(source)
 	} else {
-		err = Error.New("unsupported db scheme: %s", dburl.Scheme)
+		err = Error.New("unsupported db scheme: %s", driver)
 	}
 	return db, err
 }

--- a/pkg/satellite/satellitedb/db.go
+++ b/pkg/satellite/satellitedb/db.go
@@ -29,7 +29,6 @@ type Database struct {
 // New - constructor for DB
 func New(driver, source string) (*Database, error) {
 	db, err := dbx.Open(driver, source)
-
 	if err != nil {
 		return nil, Error.New("failed opening database %q, %q: %v",
 			driver, source, err)
@@ -68,7 +67,6 @@ func (db *Database) CreateTables() error {
 	if db.db == nil {
 		return errs.New("Connection is closed")
 	}
-
 	return migrate.Create("satellitedb", db.db)
 }
 
@@ -77,7 +75,6 @@ func (db *Database) Close() error {
 	if db.db == nil {
 		return errs.New("Connection is closed")
 	}
-
 	return db.db.Close()
 }
 

--- a/pkg/satellite/satelliteweb/config.go
+++ b/pkg/satellite/satelliteweb/config.go
@@ -29,12 +29,12 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) error {
 	log := zap.NewExample()
 
 	// Create satellite DB
-	dbURL, err := utils.ParseURL(c.DatabaseURL)
+	driver, source, err := utils.SplitDBURL(c.DatabaseURL)
 	if err != nil {
 		return err
 	}
 
-	db, err := satellitedb.New(dbURL.Scheme, dbURL.Path)
+	db, err := satellitedb.New(driver, source)
 	if err != nil {
 		return err
 	}

--- a/pkg/statdb/statdb_test.go
+++ b/pkg/statdb/statdb_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-
 	"storj.io/storj/internal/teststorj"
 	"storj.io/storj/pkg/statdb"
 	dbx "storj.io/storj/pkg/statdb/dbx"

--- a/satellite/satellitedb/database.go
+++ b/satellite/satellitedb/database.go
@@ -23,22 +23,17 @@ type DB struct {
 	db *dbx.DB
 }
 
-// New creates instance of satellite database (supports: postgres, sqlite3)
+// New creates instance of database (supports: postgres, sqlite3)
 func New(databaseURL string) (*DB, error) {
-	dbURL, err := utils.ParseURL(databaseURL)
+	driver, source, err := utils.SplitDBURL(databaseURL)
 	if err != nil {
 		return nil, err
 	}
-	source := databaseURL
-	if dbURL.Scheme == "sqlite3" {
-		source = dbURL.Path
-	}
-	db, err := dbx.Open(dbURL.Scheme, source)
+	db, err := dbx.Open(driver, source)
 	if err != nil {
 		return nil, Error.New("failed opening database %q, %q: %v",
-			dbURL.Scheme, source, err)
+			driver, source, err)
 	}
-
 	return &DB{db: db}, nil
 }
 

--- a/satellite/satellitedb/irreparabledb.go
+++ b/satellite/satellitedb/irreparabledb.go
@@ -19,7 +19,7 @@ type irreparableDB struct {
 func (db *irreparableDB) IncrementRepairAttempts(ctx context.Context, segmentInfo *irreparable.RemoteSegmentInfo) (err error) {
 	tx, err := db.db.Begin()
 	if err != nil {
-		return err
+		return Error.Wrap(err)
 	}
 
 	dbxInfo, err := db.Get(ctx, segmentInfo.EncryptedSegmentPath)
@@ -34,7 +34,7 @@ func (db *irreparableDB) IncrementRepairAttempts(ctx context.Context, segmentInf
 			dbx.Irreparabledb_RepairAttemptCount(segmentInfo.RepairAttemptCount),
 		)
 		if err != nil {
-			return utils.CombineErrors(err, tx.Rollback())
+			return Error.Wrap(utils.CombineErrors(err, tx.Rollback()))
 		}
 	} else {
 		// row exits increment the attempt counter
@@ -47,18 +47,18 @@ func (db *irreparableDB) IncrementRepairAttempts(ctx context.Context, segmentInf
 			updateFields,
 		)
 		if err != nil {
-			return utils.CombineErrors(err, tx.Rollback())
+			return Error.Wrap(utils.CombineErrors(err, tx.Rollback()))
 		}
 	}
 
-	return tx.Commit()
+	return Error.Wrap(tx.Commit())
 }
 
 // Get a irreparable's segment info from the db
 func (db *irreparableDB) Get(ctx context.Context, segmentPath []byte) (resp *irreparable.RemoteSegmentInfo, err error) {
 	dbxInfo, err := db.db.Get_Irreparabledb_By_Segmentpath(ctx, dbx.Irreparabledb_Segmentpath(segmentPath))
 	if err != nil {
-		return &irreparable.RemoteSegmentInfo{}, err
+		return &irreparable.RemoteSegmentInfo{}, Error.Wrap(err)
 	}
 
 	return &irreparable.RemoteSegmentInfo{
@@ -74,5 +74,5 @@ func (db *irreparableDB) Get(ctx context.Context, segmentPath []byte) (resp *irr
 func (db *irreparableDB) Delete(ctx context.Context, segmentPath []byte) (err error) {
 	_, err = db.db.Delete_Irreparabledb_By_Segmentpath(ctx, dbx.Irreparabledb_Segmentpath(segmentPath))
 
-	return err
+	return Error.Wrap(err)
 }

--- a/storage/redis/client.go
+++ b/storage/redis/client.go
@@ -4,14 +4,13 @@
 package redis
 
 import (
+	"net/url"
 	"sort"
 	"strconv"
 	"time"
 
 	"github.com/go-redis/redis"
 	"github.com/zeebo/errs"
-
-	"storj.io/storj/pkg/utils"
 	"storj.io/storj/storage"
 )
 
@@ -49,7 +48,7 @@ func NewClient(address, password string, db int) (*Client, error) {
 
 // NewClientFrom returns a configured Client instance from a redis address, verifying a successful connection to redis
 func NewClientFrom(address string) (*Client, error) {
-	redisurl, err := utils.ParseURL(address)
+	redisurl, err := url.Parse(address)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Integrate tally service with Captplanet

Acceptance criteria:
- Add a config struct to captplanet so that the tally service starts automatically.
- The Tally service starts when you run captplanet