### PR TITLE
Add time limit to ensure that travis prints something when it fails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
         - go install -race ./...
       script:
         - go run scripts/use-ports.go -from 1024 -to 10000 &
-        - go test -race -cover -coverprofile=.coverprofile -json ./... | tparse -all
+        - go test -race -cover -coverprofile=.coverprofile -json -timeout 9m ./... | tparse -all
         - goveralls -coverprofile=.coverprofile -service=travis-ci
         - rm .coverprofile
         - go run scripts/check-clean-directory.go


### PR DESCRIPTION
Travis doesn't show anything when it fails in 10min time-limit, ensure that go returns before that.