### PR TITLE
clean up uplink config section

### DIFF
--- a/cmd/captplanet/run.go
+++ b/cmd/captplanet/run.go
@@ -159,7 +159,9 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	// start s3 uplink
 	go func() {
 		_, _ = fmt.Printf("Starting s3-gateway on %s\nAccess key: %s\nSecret key: %s\n",
-			runCfg.Uplink.IdentityConfig.Address, runCfg.Uplink.AccessKey, runCfg.Uplink.SecretKey)
+			runCfg.Uplink.Identity.Address,
+			runCfg.Uplink.Minio.AccessKey,
+			runCfg.Uplink.Minio.SecretKey)
 		errch <- runCfg.Uplink.Run(ctx)
 	}()
 

--- a/cmd/captplanet/setup.go
+++ b/cmd/captplanet/setup.go
@@ -150,18 +150,18 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		"satellite.repairer.pointer-db-addr": joinHostPort(
 			setupCfg.ListenHost, startingPort+1),
 		"satellite.repairer.api-key": setupCfg.APIKey,
-		"uplink.cert-path":           setupCfg.ULIdentity.CertPath,
-		"uplink.key-path":            setupCfg.ULIdentity.KeyPath,
-		"uplink.address": joinHostPort(
+		"uplink.identity.cert-path":  setupCfg.ULIdentity.CertPath,
+		"uplink.identity.key-path":   setupCfg.ULIdentity.KeyPath,
+		"uplink.identity.address": joinHostPort(
 			setupCfg.ListenHost, startingPort),
-		"uplink.overlay-addr": joinHostPort(
+		"uplink.client.overlay-addr": joinHostPort(
 			setupCfg.ListenHost, startingPort+1),
-		"uplink.pointer-db-addr": joinHostPort(
+		"uplink.client.pointer-db-addr": joinHostPort(
 			setupCfg.ListenHost, startingPort+1),
-		"uplink.minio-dir": filepath.Join(
+		"uplink.minio.dir": filepath.Join(
 			setupCfg.BasePath, "uplink", "minio"),
-		"uplink.enc-key":          setupCfg.EncKey,
-		"uplink.api-key":          setupCfg.APIKey,
+		"uplink.enc.key":          setupCfg.EncKey,
+		"uplink.client.api-key":   setupCfg.APIKey,
 		"pointer-db.auth.api-key": setupCfg.APIKey,
 
 		// Repairer

--- a/cmd/uplink/cmd/mb.go
+++ b/cmd/uplink/cmd/mb.go
@@ -53,7 +53,7 @@ func makeBucket(cmd *cobra.Command, args []string) error {
 	if !storj.ErrBucketNotFound.Has(err) {
 		return err
 	}
-	_, err = metainfo.CreateBucket(ctx, dst.Bucket(), &storj.Bucket{PathCipher: storj.Cipher(cfg.PathEncType)})
+	_, err = metainfo.CreateBucket(ctx, dst.Bucket(), &storj.Bucket{PathCipher: storj.Cipher(cfg.Enc.PathType)})
 	if err != nil {
 		return err
 	}

--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -50,7 +50,7 @@ func addCmd(cmd *cobra.Command, root *cobra.Command) *cobra.Command {
 // Temporarily it also returns an instance of streams.Store until we improve
 // the metainfo and streas implementations.
 func (c *Config) Metainfo(ctx context.Context) (storj.Metainfo, streams.Store, error) {
-	identity, err := c.Load()
+	identity, err := c.Identity.Load()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/uplink/cmd/run.go
+++ b/cmd/uplink/cmd/run.go
@@ -26,7 +26,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("Invalid argument %#v. Try 'uplink run'", flagname)
 	}
 
-	address := cfg.Address
+	address := cfg.Identity.Address
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return err
@@ -37,8 +37,8 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 
 	fmt.Printf("Starting Storj S3-compatible gateway!\n\n")
 	fmt.Printf("Endpoint: %s\n", address)
-	fmt.Printf("Access key: %s\n", cfg.AccessKey)
-	fmt.Printf("Secret key: %s\n", cfg.SecretKey)
+	fmt.Printf("Access key: %s\n", cfg.Minio.AccessKey)
+	fmt.Printf("Secret key: %s\n", cfg.Minio.SecretKey)
 
 	ctx := process.Ctx(cmd)
 	metainfo, _, err := cfg.Metainfo(ctx)

--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -101,14 +101,14 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	o := map[string]interface{}{
-		"cert-path":       setupCfg.Identity.CertPath,
-		"key-path":        setupCfg.Identity.KeyPath,
-		"api-key":         setupCfg.APIKey,
-		"pointer-db-addr": setupCfg.SatelliteAddr,
-		"overlay-addr":    setupCfg.SatelliteAddr,
-		"access-key":      accessKey,
-		"secret-key":      secretKey,
-		"enc-key":         setupCfg.EncKey,
+		"identity.cert-path":     setupCfg.Identity.CertPath,
+		"identity.key-path":      setupCfg.Identity.KeyPath,
+		"client.api-key":         setupCfg.APIKey,
+		"client.pointer-db-addr": setupCfg.SatelliteAddr,
+		"client.overlay-addr":    setupCfg.SatelliteAddr,
+		"minio.access-key":       accessKey,
+		"minio.secret-key":       secretKey,
+		"enc.key":                setupCfg.EncKey,
 	}
 
 	return process.SaveConfig(runCmd.Flags(),

--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -38,10 +38,10 @@ type RSConfig struct {
 // EncryptionConfig is a configuration struct that keeps details about
 // encrypting segments
 type EncryptionConfig struct {
-	EncKey       string `help:"root key for encrypting the data"`
-	EncBlockSize int    `help:"size (in bytes) of encrypted blocks" default:"1024"`
-	EncType      int    `help:"Type of encryption to use for content and metadata (1=AES-GCM, 2=SecretBox)" default:"1"`
-	PathEncType  int    `help:"Type of encryption to use for paths (0=Unencrypted, 1=AES-GCM, 2=SecretBox)" default:"1"`
+	Key       string `help:"root key for encrypting the data"`
+	BlockSize int    `help:"size (in bytes) of encrypted blocks" default:"1024"`
+	DataType  int    `help:"Type of encryption to use for content and metadata (1=AES-GCM, 2=SecretBox)" default:"1"`
+	PathType  int    `help:"Type of encryption to use for paths (0=Unencrypted, 1=AES-GCM, 2=SecretBox)" default:"1"`
 }
 
 // MinioConfig is a configuration struct that keeps details about starting
@@ -49,7 +49,7 @@ type EncryptionConfig struct {
 type MinioConfig struct {
 	AccessKey string `help:"Minio Access Key to use" default:"insecure-dev-access-key"`
 	SecretKey string `help:"Minio Secret Key to use" default:"insecure-dev-secret-key"`
-	MinioDir  string `help:"Minio generic server config path" default:"$CONFDIR/minio"`
+	Dir       string `help:"Minio generic server config path" default:"$CONFDIR/minio"`
 }
 
 // ClientConfig is a configuration struct for the miniogw that controls how
@@ -67,18 +67,18 @@ type ClientConfig struct {
 // Config is a general miniogw configuration struct. This should be everything
 // one needs to start a minio gateway.
 type Config struct {
-	provider.IdentityConfig
-	MinioConfig
-	ClientConfig
-	RSConfig
-	EncryptionConfig
+	Identity provider.IdentityConfig
+	Minio    MinioConfig
+	Client   ClientConfig
+	RS       RSConfig
+	Enc      EncryptionConfig
 }
 
 // Run starts a Minio Gateway given proper config
 func (c Config) Run(ctx context.Context) (err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	identity, err := c.Load()
+	identity, err := c.Identity.Load()
 	if err != nil {
 		return err
 	}
@@ -96,17 +96,17 @@ func (c Config) Run(ctx context.Context) (err error) {
 	}
 
 	// TODO(jt): Surely there is a better way. This is so upsetting
-	err = os.Setenv("MINIO_ACCESS_KEY", c.AccessKey)
+	err = os.Setenv("MINIO_ACCESS_KEY", c.Minio.AccessKey)
 	if err != nil {
 		return err
 	}
-	err = os.Setenv("MINIO_SECRET_KEY", c.SecretKey)
+	err = os.Setenv("MINIO_SECRET_KEY", c.Minio.SecretKey)
 	if err != nil {
 		return err
 	}
 
 	minio.Main([]string{"storj", "gateway", "storj",
-		"--address", c.Address, "--config-dir", c.MinioDir, "--quiet"})
+		"--address", c.Identity.Address, "--config-dir", c.Minio.Dir, "--quiet"})
 	return Error.New("unexpected minio exit")
 }
 
@@ -145,37 +145,37 @@ func (c Config) GetMetainfo(ctx context.Context, identity *provider.FullIdentity
 
 func (c Config) init(ctx context.Context, identity *provider.FullIdentity) (buckets.Store, streams.Store, segments.Store, pdbclient.Client, *storj.Key, error) {
 	var oc overlay.Client
-	oc, err := overlay.NewOverlayClient(identity, c.OverlayAddr)
+	oc, err := overlay.NewOverlayClient(identity, c.Client.OverlayAddr)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
 
-	pdb, err := pdbclient.NewClient(identity, c.PointerDBAddr, c.APIKey)
+	pdb, err := pdbclient.NewClient(identity, c.Client.PointerDBAddr, c.Client.APIKey)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
 
-	ec := ecclient.NewClient(identity, c.MaxBufferMem)
-	fc, err := infectious.NewFEC(c.MinThreshold, c.MaxThreshold)
+	ec := ecclient.NewClient(identity, c.RS.MaxBufferMem)
+	fc, err := infectious.NewFEC(c.RS.MinThreshold, c.RS.MaxThreshold)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
-	rs, err := eestream.NewRedundancyStrategy(eestream.NewRSScheme(fc, c.ErasureShareSize), c.RepairThreshold, c.SuccessThreshold)
+	rs, err := eestream.NewRedundancyStrategy(eestream.NewRSScheme(fc, c.RS.ErasureShareSize), c.RS.RepairThreshold, c.RS.SuccessThreshold)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
 
-	segments := segments.NewSegmentStore(oc, ec, pdb, rs, c.MaxInlineSize)
+	segments := segments.NewSegmentStore(oc, ec, pdb, rs, c.Client.MaxInlineSize)
 
-	if c.ErasureShareSize*c.MinThreshold%c.EncBlockSize != 0 {
+	if c.RS.ErasureShareSize*c.RS.MinThreshold%c.Enc.BlockSize != 0 {
 		err = Error.New("EncryptionBlockSize must be a multiple of ErasureShareSize * RS MinThreshold")
 		return nil, nil, nil, nil, nil, err
 	}
 
 	key := new(storj.Key)
-	copy(key[:], c.EncKey)
+	copy(key[:], c.Enc.Key)
 
-	streams, err := streams.NewStreamStore(segments, c.SegmentSize, key, c.EncBlockSize, storj.Cipher(c.EncType))
+	streams, err := streams.NewStreamStore(segments, c.Client.SegmentSize, key, c.Enc.BlockSize, storj.Cipher(c.Enc.DataType))
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
@@ -189,18 +189,18 @@ func (c Config) init(ctx context.Context, identity *provider.FullIdentity) (buck
 func (c Config) GetRedundancyScheme() storj.RedundancyScheme {
 	return storj.RedundancyScheme{
 		Algorithm:      storj.ReedSolomon,
-		RequiredShares: int16(c.MinThreshold),
-		RepairShares:   int16(c.RepairThreshold),
-		OptimalShares:  int16(c.SuccessThreshold),
-		TotalShares:    int16(c.MaxThreshold),
+		RequiredShares: int16(c.RS.MinThreshold),
+		RepairShares:   int16(c.RS.RepairThreshold),
+		OptimalShares:  int16(c.RS.SuccessThreshold),
+		TotalShares:    int16(c.RS.MaxThreshold),
 	}
 }
 
 // GetEncryptionScheme returns the configured encryption scheme for new uploads
 func (c Config) GetEncryptionScheme() storj.EncryptionScheme {
 	return storj.EncryptionScheme{
-		Cipher:    storj.Cipher(c.EncType),
-		BlockSize: int32(c.EncBlockSize),
+		Cipher:    storj.Cipher(c.Enc.DataType),
+		BlockSize: int32(c.Enc.BlockSize),
 	}
 }
 
@@ -213,5 +213,5 @@ func (c Config) NewGateway(ctx context.Context, identity *provider.FullIdentity)
 		return nil, err
 	}
 
-	return NewStorjGateway(bs, storj.Cipher(c.PathEncType)), nil
+	return NewStorjGateway(bs, storj.Cipher(c.Enc.PathType)), nil
 }


### PR DESCRIPTION
This changes the uplink config from looking like this:

```
uplink:
  access-key: insecure-dev-access-key
  address: 127.0.0.1:7777
  api-key: abc123
  cert-path: /home/jt/.local/share/storj/capt/uplink/identity.cert
  enc-block-size: 1024
  enc-key: highlydistributedridiculouslyresilient
  enc-type: 1
  erasure-share-size: 1024
  key-path: /home/jt/.local/share/storj/capt/uplink/identity.key
  max-buffer-mem: 4194304
  max-inline-size: 4096
  max-threshold: 95
  min-threshold: 29
  minio-dir: /home/jt/.local/share/storj/capt/uplink/minio
  overlay-addr: 127.0.0.1:7778
  path-enc-type: 1
  peer-ca-whitelist-path: ""
  pointer-db-addr: 127.0.0.1:7778
  repair-threshold: 35
  secret-key: insecure-dev-secret-key
  segment-size: 64000000
  success-threshold: 80
  verify-auth-ext-sig: false
```

to this:

```
uplink:
  client:
    api-key: abc123
    max-inline-size: 4096
    overlay-addr: 127.0.0.1:7778
    pointer-db-addr: 127.0.0.1:7778
    segment-size: 64000000
  enc:
    block-size: 1024
    data-type: 1
    key: highlydistributedridiculouslyresilient
    path-type: 1
  identity:
    address: 127.0.0.1:7777
    cert-path: /home/jt/.local/share/storj/capt/uplink/identity.cert
    key-path: /home/jt/.local/share/storj/capt/uplink/identity.key
    peer-ca-whitelist-path: ""
    verify-auth-ext-sig: false
  minio:
    access-key: insecure-dev-access-key
    dir: /home/jt/.local/share/storj/capt/uplink/minio
    secret-key: insecure-dev-secret-key
  rs:
    erasure-share-size: 1024
    max-buffer-mem: 4194304
    max-threshold: 95
    min-threshold: 29
    repair-threshold: 35
    success-threshold: 80
```