### PR TITLE
Draft implementation - Kademlia event hooks

### DIFF
--- a/pkg/emitter/README.md
+++ b/pkg/emitter/README.md
@@ -1,0 +1,76 @@
+emitter
+--------
+
+A simple event emitter for Go.
+
+## Usage
+
+If you've ever used an event emitter before, using Emission should be very familiar.
+
+```go
+package main
+
+import (
+  "fmt"
+)
+
+import (
+  "storj.io/storj/pkg/emitter"
+)
+
+func main() {
+  emitter := emitter.NewEmitter()
+
+  hello := func(to string) {
+    fmt.Printf("Hello %s!\n", to)
+  }
+  
+  count := func(count int) {
+    for i := 0; i < count; i++ {
+      fmt.Println(i)
+    }
+  }
+  
+  emitter.On("hello", hello).
+    On("count", count).
+    Emit("hello", "world").
+    Emit("count", 5)
+}
+
+```
+
+## About
+
+The `emission` package provides an event emitter making use of the reflect packages ability to call functions.  Using the `Call` method on the value of a function allows passing any type of function to the event emiiter, regardless of the functions parameters.
+
+## Documentation
+
+View godoc's or visit [godoc.org](http://godoc.org/github.com/chuckpreslar/emission).
+
+    $ godoc emission
+
+## License
+
+Credit goes to Chuck Preslar [github.com/chuckpreslar]() for creating this library. 
+
+> The MIT License (MIT)
+
+> Copyright (c) 2013 - 2015 Chuck Preslar
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.

--- a/pkg/emitter/emitter.go
+++ b/pkg/emitter/emitter.go
@@ -1,0 +1,313 @@
+package emitter
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+)
+
+// DefaultMaxListeners is the maximum allowed listeners for an event.
+const DefaultMaxListeners = 10
+
+// ErrNoneFunction is thrown when an invalid type is provided as a listener function
+var ErrNoneFunction = errors.New("value for listener is not of type `Func`")
+
+// RecoveryListener ...
+type RecoveryListener func(interface{}, interface{}, error)
+
+// Emitter ...
+type Emitter struct {
+	// Mutex to prevent race conditions within the Emitter.
+	*sync.Mutex
+	// Map of event to a slice of listener function's reflect Values.
+	events map[interface{}][]reflect.Value
+	// Optional RecoveryListener to call when a panic occurs.
+	recoverer RecoveryListener
+	// Maximum listeners for debugging potential memory leaks.
+	maxListeners int
+	// Map used to remove Listeners wrapped in a Once func
+	onces map[reflect.Value]reflect.Value
+}
+
+// AddListener appends the listener argument to the event arguments slice
+// in the Emitter's events map. If the number of listeners for an event
+// is greater than the Emitter's maximum listeners then a warning is printed.
+// If the relect Value of the listener does not have a Kind of Func then
+// AddListener panics. If a RecoveryListener has been set then it is called
+// recovering from the panic.
+func (emitter *Emitter) AddListener(event, listener interface{}) *Emitter {
+	emitter.Lock()
+	defer emitter.Unlock()
+
+	fn := reflect.ValueOf(listener)
+
+	if reflect.Func != fn.Kind() {
+		if nil == emitter.recoverer {
+			panic(ErrNoneFunction)
+		} else {
+			emitter.recoverer(event, listener, ErrNoneFunction)
+		}
+	}
+
+	if emitter.maxListeners != -1 && emitter.maxListeners < len(emitter.events[event])+1 {
+		fmt.Fprintf(os.Stdout, "Warning: event `%v` has exceeded the maximum "+
+			"number of listeners of %d.\n", event, emitter.maxListeners)
+	}
+
+	emitter.events[event] = append(emitter.events[event], fn)
+
+	return emitter
+}
+
+// On is an alias for AddListener.
+func (emitter *Emitter) On(event, listener interface{}) *Emitter {
+	return emitter.AddListener(event, listener)
+}
+
+// RemoveListener removes the listener argument from the event arguments slice
+// in the Emitter's events map.  If the reflect Value of the listener does not
+// have a Kind of Func then RemoveListener panics. If a RecoveryListener has
+// been set then it is called after recovering from the panic.
+func (emitter *Emitter) RemoveListener(event, listener interface{}) *Emitter {
+	emitter.Lock()
+	defer emitter.Unlock()
+
+	fn := reflect.ValueOf(listener)
+
+	if reflect.Func != fn.Kind() {
+		if nil == emitter.recoverer {
+			panic(ErrNoneFunction)
+		} else {
+			emitter.recoverer(event, listener, ErrNoneFunction)
+		}
+	}
+
+	if events, ok := emitter.events[event]; ok {
+		if _, ok = emitter.onces[fn]; ok {
+			fn = emitter.onces[fn]
+		}
+
+		newEvents := []reflect.Value{}
+
+		for _, listener := range events {
+			if fn.Pointer() != listener.Pointer() {
+				newEvents = append(newEvents, listener)
+			}
+		}
+
+		emitter.events[event] = newEvents
+	}
+
+	return emitter
+}
+
+// Off is an alias for RemoveListener.
+func (emitter *Emitter) Off(event, listener interface{}) *Emitter {
+	return emitter.RemoveListener(event, listener)
+}
+
+// Once generates a new function which invokes the supplied listener
+// only once before removing itself from the event's listener slice
+// in the Emitter's events map. If the reflect Value of the listener
+// does not have a Kind of Func then Once panics. If a RecoveryListener
+// has been set then it is called after recovering from the panic.
+func (emitter *Emitter) Once(event, listener interface{}) *Emitter {
+	fn := reflect.ValueOf(listener)
+
+	if reflect.Func != fn.Kind() {
+		if nil == emitter.recoverer {
+			panic(ErrNoneFunction)
+		} else {
+			emitter.recoverer(event, listener, ErrNoneFunction)
+		}
+	}
+
+	var run func(...interface{})
+
+	run = func(arguments ...interface{}) {
+		defer emitter.RemoveListener(event, run)
+
+		var values []reflect.Value
+
+		for i := 0; i < len(arguments); i++ {
+			values = append(values, reflect.ValueOf(arguments[i]))
+		}
+
+		fn.Call(values)
+	}
+
+	// Lock before changing onces
+	emitter.Lock()
+	emitter.onces[fn] = reflect.ValueOf(run)
+	emitter.Unlock()
+
+	emitter.AddListener(event, run)
+	return emitter
+}
+
+// Emit attempts to use the reflect package to Call each listener stored
+// in the Emitter's events map with the supplied arguments. Each listener
+// is called within its own go routine. The reflect package will panic if
+// the agruments supplied do not align the parameters of a listener function.
+// If a RecoveryListener has been set then it is called after recovering from
+// the panic.
+func (emitter *Emitter) Emit(event interface{}, arguments ...interface{}) *Emitter {
+	var (
+		listeners []reflect.Value
+		ok        bool
+	)
+
+	// Lock the mutex when reading from the Emitter's
+	// events map.
+	emitter.Lock()
+
+	if listeners, ok = emitter.events[event]; !ok {
+		// If the Emitter does not include the event in its
+		// event map, it has no listeners to Call yet.
+		emitter.Unlock()
+		return emitter
+	}
+
+	// Unlock the mutex immediately following the read
+	// instead of deferring so that listeners registered
+	// with Once can aquire the mutex for removal.
+	emitter.Unlock()
+
+	var wg sync.WaitGroup
+
+	wg.Add(len(listeners))
+
+	for _, fn := range listeners {
+		go func(fn reflect.Value) {
+			defer wg.Done()
+
+			// Recover from potential panics, supplying them to a
+			// RecoveryListener if one has been set, else allowing
+			// the panic to occur.
+			if nil != emitter.recoverer {
+				defer func() {
+					if r := recover(); nil != r {
+						err := fmt.Errorf("%v", r)
+						emitter.recoverer(event, fn.Interface(), err)
+					}
+				}()
+			}
+
+			var values []reflect.Value
+
+			for i := 0; i < len(arguments); i++ {
+				if arguments[i] == nil {
+					values = append(values, reflect.New(fn.Type().In(i)).Elem())
+				} else {
+					values = append(values, reflect.ValueOf(arguments[i]))
+				}
+			}
+
+			fn.Call(values)
+		}(fn)
+	}
+
+	wg.Wait()
+	return emitter
+}
+
+// EmitSync attempts to use the reflect package to Call each listener stored
+// in the Emitter's events map with the supplied arguments. Each listener
+// is called synchronously. The reflect package will panic if
+// the agruments supplied do not align the parameters of a listener function.
+// If a RecoveryListener has been set then it is called after recovering from
+// the panic.
+func (emitter *Emitter) EmitSync(event interface{}, arguments ...interface{}) *Emitter {
+	var (
+		listeners []reflect.Value
+		ok        bool
+	)
+
+	// Lock the mutex when reading from the Emitter's
+	// events map.
+	emitter.Lock()
+
+	if listeners, ok = emitter.events[event]; !ok {
+		// If the Emitter does not include the event in its
+		// event map, it has no listeners to Call yet.
+		emitter.Unlock()
+		return emitter
+	}
+
+	// Unlock the mutex immediately following the read
+	// instead of deferring so that listeners registered
+	// with Once can aquire the mutex for removal.
+	emitter.Unlock()
+
+	for _, fn := range listeners {
+		// Recover from potential panics, supplying them to a
+		// RecoveryListener if one has been set, else allowing
+		// the panic to occur.
+		if nil != emitter.recoverer {
+			defer func() {
+				if r := recover(); nil != r {
+					err := fmt.Errorf("%v", r)
+					emitter.recoverer(event, fn.Interface(), err)
+				}
+			}()
+		}
+
+		var values []reflect.Value
+
+		for i := 0; i < len(arguments); i++ {
+			if arguments[i] == nil {
+				values = append(values, reflect.New(fn.Type().In(i)).Elem())
+			} else {
+				values = append(values, reflect.ValueOf(arguments[i]))
+			}
+		}
+
+		fn.Call(values)
+	}
+
+	return emitter
+}
+
+// RecoverWith sets the listener to call when a panic occurs, recovering from
+// panics and attempting to keep the application from crashing.
+func (emitter *Emitter) RecoverWith(listener RecoveryListener) *Emitter {
+	emitter.recoverer = listener
+	return emitter
+}
+
+// SetMaxListeners sets the maximum number of listeners per
+// event for the Emitter. If -1 is passed as the maximum,
+// all events may have unlimited listeners. By default, each
+// event can have a maximum number of 10 listeners which is
+// useful for finding memory leaks.
+func (emitter *Emitter) SetMaxListeners(max int) *Emitter {
+	emitter.Lock()
+	defer emitter.Unlock()
+
+	emitter.maxListeners = max
+	return emitter
+}
+
+// GetListenerCount gets count of listeners for a given event.
+func (emitter *Emitter) GetListenerCount(event interface{}) (count int) {
+	emitter.Lock()
+	if listeners, ok := emitter.events[event]; ok {
+		count = len(listeners)
+	}
+	emitter.Unlock()
+	return
+}
+
+// NewEmitter returns a new Emitter object, defaulting the
+// number of maximum listeners per event to the DefaultMaxListeners
+// constant and initializing its events map.
+func NewEmitter() (emitter *Emitter) {
+	emitter = new(Emitter)
+	emitter.Mutex = new(sync.Mutex)
+	emitter.events = make(map[interface{}][]reflect.Value)
+	emitter.maxListeners = DefaultMaxListeners
+	emitter.onces = make(map[reflect.Value]reflect.Value)
+	return
+}

--- a/pkg/emitter/emitter_test.go
+++ b/pkg/emitter/emitter_test.go
@@ -1,0 +1,154 @@
+package emitter
+
+import (
+	"testing"
+)
+
+func TestAddListener(t *testing.T) {
+	event := "test"
+
+	emitter := NewEmitter().
+		AddListener(event, func() {})
+
+	if 1 != len(emitter.events[event]) {
+		t.Error("Failed to add listener to the emitter.")
+	}
+}
+
+func TestEmit(t *testing.T) {
+	event := "test"
+	flag := true
+
+	NewEmitter().
+		AddListener(event, func() { flag = !flag }).
+		Emit(event)
+
+	if flag {
+		t.Error("Emit failed to call listener to unset flag.")
+	}
+}
+
+func TestEmitSync(t *testing.T) {
+	event := "test"
+	flag := true
+
+	NewEmitter().
+		AddListener(event, func() { flag = !flag }).
+		EmitSync(event)
+
+	if flag {
+		t.Error("EmitSync failed to call listener to unset flag.")
+	}
+}
+
+func TestEmitWithMultipleListeners(t *testing.T) {
+	event := "test"
+	invoked := 0
+
+	NewEmitter().
+		AddListener(event, func() {
+			invoked = invoked + 1
+		}).
+		AddListener(event, func() {
+			invoked = invoked + 1
+		}).
+		Emit(event)
+
+	if invoked != 2 {
+		t.Error("Emit failed to call all listeners.")
+	}
+}
+
+func TestRemoveListener(t *testing.T) {
+	event := "test"
+	listener := func() {}
+
+	emitter := NewEmitter().
+		AddListener(event, listener).
+		RemoveListener(event, listener)
+
+	if 0 != len(emitter.events[event]) {
+		t.Error("Failed to remove listener from the emitter.")
+	}
+}
+
+func TestOnce(t *testing.T) {
+	event := "test"
+	flag := true
+
+	NewEmitter().
+		Once(event, func() { flag = !flag }).
+		Emit(event).
+		Emit(event)
+
+	if flag {
+		t.Error("Once called listener multiple times reseting the flag.")
+	}
+}
+
+func TestRecoveryWith(t *testing.T) {
+	event := "test"
+	flag := true
+
+	NewEmitter().
+		AddListener(event, func() { panic(event) }).
+		RecoverWith(func(event, listener interface{}, err error) { flag = !flag }).
+		Emit(event)
+
+	if flag {
+		t.Error("Listener supplied to RecoverWith was not called to unset flag on panic.")
+	}
+}
+
+func TestRemoveOnce(t *testing.T) {
+	event := "test"
+	flag := false
+	fn := func() { flag = !flag }
+
+	NewEmitter().
+		Once(event, fn).
+		RemoveListener(event, fn).
+		Emit(event)
+
+	if flag {
+		t.Error("Failed to remove Listener for Once")
+	}
+}
+
+func TestCountListener(t *testing.T) {
+	event := "test"
+
+	emitter := NewEmitter().
+		AddListener(event, func() {})
+
+	if 1 != emitter.GetListenerCount(event) {
+		t.Error("Failed to get listener count from emitter.")
+	}
+
+	if 0 != emitter.GetListenerCount("fake") {
+		t.Error("Failed to get listener count from emitter.")
+	}
+}
+
+type SomeType struct{}
+
+func (*SomeType) Receiver(evt string) {}
+
+func TestRemoveStructMethod(t *testing.T) {
+	event := "test"
+	listener := &SomeType{}
+	emitter := NewEmitter().AddListener(event, listener.Receiver)
+
+	emitter.RemoveListener(event, listener.Receiver)
+	if 0 != emitter.GetListenerCount(event) {
+		t.Error("Failed to remove listener from emitter.")
+	}
+}
+
+func TestRemoveDoubleListener(t *testing.T) {
+	event := "test"
+
+	fn1 := func() {}
+
+	NewEmitter().On(event, fn1).On(event, fn1).RemoveListener(event, fn1)
+}

--- a/pkg/kademlia/config.go
+++ b/pkg/kademlia/config.go
@@ -6,6 +6,8 @@ package kademlia
 import (
 	"context"
 	"flag"
+	"fmt"
+	"time"
 
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"
@@ -87,6 +89,19 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) (
 			zap.L().Error("Failed to bootstrap Kademlia", zap.String("ID", server.Identity().ID.String()))
 		}
 	}()
+
+	// Kademlia Events
+	kad.events.On("disconnect", func(k Kademlia) {
+		zap.L().Info(fmt.Sprintf("node %+v disconnected", k.identity.ID.String()))
+	})
+
+	kad.events.On("bootstrap:start", func(t time.Time) {
+		zap.L().Info(fmt.Sprintf("bootstrap started at %+v", t))
+	})
+
+	kad.events.On("bootstrap:complete", func(t time.Time) {
+		zap.L().Info(fmt.Sprintf("bootstrap finished at %+v", t))
+	})
 
 	return server.Run(context.WithValue(ctx, ctxKeyKad, kad))
 }


### PR DESCRIPTION
Draft implementation of an event system for hooking into Kademlia lifecycle events.

Adds events for - 
* ConnectionSuccess
* Disconnect (graceful disconnect, not hard disconnect)
* Bootstrap Completed
* Refresh Completed
* Node Added to Seen()
* Node Added to RoutingTable