### PR TITLE
Fix race in connection pool

### DIFF
--- a/pkg/node/connection_pool_test.go
+++ b/pkg/node/connection_pool_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -61,7 +62,7 @@ func TestDisconnect(t *testing.T) {
 		{
 			pool: ConnectionPool{
 				mu:    sync.RWMutex{},
-				items: map[storj.NodeID]*Conn{fooID: &Conn{grpc: conn}},
+				items: map[storj.NodeID]*Conn{fooID: &Conn{grpc: unsafe.Pointer(conn)}},
 			},
 			nodeID:        fooID,
 			expected:      nil,


### PR DESCRIPTION
This fixes races in tests like this one:

```
==================
WARNING: DATA RACE
Write at 0x00c00018bfc0 by goroutine 356:
  storj.io/storj/pkg/node.(*ConnectionPool).Dial.func1()
      /home/kaloyan/git/storj/pkg/node/connection_pool.go:98 +0x189
  sync.(*Once).Do()
      /usr/local/go/src/sync/once.go:44 +0xde
  storj.io/storj/pkg/node.(*ConnectionPool).Dial()
      /home/kaloyan/git/storj/pkg/node/connection_pool.go:97 +0x1e8
  storj.io/storj/pkg/node.(*Node).Lookup()
      /home/kaloyan/git/storj/pkg/node/node.go:22 +0x174
  storj.io/storj/pkg/kademlia.(*peerDiscovery).Run.func1()
      /home/kaloyan/git/storj/pkg/kademlia/peer_discovery.go:90 +0x332

Previous read at 0x00c00018bfc0 by goroutine 107:
  storj.io/storj/pkg/node.(*ConnectionPool).disconnect()
      /home/kaloyan/git/storj/pkg/node/connection_pool.go:77 +0x119
  storj.io/storj/pkg/node.(*ConnectionPool).DisconnectAll()
      /home/kaloyan/git/storj/pkg/node/connection_pool.go:120 +0x1d9
  storj.io/storj/pkg/node.(*Node).Disconnect()
      /home/kaloyan/git/storj/pkg/node/node.go:61 +0x56
  storj.io/storj/pkg/kademlia.(*Kademlia).Disconnect()
      /home/kaloyan/git/storj/pkg/kademlia/kademlia.go:112 +0x59
  storj.io/storj/internal/testplanet.(*Node).Shutdown()
      /home/kaloyan/git/storj/internal/testplanet/node.go:102 +0x364
  storj.io/storj/internal/testplanet.(*Planet).Shutdown()
      /home/kaloyan/git/storj/internal/testplanet/planet.go:203 +0x160
  storj.io/storj/internal/testplanet.(*Planet).Shutdown-fm()
      /home/kaloyan/git/storj/pkg/miniogw/gateway-storj_test.go:645 +0x41
  storj.io/storj/internal/testcontext.(*Context).Check()
      /home/kaloyan/git/storj/internal/testcontext/context.go:102 +0x68
  storj.io/storj/pkg/miniogw.runTest()
      /home/kaloyan/git/storj/pkg/miniogw/gateway-storj_test.go:655 +0x2aa
  storj.io/storj/pkg/miniogw.TestGetBucketInfo()
      /home/kaloyan/git/storj/pkg/miniogw/gateway-storj_test.go:68 +0x5b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162

Goroutine 356 (running) created at:
  storj.io/storj/pkg/kademlia.(*peerDiscovery).Run()
      /home/kaloyan/git/storj/pkg/kademlia/peer_discovery.go:59 +0x218
  storj.io/storj/pkg/kademlia.(*Kademlia).lookup()
      /home/kaloyan/git/storj/pkg/kademlia/kademlia.go:195 +0x48e
  storj.io/storj/pkg/kademlia.(*Kademlia).Bootstrap()
      /home/kaloyan/git/storj/pkg/kademlia/kademlia.go:175 +0x27a
  storj.io/storj/internal/testplanet.New.func5()
      /home/kaloyan/git/storj/internal/testplanet/planet.go:161 +0x8c

Goroutine 107 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:878 +0x650
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1119 +0xa8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1117 +0x4ee
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1034 +0x2ee
  main.main()
      _testmain.go:62 +0x221
==================
--- FAIL: TestGetBucketInfo (20.61s)
    testing.go:771: race detected during execution of test
```