### PR TITLE
Fix deadlock on testplanet shutdown

### DIFF
--- a/internal/testplanet/node.go
+++ b/internal/testplanet/node.go
@@ -91,6 +91,9 @@ func (node *Node) Addr() string { return node.Info.Address.Address }
 // Shutdown shuts down all node dependencies
 func (node *Node) Shutdown() error {
 	var errs []error
+	if node.Kademlia != nil {
+		errs = append(errs, node.Kademlia.Disconnect())
+	}
 	if node.Provider != nil {
 		errs = append(errs, node.Provider.Close())
 	}
@@ -98,9 +101,6 @@ func (node *Node) Shutdown() error {
 	// if node.Listener != nil {
 	//    errs = append(errs, node.Listener.Close())
 	// }
-	if node.Kademlia != nil {
-		errs = append(errs, node.Kademlia.Disconnect())
-	}
 
 	for _, dep := range node.Dependencies {
 		err := dep.Close()

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -46,12 +46,13 @@ type discoveryOptions struct {
 
 // Kademlia is an implementation of kademlia adhering to the DHT interface.
 type Kademlia struct {
-	alpha          int // alpha is a system wide concurrency parameter
-	routingTable   *RoutingTable
-	bootstrapNodes []pb.Node
-	address        string
-	nodeClient     node.Client
-	identity       *provider.FullIdentity
+	alpha           int // alpha is a system wide concurrency parameter
+	routingTable    *RoutingTable
+	bootstrapNodes  []pb.Node
+	address         string
+	nodeClient      node.Client
+	identity        *provider.FullIdentity
+	bootstrapCancel context.CancelFunc
 }
 
 // NewKademlia returns a newly configured Kademlia instance
@@ -108,6 +109,10 @@ func NewKademliaWithRoutingTable(self pb.Node, bootstrapNodes []pb.Node, identit
 
 // Disconnect safely closes connections to the Kademlia network
 func (k *Kademlia) Disconnect() error {
+	if k.bootstrapCancel != nil {
+		k.bootstrapCancel()
+	}
+
 	return utils.CombineErrors(
 		k.nodeClient.Disconnect(),
 		k.routingTable.Close(),
@@ -172,7 +177,10 @@ func (k *Kademlia) Bootstrap(ctx context.Context) error {
 		return BootstrapErr.New("no bootstrap nodes provided")
 	}
 
-	return k.lookup(ctx, k.routingTable.self.Id, discoveryOptions{
+	bootstrapContext, bootstrapCancel := context.WithCancel(ctx)
+	k.bootstrapCancel = bootstrapCancel
+
+	return k.lookup(bootstrapContext, k.routingTable.self.Id, discoveryOptions{
 		concurrency: k.alpha, retries: defaultRetries, bootstrap: true, bootstrapNodes: k.bootstrapNodes,
 	})
 }


### PR DESCRIPTION
Test cases running on testplanet may be delayed with 20 seconds due to a deadlock during testplanet shutdown.

These are the two goroutines that take part in the deadlock:

```
goroutine 5 [sync.Cond.Wait]:
sync.runtime_notifyListWait(0xc0001a26d0, 0x100000002)
	/usr/local/go/src/runtime/sema.go:510 +0xeb
sync.(*Cond).Wait(0xc0001a26c0)
	/usr/local/go/src/sync/cond.go:56 +0x8e
google.golang.org/grpc.(*Server).GracefulStop(0xc00048d080)
	/home/kaloyan/go/pkg/mod/google.golang.org/grpc@v1.15.0/server.go:1362 +0x29e
storj.io/storj/pkg/provider.(*Provider).Close(0xc0001a2700, 0x2, 0x2)
	/home/kaloyan/git/storj/pkg/provider/provider.go:112 +0x51
storj.io/storj/internal/testplanet.(*Node).Shutdown(0xc0003421e0, 0x0, 0x0)
	/home/kaloyan/git/storj/internal/testplanet/node.go:95 +0x4a6
storj.io/storj/internal/testplanet.(*Planet).Shutdown(0xc00033e0c0, 0xc00031e148, 0xc00064be68)
	/home/kaloyan/git/storj/internal/testplanet/planet.go:203 +0x161
storj.io/storj/internal/testplanet.(*Planet).Shutdown-fm(0xc00031e100, 0x443161)
	/home/kaloyan/git/storj/pkg/metainfo/kvmetainfo/buckets_test.go:319 +0x42
storj.io/storj/internal/testcontext.(*Context).Check(0xc000159c80, 0xc00064bf28)
	/home/kaloyan/git/storj/internal/testcontext/context.go:102 +0x69
storj.io/storj/pkg/metainfo/kvmetainfo.runTest(0xc00031e100, 0xc000667f58)
	/home/kaloyan/git/storj/pkg/metainfo/kvmetainfo/buckets_test.go:329 +0x201
storj.io/storj/pkg/metainfo/kvmetainfo.TestListBucketsEmpty(0xc00031e100)
	/home/kaloyan/git/storj/pkg/metainfo/kvmetainfo/buckets_test.go:182 +0x5c
testing.tRunner(0xc00031e100, 0x101c5a8)
	/usr/local/go/src/testing/testing.go:827 +0x163
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:878 +0x651
```

```
goroutine 73 [select]:
google.golang.org/grpc.(*ClientConn).WaitForStateChange(0xc000d42000, 0x110ab20, 0xc000555c20, 0x3, 0x1)
	/home/kaloyan/go/pkg/mod/google.golang.org/grpc@v1.15.0/clientconn.go:387 +0x15b
google.golang.org/grpc.DialContext(0x110ab20, 0xc000555c20, 0xc00025c9a0, 0xf, 0xc00022e600, 0x2, 0x2, 0x0, 0x0, 0x0)
	/home/kaloyan/go/pkg/mod/google.golang.org/grpc@v1.15.0/clientconn.go:295 +0xe77
storj.io/storj/pkg/transport.(*Transport).DialNode(0xc00000e200, 0x110aae0, 0xc0000c2010, 0xc0002d55f0, 0xc0002f2b30, 0x1, 0x1, 0x0, 0xc000463080, 0xc0002cab80)
	/home/kaloyan/git/storj/pkg/transport/transport.go:62 +0x629
storj.io/storj/pkg/node.(*ConnectionPool).Dial.func1()
	/home/kaloyan/git/storj/pkg/node/connection_pool.go:89 +0x14a
sync.(*Once).Do(0xc000d2e1a0, 0xc00095bac0)
	/usr/local/go/src/sync/once.go:44 +0xdf
storj.io/storj/pkg/node.(*ConnectionPool).Dial(0xc0001a3000, 0x110aae0, 0xc0000c2010, 0xc0002d55f0, 0x0, 0xc0002a60a0, 0xc00095bb50, 0x453e1a)
	/home/kaloyan/git/storj/pkg/node/connection_pool.go:88 +0x220
storj.io/storj/pkg/node.(*Node).Lookup(0xc0000f7680, 0x110aae0, 0xc0000c2010, 0xf493784bd48d1cda, 0xbd662331cf7070d8, 0xed6f5e5b9f01e319, 0x8059d504d1f678, 0xc000cc20c0, 0x1, 0x0, ...)
	/home/kaloyan/git/storj/pkg/node/node.go:22 +0x175
storj.io/storj/pkg/kademlia.(*peerDiscovery).Run.func1(0xc0002a60b4, 0xc0002d60d0, 0xc0002a60b0, 0xc0000c4368, 0xc0002a60a8, 0x110aae0, 0xc0000c2010)
	/home/kaloyan/git/storj/pkg/kademlia/peer_discovery.go:90 +0x333
created by storj.io/storj/pkg/kademlia.(*peerDiscovery).Run
	/home/kaloyan/git/storj/pkg/kademlia/peer_discovery.go:59 +0x219
```

Goroutine 5 waits on `Provider.Close` for all grpc connections to be closed, and goroutine 73 wait on grpc for someone to cancel it. Eventually, it is the Transport Client's timeout of 20 seconds that expires, cancel the context and breaks the context.

The fix is to cancel the context as part of the shutdown process, so all grpc connections are closed before calling `Provider.Close`.