### PR TITLE
config: use nested config paths

### DIFF
--- a/cmd/captplanet/setup.go
+++ b/cmd/captplanet/setup.go
@@ -67,11 +67,7 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	satellitePath := filepath.Join(setupCfg.BasePath, "satellite")
-	err = os.MkdirAll(satellitePath, 0700)
-	if err != nil {
-		return err
-	}
+	satellitePath := filepath.Join(setupCfg.BasePath, "satellite", "identity")
 	setupCfg.SatelliteCA.CertPath = filepath.Join(satellitePath, "ca.cert")
 	setupCfg.SatelliteCA.KeyPath = filepath.Join(satellitePath, "ca.key")
 	setupCfg.SatelliteIdentity.CertPath = filepath.Join(satellitePath, "identity.cert")
@@ -83,11 +79,8 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	for i := 0; i < len(runCfg.StorageNodes); i++ {
-		storagenodePath := filepath.Join(setupCfg.BasePath, fmt.Sprintf("f%d", i))
-		err = os.MkdirAll(storagenodePath, 0700)
-		if err != nil {
-			return err
-		}
+		storagenodePath := filepath.Join(setupCfg.BasePath, "storage-nodes",
+			fmt.Sprintf("%02d", i), "identity")
 		storagenodeCA := setupCfg.StorageNodeCA
 		storagenodeCA.CertPath = filepath.Join(storagenodePath, "ca.cert")
 		storagenodeCA.KeyPath = filepath.Join(storagenodePath, "ca.key")
@@ -101,11 +94,7 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	uplinkPath := filepath.Join(setupCfg.BasePath, "uplink")
-	err = os.MkdirAll(uplinkPath, 0700)
-	if err != nil {
-		return err
-	}
+	uplinkPath := filepath.Join(setupCfg.BasePath, "uplink/identity")
 	setupCfg.UplinkCA.CertPath = filepath.Join(uplinkPath, "ca.cert")
 	setupCfg.UplinkCA.KeyPath = filepath.Join(uplinkPath, "ca.key")
 	setupCfg.UplinkIdentity.CertPath = filepath.Join(uplinkPath, "identity.cert")
@@ -117,14 +106,16 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	if setupCfg.GenerateMinioCerts {
-		minioCertsPath := filepath.Join(uplinkPath, "minio", "certs")
+		minioCertsPath := filepath.Join(uplinkPath, "uplink", "minio", "certs")
 		if err := os.MkdirAll(minioCertsPath, 0744); err != nil {
 			return err
 		}
-		if err := os.Link(setupCfg.UplinkIdentity.CertPath, filepath.Join(minioCertsPath, "public.crt")); err != nil {
+		if err := os.Link(setupCfg.UplinkIdentity.CertPath,
+			filepath.Join(minioCertsPath, "public.crt")); err != nil {
 			return err
 		}
-		if err := os.Link(setupCfg.UplinkIdentity.KeyPath, filepath.Join(minioCertsPath, "private.key")); err != nil {
+		if err := os.Link(setupCfg.UplinkIdentity.KeyPath,
+			filepath.Join(minioCertsPath, "private.key")); err != nil {
 			return err
 		}
 	}
@@ -134,32 +125,22 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 	overlayAddr := joinHostPort(setupCfg.ListenHost, startingPort+1)
 
 	overrides := map[string]interface{}{
-		"satellite.identity.cert-path": setupCfg.SatelliteIdentity.CertPath,
-		"satellite.identity.key-path":  setupCfg.SatelliteIdentity.KeyPath,
 		"satellite.identity.server.address": joinHostPort(
 			setupCfg.ListenHost, startingPort+1),
 		"satellite.kademlia.bootstrap-addr": joinHostPort(
 			setupCfg.ListenHost, startingPort+1),
-		"satellite.pointer-db.database-url": "bolt://" + filepath.Join(
-			setupCfg.BasePath, "satellite", "pointerdb.db"),
-		"satellite.overlay.database-url": "bolt://" + filepath.Join(
-			setupCfg.BasePath, "satellite", "overlay.db"),
 		"satellite.kademlia.alpha":         3,
 		"satellite.repairer.queue-address": "redis://127.0.0.1:6378?db=1&password=abc123",
 		"satellite.repairer.overlay-addr":  overlayAddr,
 		"satellite.repairer.pointer-db-addr": joinHostPort(
 			setupCfg.ListenHost, startingPort+1),
 		"satellite.repairer.api-key": setupCfg.APIKey,
-		"uplink.identity.cert-path":  setupCfg.UplinkIdentity.CertPath,
-		"uplink.identity.key-path":   setupCfg.UplinkIdentity.KeyPath,
 		"uplink.identity.server.address": joinHostPort(
 			setupCfg.ListenHost, startingPort),
 		"uplink.client.overlay-addr": joinHostPort(
 			setupCfg.ListenHost, startingPort+1),
 		"uplink.client.pointer-db-addr": joinHostPort(
 			setupCfg.ListenHost, startingPort+1),
-		"uplink.minio.dir": filepath.Join(
-			setupCfg.BasePath, "uplink", "minio"),
 		"uplink.enc.key":                  setupCfg.EncKey,
 		"uplink.client.api-key":           setupCfg.APIKey,
 		"uplink.rs.min-threshold":         1 * len(runCfg.StorageNodes) / 5,
@@ -181,17 +162,11 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	for i := 0; i < len(runCfg.StorageNodes); i++ {
-		storagenodePath := filepath.Join(setupCfg.BasePath, fmt.Sprintf("f%d", i))
 		storagenode := fmt.Sprintf("storage-nodes.%02d.", i)
-		overrides[storagenode+"identity.cert-path"] = filepath.Join(
-			storagenodePath, "identity.cert")
-		overrides[storagenode+"identity.key-path"] = filepath.Join(
-			storagenodePath, "identity.key")
 		overrides[storagenode+"identity.server.address"] = joinHostPort(
 			setupCfg.ListenHost, startingPort+i*2+3)
 		overrides[storagenode+"kademlia.bootstrap-addr"] = joinHostPort(
 			setupCfg.ListenHost, startingPort+1)
-		overrides[storagenode+"storage.path"] = filepath.Join(storagenodePath, "data")
 		overrides[storagenode+"kademlia.alpha"] = 3
 	}
 

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -150,7 +150,7 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	err = os.MkdirAll(setupCfg.BasePath, 0700)
+	err = os.MkdirAll(filepath.Join(setupCfg.BasePath, "identity"), 0700)
 	if err != nil {
 		return err
 	}
@@ -168,13 +168,8 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	o := map[string]interface{}{
-		"identity.cert-path": setupCfg.Identity.CertPath,
-		"identity.key-path":  setupCfg.Identity.KeyPath,
-	}
-
 	return process.SaveConfig(runCmd.Flags(),
-		filepath.Join(setupCfg.BasePath, "config.yaml"), o)
+		filepath.Join(setupCfg.BasePath, "config.yaml"), nil)
 }
 
 func cmdDiag(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/storagenode/main.go
+++ b/cmd/storagenode/main.go
@@ -100,14 +100,8 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	overrides := map[string]interface{}{
-		"identity.cert-path": setupCfg.Identity.CertPath,
-		"identity.key-path":  setupCfg.Identity.KeyPath,
-		"storage.path":       filepath.Join(setupCfg.BasePath, "storage"),
-	}
-
 	return process.SaveConfig(runCmd.Flags(),
-		filepath.Join(setupCfg.BasePath, "config.yaml"), overrides)
+		filepath.Join(setupCfg.BasePath, "config.yaml"), nil)
 }
 
 func cmdDiag(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -101,8 +101,6 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	o := map[string]interface{}{
-		"identity.cert-path":     setupCfg.Identity.CertPath,
-		"identity.key-path":      setupCfg.Identity.KeyPath,
 		"client.api-key":         setupCfg.APIKey,
 		"client.pointer-db-addr": setupCfg.SatelliteAddr,
 		"client.overlay-addr":    setupCfg.SatelliteAddr,

--- a/pkg/accounting/rollup/config.go
+++ b/pkg/accounting/rollup/config.go
@@ -15,7 +15,7 @@ import (
 // Config contains configurable values for rollup
 type Config struct {
 	Interval    time.Duration `help:"how frequently rollup should run" default:"30s"`
-	DatabaseURL string        `help:"the database connection string to use" default:"sqlite3://$CONFDIR/stats.db"`
+	DatabaseURL string        `help:"the database connection string to use" default:"sqlite3://${CONFNAME}.db"`
 }
 
 // Initialize a rollup struct

--- a/pkg/accounting/tally/config.go
+++ b/pkg/accounting/tally/config.go
@@ -21,7 +21,7 @@ import (
 // Config contains configurable values for tally
 type Config struct {
 	Interval    time.Duration `help:"how frequently tally should run" default:"30s"`
-	DatabaseURL string        `help:"the database connection string to use" default:"sqlite3://$CONFDIR/accounting.db"`
+	DatabaseURL string        `help:"the database connection string to use" default:"sqlite3://${CONFNAME}.db"`
 }
 
 // Initialize a tally struct
@@ -34,7 +34,9 @@ func (c Config) initialize(ctx context.Context) (Tally, error) {
 		return nil, Error.Wrap(err)
 	}
 
-	masterDB, ok := ctx.Value("masterdb").(interface{ BandwidthAgreement() bwagreement.DB })
+	masterDB, ok := ctx.Value("masterdb").(interface {
+		BandwidthAgreement() bwagreement.DB
+	})
 	if !ok {
 		return nil, errs.New("unable to get master db instance")
 	}

--- a/pkg/bwagreement/config.go
+++ b/pkg/bwagreement/config.go
@@ -21,7 +21,7 @@ var (
 // Config is a configuration struct that is everything you need to start an
 // agreement receiver responsibility
 type Config struct {
-	DatabaseURL string `help:"the database connection string to use" default:"sqlite3://$CONFDIR/bw.db"`
+	DatabaseURL string `help:"the database connection string to use" default:"sqlite3://${CONFNAME}.db"`
 }
 
 // Run implements the provider.Responsibility interface

--- a/pkg/cfgstruct/bind.go
+++ b/pkg/cfgstruct/bind.go
@@ -17,8 +17,10 @@ import (
 // BindOpt is an option for the Bind method
 type BindOpt func(vars map[string]confVar)
 
-// ConfDir sets variables for default options called $CONFDIR and $CONFNAME.
-func ConfDir(confdir string) BindOpt {
+// ConfDirUnnested sets variables for default options called $CONFDIR and
+// $CONFNAME. ConfDirUnnested does not append parent struct field names to the
+// path when descending into substructs.
+func ConfDirUnnested(confdir string) BindOpt {
 	val := filepath.Clean(os.ExpandEnv(confdir))
 	return BindOpt(func(vars map[string]confVar) {
 		vars["CONFDIR"] = confVar{val: val, nested: false}
@@ -26,10 +28,10 @@ func ConfDir(confdir string) BindOpt {
 	})
 }
 
-// ConfDirNested sets variables for default options called $CONFDIR and $CONFNAME.
-// ConfDirNested also appends the parent struct field name to the paths before
+// ConfDir sets variables for default options called $CONFDIR and $CONFNAME.
+// ConfDir also appends the parent struct field name to the paths before
 // descending into substructs.
-func ConfDirNested(confdir string) BindOpt {
+func ConfDir(confdir string) BindOpt {
 	val := filepath.Clean(os.ExpandEnv(confdir))
 	return BindOpt(func(vars map[string]confVar) {
 		vars["CONFDIR"] = confVar{val: val, nested: true}

--- a/pkg/cfgstruct/bind_test.go
+++ b/pkg/cfgstruct/bind_test.go
@@ -75,6 +75,23 @@ func TestBind(t *testing.T) {
 	assertEqual(c.Fields[3].AnotherInt, int(1))
 }
 
+func TestConfDirUnnested(t *testing.T) {
+	f := flag.NewFlagSet("test", flag.PanicOnError)
+	var c struct {
+		String    string `default:"-$CONFDIR+"`
+		MyStruct1 struct {
+			String    string `default:"1${CONFDIR}2"`
+			MyStruct2 struct {
+				String string `default:"2${CONFDIR}3"`
+			}
+		}
+	}
+	Bind(f, &c, ConfDirUnnested("confpath"))
+	assertEqual(f.Lookup("string").DefValue, "-confpath+")
+	assertEqual(f.Lookup("my-struct1.string").DefValue, "1confpath2")
+	assertEqual(f.Lookup("my-struct1.my-struct2.string").DefValue, "2confpath3")
+}
+
 func TestConfDir(t *testing.T) {
 	f := flag.NewFlagSet("test", flag.PanicOnError)
 	var c struct {
@@ -87,23 +104,6 @@ func TestConfDir(t *testing.T) {
 		}
 	}
 	Bind(f, &c, ConfDir("confpath"))
-	assertEqual(f.Lookup("string").DefValue, "-confpath+")
-	assertEqual(f.Lookup("my-struct1.string").DefValue, "1confpath2")
-	assertEqual(f.Lookup("my-struct1.my-struct2.string").DefValue, "2confpath3")
-}
-
-func TestNesting(t *testing.T) {
-	f := flag.NewFlagSet("test", flag.PanicOnError)
-	var c struct {
-		String    string `default:"-$CONFDIR+"`
-		MyStruct1 struct {
-			String    string `default:"1${CONFDIR}2"`
-			MyStruct2 struct {
-				String string `default:"2${CONFDIR}3"`
-			}
-		}
-	}
-	Bind(f, &c, ConfDirNested("confpath"))
 	assertEqual(f.Lookup("string").DefValue, "-confpath+")
 	assertEqual(f.Lookup("my-struct1.string").DefValue, "1confpath/my-struct12")
 	assertEqual(f.Lookup("my-struct1.my-struct2.string").DefValue, "2confpath/my-struct1/my-struct23")

--- a/pkg/datarepair/checker/config.go
+++ b/pkg/datarepair/checker/config.go
@@ -23,7 +23,7 @@ import (
 type Config struct {
 	QueueAddress     string        `help:"data checker queue address" default:"redis://127.0.0.1:6378?db=1&password=abc123"`
 	Interval         time.Duration `help:"how frequently checker should audit segments" default:"30s"`
-	IrreparabledbURL string        `help:"the database connection string to use" default:"sqlite3://$CONFDIR/irreparable.db"`
+	IrreparabledbURL string        `help:"the database connection string to use" default:"sqlite3://${CONFNAME}.db"`
 }
 
 // Initialize a Checker struct

--- a/pkg/kademlia/config.go
+++ b/pkg/kademlia/config.go
@@ -45,7 +45,7 @@ type FarmerConfig struct {
 // server endpoints (and not necessarily client code).
 type Config struct {
 	BootstrapAddr   string `help:"the kademlia node to bootstrap against" default:"bootstrap-dev.storj.io:8080"`
-	DBPath          string `help:"the path for our db services to be created on" default:"$CONFDIR/kademlia"`
+	DBPath          string `help:"the path for our db services to be created on" default:"${CONFNAME}.db"`
 	Alpha           int    `help:"alpha is a system wide concurrency parameter." default:"5"`
 	ExternalAddress string `help:"the public address of the kademlia node; defaults to the gRPC server address." default:""`
 	Farmer          FarmerConfig

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -5,7 +5,6 @@ package kademlia
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -66,16 +65,11 @@ func NewKademlia(id storj.NodeID, nodeType pb.NodeType, bootstrapNodes []pb.Node
 		Metadata: metadata,
 	}
 
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		if err := os.MkdirAll(path, 0777); err != nil {
-			return nil, err
-		}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, BootstrapErr.Wrap(err)
 	}
 
-	bucketIdentifier := id.String()[:5] // need a way to differentiate between nodes if running more than one simultaneously
-	dbpath := filepath.Join(path, fmt.Sprintf("kademlia_%s.db", bucketIdentifier))
-
-	dbs, err := boltdb.NewShared(dbpath, KademliaBucket, NodeBucket)
+	dbs, err := boltdb.NewShared(path, KademliaBucket, NodeBucket)
 	if err != nil {
 		return nil, BootstrapErr.Wrap(err)
 	}

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -60,7 +60,7 @@ func TestNewKademlia(t *testing.T) {
 	}
 
 	for i, v := range cases {
-		dir := filepath.Join(rootdir, strconv.Itoa(i))
+		dir := filepath.Join(rootdir, strconv.Itoa(i)+".db")
 
 		ca, err := testidentity.NewTestCA(context.Background())
 		assert.NoError(t, err)
@@ -94,7 +94,7 @@ func TestPeerDiscovery(t *testing.T) {
 		Email:  "foo@bar.com",
 		Wallet: "FarmerWallet",
 	}
-	k, err := NewKademlia(testID.ID, pb.NodeType_STORAGE, bootstrapNodes, testAddress, metadata, testID, dir, defaultAlpha)
+	k, err := NewKademlia(testID.ID, pb.NodeType_STORAGE, bootstrapNodes, testAddress, metadata, testID, filepath.Join(dir, "db.db"), defaultAlpha)
 	assert.NoError(t, err)
 	rt, err := k.GetRoutingTable(context.Background())
 	assert.NoError(t, err)
@@ -168,7 +168,7 @@ func testNode(t *testing.T, bn []pb.Node) (*Kademlia, *grpc.Server, func()) {
 	// new kademlia
 	dir, cleanup := mktempdir(t, "kademlia")
 
-	k, err := NewKademlia(fid.ID, pb.NodeType_STORAGE, bn, lis.Addr().String(), nil, fid, dir, defaultAlpha)
+	k, err := NewKademlia(fid.ID, pb.NodeType_STORAGE, bn, lis.Addr().String(), nil, fid, filepath.Join(dir, "db.db"), defaultAlpha)
 	assert.NoError(t, err)
 	s := node.NewServer(k)
 	// new ident opts
@@ -214,7 +214,7 @@ func TestGetNodes(t *testing.T) {
 	assert.NotEqual(t, fid.ID, fid2.ID)
 	dir, cleanup := mktempdir(t, "kademlia")
 	defer cleanup()
-	k, err := NewKademlia(fid.ID, pb.NodeType_STORAGE, []pb.Node{{Id: fid2.ID, Address: &pb.NodeAddress{Address: lis.Addr().String()}}}, lis.Addr().String(), nil, fid, dir, defaultAlpha)
+	k, err := NewKademlia(fid.ID, pb.NodeType_STORAGE, []pb.Node{{Id: fid2.ID, Address: &pb.NodeAddress{Address: lis.Addr().String()}}}, lis.Addr().String(), nil, fid, filepath.Join(dir, "db.db"), defaultAlpha)
 	assert.NoError(t, err)
 	defer func() {
 		assert.NoError(t, k.Disconnect())

--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -29,7 +29,7 @@ import (
 // redundancy strategy information
 type RSConfig struct {
 	MaxBufferMem     int `help:"maximum buffer memory (in bytes) to be allocated for read buffers" default:"0x400000"`
-	ErasureShareSize int `help:"the size of each new erasure sure in bytes" default:"1024"`
+	ErasureShareSize int `help:"the size of each new erasure share in bytes" default:"1024"`
 	MinThreshold     int `help:"the minimum pieces required to recover a segment. k." default:"29"`
 	RepairThreshold  int `help:"the minimum safe pieces before a repair is triggered. m." default:"35"`
 	SuccessThreshold int `help:"the desired total pieces for a segment. o." default:"80"`
@@ -59,7 +59,7 @@ type EncryptionConfig struct {
 type MinioConfig struct {
 	AccessKey string `help:"Minio Access Key to use" default:"insecure-dev-access-key"`
 	SecretKey string `help:"Minio Secret Key to use" default:"insecure-dev-secret-key"`
-	Dir       string `help:"Minio generic server config path" default:"$CONFDIR/minio"`
+	Dir       string `help:"Minio generic server config path" default:"$CONFDIR"`
 }
 
 // ClientConfig is a configuration struct for the miniogw that controls how

--- a/pkg/overlay/config.go
+++ b/pkg/overlay/config.go
@@ -32,7 +32,7 @@ var (
 // Config is a configuration struct for everything you need to start the
 // Overlay cache responsibility.
 type Config struct {
-	DatabaseURL     string        `help:"the database connection string to use" default:"bolt://$CONFDIR/overlay.db"`
+	DatabaseURL     string        `help:"the database connection string to use" default:"bolt://${CONFNAME}.db"`
 	RefreshInterval time.Duration `help:"the interval at which the cache refreshes itself in seconds" default:"1s"`
 }
 

--- a/pkg/pointerdb/config.go
+++ b/pkg/pointerdb/config.go
@@ -30,7 +30,7 @@ const (
 // Config is a configuration struct that is everything you need to start a
 // PointerDB responsibility
 type Config struct {
-	DatabaseURL          string `help:"the database connection string to use" default:"bolt://$CONFDIR/pointerdb.db"`
+	DatabaseURL          string `help:"the database connection string to use" default:"bolt://${CONFNAME}.db"`
 	MinRemoteSegmentSize int    `default:"1240" help:"minimum remote segment size"`
 	MaxInlineSegmentSize int    `default:"8000" help:"maximum inline segment size"`
 	Overlay              bool   `default:"true" help:"toggle flag if overlay is enabled"`

--- a/pkg/process/exec.go
+++ b/pkg/process/exec.go
@@ -12,7 +12,6 @@ import (
 )
 
 func init() {
-
 	cobra.MousetrapHelpText = "This is a command line tool.\n\n" +
 		"This needs to be run from a Command Prompt.\n"
 

--- a/pkg/satellite/satelliteweb/config.go
+++ b/pkg/satellite/satelliteweb/config.go
@@ -21,7 +21,7 @@ import (
 type Config struct {
 	GatewayConfig
 	SatelliteAddr string `help:"satellite main endpoint" default:""`
-	DatabaseURL   string `help:"" default:"sqlite3://$CONFDIR/satellitedb.db"`
+	DatabaseURL   string `help:"" default:"sqlite3://${CONFNAME}.db"`
 }
 
 // Run implements Responsibility interface

--- a/pkg/statdb/config.go
+++ b/pkg/statdb/config.go
@@ -21,7 +21,7 @@ const (
 // Config is a configuration struct that is everything you need to start a
 // StatDB responsibility
 type Config struct {
-	DatabaseURL    string `help:"the database connection string to use" default:"$CONFDIR/stats.db"`
+	DatabaseURL    string `help:"the database connection string to use" default:"${CONFNAME}.db"`
 	DatabaseDriver string `help:"the database driver to use" default:"sqlite3"`
 }
 


### PR DESCRIPTION
The goal of this PR is to clean up everything in the ~/local/share/storj/ directory. Everything Satellite related should be under a specific Satellite directory. Everything under a specific storage node (including Kademlia) should be under a specific storage node directory. Etc. This uses the inherent config struct nesting to choose paths on disk.