### PR TITLE
Changed SelfAddr -> ExternalAddress

### DIFF
--- a/pkg/kademlia/config.go
+++ b/pkg/kademlia/config.go
@@ -49,11 +49,11 @@ type FarmerConfig struct {
 // Config defines all of the things that are needed to start up Kademlia
 // server endpoints (and not necessarily client code).
 type Config struct {
-	BootstrapAddr string `help:"the kademlia node to bootstrap against" default:"bootstrap-dev.storj.io:8080"`
-	DBPath        string `help:"the path for our db services to be created on" default:"$CONFDIR/kademlia"`
-	Alpha         int    `help:"alpha is a system wide concurrency parameter." default:"5"`
-	SelfAddr      string `help:"the public address of the kademlia node; defaults to the gRPC server address." default:""`
-	Farmer        FarmerConfig
+	BootstrapAddr   string `help:"the kademlia node to bootstrap against" default:"bootstrap-dev.storj.io:8080"`
+	DBPath          string `help:"the path for our db services to be created on" default:"$CONFDIR/kademlia"`
+	Alpha           int    `help:"alpha is a system wide concurrency parameter." default:"5"`
+	ExternalAddress string `help:"the public address of the kademlia node; defaults to the gRPC server address." default:""`
+	Farmer          FarmerConfig
 }
 
 // Run implements provider.Responsibility
@@ -76,8 +76,8 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) (
 	nodeType := pb.NodeType_STORAGE // TODO: fix this for satellites
 
 	addr := server.Addr().String()
-	if c.SelfAddr != "" {
-		addr = c.SelfAddr
+	if c.ExternalAddress != "" {
+		addr = c.ExternalAddress
 	}
 
 	kad, err := NewKademlia(server.Identity().ID, nodeType, []pb.Node{*in}, addr, metadata, server.Identity(), c.DBPath, c.Alpha)


### PR DESCRIPTION
Changed the optional configured publicly published address name for a Kademlia Node from SelfAddr to ExternalAddress.

