### PR TITLE
Add script for listing captplanet storage node ids

### DIFF
--- a/scripts/print-capt-ids.sh
+++ b/scripts/print-capt-ids.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# osx: $ ./print-capt-ids.sh ~/Library/Application\ Support/Storj/Capt/
+basepath=$1
+i=0
+while [ $i -le 99 ]
+do
+  identity ca id --ca.cert-path "${basepath}/f${i}/ca.cert"
+  ((i++))
+done
+


### PR DESCRIPTION
I'm using this script for a demo, but it might be useful for other things in the future.