### PR TITLE
adds node selection config

### DIFF
--- a/pkg/datarepair/repairer/config.go
+++ b/pkg/datarepair/repairer/config.go
@@ -28,6 +28,15 @@ type Config struct {
 	Interval     time.Duration `help:"how frequently checker should audit segments" default:"3600s"`
 	miniogw.ClientConfig
 	miniogw.RSConfig
+	nodeStats nodeStats
+}
+
+type nodeStats struct {
+	Uptime       int
+	UptimeCount  int
+	AuditSuccess int
+	AuditCount   int
+	Excluded     storj.NodeIDList
 }
 
 // Run runs the repairer with configured values
@@ -84,5 +93,6 @@ func (c Config) getSegmentStore(ctx context.Context, identity *provider.FullIden
 		return nil, err
 	}
 
-	return segment.NewSegmentStore(oc, ec, pdb, rs, c.MaxInlineSize), nil
+	return segment.NewSegmentStore(oc, ec, pdb, rs, c.MaxInlineSize, c.nodeStats.uptime, c.nodeStats.uptimeCount,
+		c.nodeStats.auditSuccess, c.nodeStats.auditCount), nil
 }

--- a/pkg/datarepair/repairer/config.go
+++ b/pkg/datarepair/repairer/config.go
@@ -14,6 +14,7 @@ import (
 	"storj.io/storj/pkg/eestream"
 	"storj.io/storj/pkg/miniogw"
 	"storj.io/storj/pkg/overlay"
+	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/pointerdb/pdbclient"
 	"storj.io/storj/pkg/provider"
 	ecclient "storj.io/storj/pkg/storage/ec"
@@ -23,13 +24,10 @@ import (
 
 // Config contains configurable values for repairer
 type Config struct {
-	QueueAddress      string        `help:"data repair queue address" default:"redis://127.0.0.1:6378?db=1&password=abc123"`
-	MaxRepair         int           `help:"maximum segments that can be repaired concurrently" default:"100"`
-	Interval          time.Duration `help:"how frequently checker should audit segments" default:"3600s"`
-	UptimeRatio       float64       `help:"the minimum uptime ratio for nodes selected" default:"0"`
-	AuditSuccessRatio float64       `help:"the minimum audit success ratio for nodes selected" default:"0"`
-	UptimeCount       int64         `help:"the minimum number of uptime checks for nodes selected" default:"0"`
-	AuditCount        int64         `help:"the minimum number of audits for nodes selected" default:"0"`
+	QueueAddress string        `help:"data repair queue address" default:"redis://127.0.0.1:6378?db=1&password=abc123"`
+	MaxRepair    int           `help:"maximum segments that can be repaired concurrently" default:"100"`
+	Interval     time.Duration `help:"how frequently checker should audit segments" default:"3600s"`
+	miniogw.NodeSelectionConfig
 	miniogw.ClientConfig
 	miniogw.RSConfig
 }
@@ -88,6 +86,12 @@ func (c Config) getSegmentStore(ctx context.Context, identity *provider.FullIden
 		return nil, err
 	}
 
-	return segment.NewSegmentStore(oc, ec, pdb, rs, c.MaxInlineSize, c.UptimeRatio, c.AuditSuccessRatio,
-		c.UptimeCount, c.AuditCount), nil
+	ns := &pb.NodeStats{
+		UptimeRatio:       c.UptimeRatio,
+		AuditSuccessRatio: c.AuditSuccessRatio,
+		UptimeCount:       c.UptimeCount,
+		AuditCount:        c.AuditCount,
+	}
+
+	return segment.NewSegmentStore(oc, ec, pdb, rs, c.MaxInlineSize, ns), nil
 }

--- a/pkg/datarepair/repairer/config.go
+++ b/pkg/datarepair/repairer/config.go
@@ -14,7 +14,6 @@ import (
 	"storj.io/storj/pkg/eestream"
 	"storj.io/storj/pkg/miniogw"
 	"storj.io/storj/pkg/overlay"
-	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/pointerdb/pdbclient"
 	"storj.io/storj/pkg/provider"
 	ecclient "storj.io/storj/pkg/storage/ec"
@@ -24,10 +23,13 @@ import (
 
 // Config contains configurable values for repairer
 type Config struct {
-	QueueAddress string        `help:"data repair queue address" default:"redis://127.0.0.1:6378?db=1&password=abc123"`
-	MaxRepair    int           `help:"maximum segments that can be repaired concurrently" default:"100"`
-	Interval     time.Duration `help:"how frequently checker should audit segments" default:"3600s"`
-	nodeStats    *pb.NodeStats `help:"the minimum values for nodes to select"`
+	QueueAddress      string        `help:"data repair queue address" default:"redis://127.0.0.1:6378?db=1&password=abc123"`
+	MaxRepair         int           `help:"maximum segments that can be repaired concurrently" default:"100"`
+	Interval          time.Duration `help:"how frequently checker should audit segments" default:"3600s"`
+	UptimeRatio       float64       `help:"the minimum uptime ratio for nodes selected" default:"0"`
+	AuditSuccessRatio float64       `help:"the minimum audit success ratio for nodes selected" default:"0"`
+	UptimeCount       int64         `help:"the minimum number of uptime checks for nodes selected" default:"0"`
+	AuditCount        int64         `help:"the minimum number of audits for nodes selected" default:"0"`
 	miniogw.ClientConfig
 	miniogw.RSConfig
 }
@@ -86,6 +88,6 @@ func (c Config) getSegmentStore(ctx context.Context, identity *provider.FullIden
 		return nil, err
 	}
 
-	return segment.NewSegmentStore(oc, ec, pdb, rs, c.MaxInlineSize, c.nodeStats.UptimeRatio,
-		c.nodeStats.AuditSuccessRatio, c.nodeStats.UptimeCount, c.nodeStats.AuditCount), nil
+	return segment.NewSegmentStore(oc, ec, pdb, rs, c.MaxInlineSize, c.UptimeRatio, c.AuditSuccessRatio,
+		c.UptimeCount, c.AuditCount), nil
 }

--- a/pkg/datarepair/repairer/config.go
+++ b/pkg/datarepair/repairer/config.go
@@ -14,6 +14,7 @@ import (
 	"storj.io/storj/pkg/eestream"
 	"storj.io/storj/pkg/miniogw"
 	"storj.io/storj/pkg/overlay"
+	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/pointerdb/pdbclient"
 	"storj.io/storj/pkg/provider"
 	ecclient "storj.io/storj/pkg/storage/ec"
@@ -26,17 +27,9 @@ type Config struct {
 	QueueAddress string        `help:"data repair queue address" default:"redis://127.0.0.1:6378?db=1&password=abc123"`
 	MaxRepair    int           `help:"maximum segments that can be repaired concurrently" default:"100"`
 	Interval     time.Duration `help:"how frequently checker should audit segments" default:"3600s"`
+	nodeStats    *pb.NodeStats `help:"the minimum values for nodes to select"`
 	miniogw.ClientConfig
 	miniogw.RSConfig
-	nodeStats nodeStats
-}
-
-type nodeStats struct {
-	Uptime       int
-	UptimeCount  int
-	AuditSuccess int
-	AuditCount   int
-	Excluded     storj.NodeIDList
 }
 
 // Run runs the repairer with configured values
@@ -93,6 +86,6 @@ func (c Config) getSegmentStore(ctx context.Context, identity *provider.FullIden
 		return nil, err
 	}
 
-	return segment.NewSegmentStore(oc, ec, pdb, rs, c.MaxInlineSize, c.nodeStats.uptime, c.nodeStats.uptimeCount,
-		c.nodeStats.auditSuccess, c.nodeStats.auditCount), nil
+	return segment.NewSegmentStore(oc, ec, pdb, rs, c.MaxInlineSize, c.nodeStats.UptimeRatio, c.nodeStats.UptimeCount,
+		c.nodeStats.AuditSuccessRatio, c.nodeStats.AuditCount), nil
 }

--- a/pkg/datarepair/repairer/config.go
+++ b/pkg/datarepair/repairer/config.go
@@ -86,6 +86,6 @@ func (c Config) getSegmentStore(ctx context.Context, identity *provider.FullIden
 		return nil, err
 	}
 
-	return segment.NewSegmentStore(oc, ec, pdb, rs, c.MaxInlineSize, c.nodeStats.UptimeRatio, c.nodeStats.UptimeCount,
-		c.nodeStats.AuditSuccessRatio, c.nodeStats.AuditCount), nil
+	return segment.NewSegmentStore(oc, ec, pdb, rs, c.MaxInlineSize, c.nodeStats.UptimeRatio,
+		c.nodeStats.AuditSuccessRatio, c.nodeStats.UptimeCount, c.nodeStats.AuditCount), nil
 }

--- a/pkg/metainfo/kvmetainfo/buckets_test.go
+++ b/pkg/metainfo/kvmetainfo/buckets_test.go
@@ -16,6 +16,7 @@ import (
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testplanet"
 	"storj.io/storj/pkg/eestream"
+	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/storage/buckets"
 	"storj.io/storj/pkg/storage/ec"
 	"storj.io/storj/pkg/storage/segments"
@@ -356,7 +357,7 @@ func newDB(planet *testplanet.Planet) (*DB, error) {
 		return nil, err
 	}
 
-	segments := segments.NewSegmentStore(oc, ec, pdb, rs, int(8*memory.KB), 0, 0, 0, 0)
+	segments := segments.NewSegmentStore(oc, ec, pdb, rs, int(8*memory.KB), &pb.NodeStats{})
 
 	key := new(storj.Key)
 	copy(key[:], TestEncKey)

--- a/pkg/metainfo/kvmetainfo/buckets_test.go
+++ b/pkg/metainfo/kvmetainfo/buckets_test.go
@@ -356,7 +356,7 @@ func newDB(planet *testplanet.Planet) (*DB, error) {
 		return nil, err
 	}
 
-	segments := segments.NewSegmentStore(oc, ec, pdb, rs, int(8*memory.KB))
+	segments := segments.NewSegmentStore(oc, ec, pdb, rs, int(8*memory.KB), 0, 0, 0, 0)
 
 	key := new(storj.Key)
 	copy(key[:], TestEncKey)

--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -35,6 +35,15 @@ type RSConfig struct {
 	MaxThreshold     int `help:"the largest amount of pieces to encode to. n." default:"95"`
 }
 
+// NodeSelectionConfig is a configuration struct that keeps information about
+// what nodes to select
+type NodeSelectionConfig struct {
+	Uptime       int `help:"a node's ratio of being up/online vs. down/offline"`
+	UptimeCount  int `help:"the number of times a node's uptime has been checked"`
+	AuditSuccess int `help:"a node's ratio of successful audits"`
+	AuditCount   int `help:"the number of times a node has been audited"`
+}
+
 // EncryptionConfig is a configuration struct that keeps details about
 // encrypting segments
 type EncryptionConfig struct {
@@ -72,6 +81,7 @@ type Config struct {
 	Client   ClientConfig
 	RS       RSConfig
 	Enc      EncryptionConfig
+	Node     NodeSelectionConfig
 }
 
 // Run starts a Minio Gateway given proper config
@@ -146,7 +156,8 @@ func (c Config) GetMetainfo(ctx context.Context, identity *provider.FullIdentity
 		return nil, nil, err
 	}
 
-	segments := segments.NewSegmentStore(oc, ec, pdb, rs, c.Client.MaxInlineSize)
+	segments := segments.NewSegmentStore(oc, ec, pdb, rs, c.Client.MaxInlineSize, c.Node.Uptime,
+		c.Node.UptimeCount, c.Node.AuditSuccess, c.Node.AuditCount)
 
 	if c.RS.ErasureShareSize*c.RS.MinThreshold%c.Enc.BlockSize != 0 {
 		err = Error.New("EncryptionBlockSize must be a multiple of ErasureShareSize * RS MinThreshold")

--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -15,6 +15,7 @@ import (
 	"storj.io/storj/pkg/eestream"
 	"storj.io/storj/pkg/metainfo/kvmetainfo"
 	"storj.io/storj/pkg/overlay"
+	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/pointerdb/pdbclient"
 	"storj.io/storj/pkg/provider"
 	"storj.io/storj/pkg/storage/buckets"
@@ -156,8 +157,14 @@ func (c Config) GetMetainfo(ctx context.Context, identity *provider.FullIdentity
 		return nil, nil, err
 	}
 
-	segments := segments.NewSegmentStore(oc, ec, pdb, rs, c.Client.MaxInlineSize, c.Node.UptimeRatio,
-		c.Node.AuditSuccessRatio, c.Node.UptimeCount, c.Node.AuditCount)
+	ns := &pb.NodeStats{
+		UptimeCount:       c.Node.UptimeCount,
+		UptimeRatio:       c.Node.UptimeRatio,
+		AuditSuccessRatio: c.Node.AuditSuccessRatio,
+		AuditCount:        c.Node.AuditCount,
+	}
+
+	segments := segments.NewSegmentStore(oc, ec, pdb, rs, c.Client.MaxInlineSize, ns)
 
 	if c.RS.ErasureShareSize*c.RS.MinThreshold%c.Enc.BlockSize != 0 {
 		err = Error.New("EncryptionBlockSize must be a multiple of ErasureShareSize * RS MinThreshold")

--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -38,10 +38,10 @@ type RSConfig struct {
 // NodeSelectionConfig is a configuration struct to determine the minimum
 // values for nodes to select
 type NodeSelectionConfig struct {
-	UptimeRatio       float64 `help:"a node's ratio of being up/online vs. down/offline"`
-	UptimeCount       int64   `help:"the number of times a node's uptime has been checked"`
-	AuditSuccessRatio float64 `help:"a node's ratio of successful audits"`
-	AuditCount        int64   `help:"the number of times a node has been audited"`
+	UptimeRatio       float64 `help:"a node's ratio of being up/online vs. down/offline" default:"0"`
+	UptimeCount       int64   `help:"the number of times a node's uptime has been checked" default:"0"`
+	AuditSuccessRatio float64 `help:"a node's ratio of successful audits" default:"0"`
+	AuditCount        int64   `help:"the number of times a node has been audited" default:"0"`
 }
 
 // EncryptionConfig is a configuration struct that keeps details about

--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -35,13 +35,13 @@ type RSConfig struct {
 	MaxThreshold     int `help:"the largest amount of pieces to encode to. n." default:"95"`
 }
 
-// NodeSelectionConfig is a configuration struct that keeps information about
-// what nodes to select
+// NodeSelectionConfig is a configuration struct to determine the minimum
+// values for nodes to select
 type NodeSelectionConfig struct {
-	Uptime       int `help:"a node's ratio of being up/online vs. down/offline"`
-	UptimeCount  int `help:"the number of times a node's uptime has been checked"`
-	AuditSuccess int `help:"a node's ratio of successful audits"`
-	AuditCount   int `help:"the number of times a node has been audited"`
+	UptimeRatio       float64 `help:"a node's ratio of being up/online vs. down/offline"`
+	UptimeCount       int64   `help:"the number of times a node's uptime has been checked"`
+	AuditSuccessRatio float64 `help:"a node's ratio of successful audits"`
+	AuditCount        int64   `help:"the number of times a node has been audited"`
 }
 
 // EncryptionConfig is a configuration struct that keeps details about
@@ -156,8 +156,8 @@ func (c Config) GetMetainfo(ctx context.Context, identity *provider.FullIdentity
 		return nil, nil, err
 	}
 
-	segments := segments.NewSegmentStore(oc, ec, pdb, rs, c.Client.MaxInlineSize, c.Node.Uptime,
-		c.Node.UptimeCount, c.Node.AuditSuccess, c.Node.AuditCount)
+	segments := segments.NewSegmentStore(oc, ec, pdb, rs, c.Client.MaxInlineSize, c.Node.UptimeRatio,
+		c.Node.AuditSuccessRatio, c.Node.UptimeCount, c.Node.AuditCount)
 
 	if c.RS.ErasureShareSize*c.RS.MinThreshold%c.Enc.BlockSize != 0 {
 		err = Error.New("EncryptionBlockSize must be a multiple of ErasureShareSize * RS MinThreshold")

--- a/pkg/miniogw/gateway_test.go
+++ b/pkg/miniogw/gateway_test.go
@@ -682,7 +682,7 @@ func initEnv(planet *testplanet.Planet) (minio.ObjectLayer, storj.Metainfo, stre
 		return nil, nil, nil, err
 	}
 
-	segments := segments.NewSegmentStore(oc, ec, pdb, rs, int(8*memory.KB), 0, 0, 0, 0)
+	segments := segments.NewSegmentStore(oc, ec, pdb, rs, int(8*memory.KB), &pb.NodeStats{})
 
 	key := new(storj.Key)
 	copy(key[:], TestEncKey)

--- a/pkg/miniogw/gateway_test.go
+++ b/pkg/miniogw/gateway_test.go
@@ -682,7 +682,7 @@ func initEnv(planet *testplanet.Planet) (minio.ObjectLayer, storj.Metainfo, stre
 		return nil, nil, nil, err
 	}
 
-	segments := segments.NewSegmentStore(oc, ec, pdb, rs, int(8*memory.KB))
+	segments := segments.NewSegmentStore(oc, ec, pdb, rs, int(8*memory.KB), 0, 0, 0, 0)
 
 	key := new(storj.Key)
 	copy(key[:], TestEncKey)

--- a/pkg/overlay/client.go
+++ b/pkg/overlay/client.go
@@ -41,6 +41,7 @@ type Overlay struct {
 type Options struct {
 	Amount       int
 	Space        int64
+	Bandwidth    int64
 	Uptime       float64
 	UptimeCount  int64
 	AuditSuccess float64
@@ -75,7 +76,7 @@ func (o *Overlay) Choose(ctx context.Context, op Options) ([]*pb.Node, error) {
 	resp, err := o.client.FindStorageNodes(ctx, &pb.FindStorageNodesRequest{
 		Opts: &pb.OverlayOptions{
 			Amount:       int64(op.Amount),
-			Restrictions: &pb.NodeRestrictions{FreeDisk: op.Space},
+			Restrictions: &pb.NodeRestrictions{FreeDisk: op.Space, FreeBandwidth: op.Bandwidth},
 			MinStats: &pb.NodeStats{
 				UptimeRatio:       op.Uptime,
 				UptimeCount:       op.UptimeCount,

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -112,7 +112,16 @@ func (s *segmentStore) Put(ctx context.Context, data io.Reader, expiration time.
 		}
 	} else {
 		// uses overlay client to request a list of nodes
-		nodes, err := s.oc.Choose(ctx, overlay.Options{Amount: s.rs.TotalCount(), Space: 0, Excluded: nil})
+		nodes, err := s.oc.Choose(ctx,
+			overlay.Options{
+				Amount:       s.rs.TotalCount(),
+				Space:        0,
+				Uptime:       0,
+				UptimeCount:  0,
+				AuditSuccess: 0,
+				AuditCount:   0,
+				Excluded:     nil,
+			})
 		if err != nil {
 			return Meta{}, Error.Wrap(err)
 		}

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -65,13 +65,13 @@ type segmentStore struct {
 
 // NewSegmentStore creates a new instance of segmentStore
 func NewSegmentStore(oc overlay.Client, ec ecclient.Client, pdb pdbclient.Client, rs eestream.RedundancyStrategy, threshold int,
-	uptimeRatio, auditSuccessRatio float64, uptimeCount, auditCount int64) Store {
+	nodeStats *pb.NodeStats) Store {
 	return &segmentStore{oc: oc, ec: ec, pdb: pdb, rs: rs, thresholdSize: threshold,
 		nodeStats: &pb.NodeStats{
-			UptimeRatio:       uptimeRatio,
-			UptimeCount:       uptimeCount,
-			AuditSuccessRatio: auditSuccessRatio,
-			AuditCount:        auditCount,
+			UptimeRatio:       nodeStats.UptimeRatio,
+			UptimeCount:       nodeStats.UptimeCount,
+			AuditSuccessRatio: nodeStats.AuditSuccessRatio,
+			AuditCount:        nodeStats.AuditCount,
 		},
 	}
 }

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -128,9 +128,9 @@ func (s *segmentStore) Put(ctx context.Context, data io.Reader, expiration time.
 				Amount:       s.rs.TotalCount(),
 				Bandwidth:    sizedReader.Size() / int64(s.rs.TotalCount()),
 				Space:        sizedReader.Size() / int64(s.rs.TotalCount()),
-				Uptime:       float64(s.nodeStats.UptimeRatio),
-				UptimeCount:  int64(s.nodeStats.UptimeCount),
-				AuditSuccess: float64(s.nodeStats.AuditSuccessRatio),
+				Uptime:       s.nodeStats.UptimeRatio,
+				UptimeCount:  s.nodeStats.UptimeCount,
+				AuditSuccess: s.nodeStats.AuditSuccessRatio,
 				AuditCount:   int64(s.nodeStats.AuditCount),
 				Excluded:     nil,
 			})

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -131,7 +131,7 @@ func (s *segmentStore) Put(ctx context.Context, data io.Reader, expiration time.
 				Uptime:       s.nodeStats.UptimeRatio,
 				UptimeCount:  s.nodeStats.UptimeCount,
 				AuditSuccess: s.nodeStats.AuditSuccessRatio,
-				AuditCount:   int64(s.nodeStats.AuditCount),
+				AuditCount:   s.nodeStats.AuditCount,
 				Excluded:     nil,
 			})
 		if err != nil {

--- a/pkg/storage/segments/store_test.go
+++ b/pkg/storage/segments/store_test.go
@@ -41,7 +41,7 @@ func TestNewSegmentStore(t *testing.T) {
 		ErasureScheme: mock_eestream.NewMockErasureScheme(ctrl),
 	}
 
-	ss := NewSegmentStore(mockOC, mockEC, mockPDB, rs, 10)
+	ss := NewSegmentStore(mockOC, mockEC, mockPDB, rs, 10, 0, 0, 0, 0)
 	assert.NotNil(t, ss)
 }
 
@@ -56,7 +56,7 @@ func TestSegmentStoreMeta(t *testing.T) {
 		ErasureScheme: mock_eestream.NewMockErasureScheme(ctrl),
 	}
 
-	ss := segmentStore{mockOC, mockEC, mockPDB, rs, 10}
+	ss := segmentStore{mockOC, mockEC, mockPDB, rs, 10, nodeStats{}}
 	assert.NotNil(t, ss)
 
 	var mExp time.Time
@@ -105,7 +105,7 @@ func TestSegmentStorePutRemote(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -161,7 +161,7 @@ func TestSegmentStorePutInline(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -207,7 +207,7 @@ func TestSegmentStoreGetInline(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -277,7 +277,7 @@ func TestSegmentStoreRepairRemote(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -349,7 +349,7 @@ func TestSegmentStoreGetRemote(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -412,7 +412,7 @@ func TestSegmentStoreDeleteInline(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -462,7 +462,7 @@ func TestSegmentStoreDeleteRemote(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -524,7 +524,7 @@ func TestSegmentStoreList(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
 		assert.NotNil(t, ss)
 
 		ti := time.Unix(0, 0).UTC()

--- a/pkg/storage/segments/store_test.go
+++ b/pkg/storage/segments/store_test.go
@@ -109,7 +109,7 @@ func TestSegmentStorePutRemote(t *testing.T) {
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
-			mockES.EXPECT().TotalCount().Return(1),
+			mockES.EXPECT().TotalCount().Return(1).AnyTimes(),
 			mockOC.EXPECT().Choose(
 				gomock.Any(), gomock.Any(),
 			).Return([]*pb.Node{

--- a/pkg/storage/segments/store_test.go
+++ b/pkg/storage/segments/store_test.go
@@ -41,7 +41,7 @@ func TestNewSegmentStore(t *testing.T) {
 		ErasureScheme: mock_eestream.NewMockErasureScheme(ctrl),
 	}
 
-	ss := NewSegmentStore(mockOC, mockEC, mockPDB, rs, 10, 0, 0, 0, 0)
+	ss := NewSegmentStore(mockOC, mockEC, mockPDB, rs, 10, &pb.NodeStats{})
 	assert.NotNil(t, ss)
 }
 

--- a/pkg/storage/segments/store_test.go
+++ b/pkg/storage/segments/store_test.go
@@ -56,7 +56,7 @@ func TestSegmentStoreMeta(t *testing.T) {
 		ErasureScheme: mock_eestream.NewMockErasureScheme(ctrl),
 	}
 
-	ss := segmentStore{mockOC, mockEC, mockPDB, rs, 10, nodeStats{}}
+	ss := segmentStore{mockOC, mockEC, mockPDB, rs, 10, &pb.NodeStats{}}
 	assert.NotNil(t, ss)
 
 	var mExp time.Time
@@ -105,7 +105,7 @@ func TestSegmentStorePutRemote(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -161,7 +161,7 @@ func TestSegmentStorePutInline(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -207,7 +207,7 @@ func TestSegmentStoreGetInline(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -277,7 +277,7 @@ func TestSegmentStoreRepairRemote(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -349,7 +349,7 @@ func TestSegmentStoreGetRemote(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -412,7 +412,7 @@ func TestSegmentStoreDeleteInline(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -462,7 +462,7 @@ func TestSegmentStoreDeleteRemote(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -524,7 +524,7 @@ func TestSegmentStoreList(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, nodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
 		assert.NotNil(t, ss)
 
 		ti := time.Unix(0, 0).UTC()


### PR DESCRIPTION
Adds a node selection config to the miniogw config, so that segment store provides minimum values of AuditCount, AuditSuccessRatio, UptimeCount, and UptimeRatio when requesting nodes from the overlay. Bandwidth and disk space are also provided as options when requesting nodes from the overlay.