### PR TITLE
Simplify testing with all supported DBs

### DIFF
--- a/pkg/bwagreement/test/server_test.go
+++ b/pkg/bwagreement/test/server_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestBandwidthAgreements(t *testing.T) {
-	satellitedbtest.ForEach(t, func(db *satellitedb.DB) {
+	satellitedbtest.Run(t, func(db *satellitedb.DB) {
 		ctx := testcontext.New(t)
 		defer ctx.Cleanup()
 

--- a/pkg/bwagreement/test/server_test.go
+++ b/pkg/bwagreement/test/server_test.go
@@ -6,8 +6,6 @@ package test
 import (
 	"context"
 	"crypto/ecdsa"
-	"flag"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,74 +18,24 @@ import (
 	"storj.io/storj/satellite/satellitedb"
 )
 
-const (
-	// postgres connstring that works with docker-compose
-	defaultPostgresConn = "postgres://storj:storj-pass@test-postgres/teststorj?sslmode=disable"
-)
-
-var (
-	testPostgres = flag.String("postgres-test-db", os.Getenv("STORJ_POSTGRES_TEST"), "PostgreSQL test database connection string")
-)
-
 func TestBandwidthAgreements(t *testing.T) {
-	testBandwidthAgreements := func(ctx context.Context, t *testing.T, service *bwagreement.Server, satelliteKey *ecdsa.PrivateKey, uplinkKey *ecdsa.PrivateKey) {
-		pba, err := GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satelliteKey)
+	satellitedb.ForEach(t, func(db *satellitedb.DB) {
+		ctx := testcontext.New(t)
+		defer ctx.Cleanup()
+
+		satellitePubKey, satellitePrivKey, uplinkPrivKey := generateKeys(ctx, t)
+		server := bwagreement.NewServer(db.BandwidthAgreement(), zap.NewNop(), satellitePubKey)
+
+		pba, err := GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satellitePrivKey)
 		assert.NoError(t, err)
 
-		rba, err := GenerateRenterBandwidthAllocation(pba, uplinkKey)
+		rba, err := GenerateRenterBandwidthAllocation(pba, uplinkPrivKey)
 		assert.NoError(t, err)
 
 		/* emulate sending the bwagreement stream from piecestore node */
-		replay, err := service.BandwidthAgreements(ctx, rba)
+		replay, err := server.BandwidthAgreements(ctx, rba)
 		assert.NoError(t, err)
 		assert.Equal(t, pb.AgreementsSummary_OK, replay.Status)
-	}
-
-	t.Run("Sqlite", func(t *testing.T) {
-		ctx := testcontext.New(t)
-		defer ctx.Cleanup()
-
-		// creating in-memory db and opening connection
-		db, err := satellitedb.NewDB("sqlite3://file::memory:?mode=memory&cache=shared")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer ctx.Check(db.Close)
-
-		err = db.CreateTables()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		satellitePubKey, satellitePrivKey, uplinkPrivKey := generateKeys(ctx, t)
-		server := bwagreement.NewServer(db.BandwidthAgreement(), zap.NewNop(), satellitePubKey)
-
-		testBandwidthAgreements(ctx, t, server, satellitePrivKey, uplinkPrivKey)
-	})
-
-	t.Run("Postgres", func(t *testing.T) {
-		if *testPostgres == "" {
-			t.Skipf("postgres flag missing, example:\n-postgres-test-db=%s", defaultPostgresConn)
-		}
-
-		ctx := testcontext.New(t)
-		defer ctx.Cleanup()
-
-		db, err := satellitedb.NewDB(*testPostgres)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer ctx.Check(db.Close)
-
-		err = db.CreateTables()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		satellitePubKey, satellitePrivKey, uplinkPrivKey := generateKeys(ctx, t)
-		server := bwagreement.NewServer(db.BandwidthAgreement(), zap.NewNop(), satellitePubKey)
-
-		testBandwidthAgreements(ctx, t, server, satellitePrivKey, uplinkPrivKey)
 	})
 }
 

--- a/pkg/bwagreement/test/server_test.go
+++ b/pkg/bwagreement/test/server_test.go
@@ -16,10 +16,11 @@ import (
 	"storj.io/storj/pkg/bwagreement"
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/satellite/satellitedb"
+	"storj.io/storj/satellite/satellitedb/satellitedbtest"
 )
 
 func TestBandwidthAgreements(t *testing.T) {
-	satellitedb.ForEach(t, func(db *satellitedb.DB) {
+	satellitedbtest.ForEach(t, func(db *satellitedb.DB) {
 		ctx := testcontext.New(t)
 		defer ctx.Cleanup()
 

--- a/satellite/satellitedb/database_test.go
+++ b/satellite/satellitedb/database_test.go
@@ -4,22 +4,11 @@
 package satellitedb
 
 import (
-	"flag"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"storj.io/storj/internal/testcontext"
-)
-
-const (
-	// this connstring is expected to work under the storj-test docker-compose instance
-	defaultPostgresConn = "postgres://storj:storj-pass@test-postgres/teststorj?sslmode=disable"
-)
-
-var (
-	testPostgres = flag.String("postgres-test-db", os.Getenv("STORJ_POSTGRES_TEST"), "PostgreSQL test database connection string")
 )
 
 func TestDatabase(t *testing.T) {

--- a/satellite/satellitedb/database_test.go
+++ b/satellite/satellitedb/database_test.go
@@ -1,52 +1,16 @@
 // Copyright (C) 2018 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-package satellitedb
+package satellitedb_test
 
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
-	"storj.io/storj/internal/testcontext"
+	"storj.io/storj/satellite/satellitedb"
+	"storj.io/storj/satellite/satellitedb/satellitedbtest"
 )
 
 func TestDatabase(t *testing.T) {
-	testDrivers(t, func(ctx *testcontext.Context, t *testing.T, db *DB) {
-		err := db.CreateTables()
-		assert.NoError(t, err)
-	})
-}
-
-func testDrivers(t *testing.T, fn func(ctx *testcontext.Context, t *testing.T, db *DB)) {
-	t.Run("Sqlite", func(t *testing.T) {
-		ctx := testcontext.New(t)
-		defer ctx.Cleanup()
-
-		// creating in-memory db and opening connection
-		db, err := NewDB("sqlite3://file::memory:?mode=memory&cache=shared")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer ctx.Check(db.Close)
-
-		fn(ctx, t, db)
-	})
-
-	t.Run("Postgres", func(t *testing.T) {
-		if *testPostgres == "" {
-			t.Skipf("postgres flag missing, example:\n-postgres-test-db=%s", defaultPostgresConn)
-		}
-
-		ctx := testcontext.New(t)
-		defer ctx.Cleanup()
-
-		db, err := NewDB(*testPostgres)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer ctx.Check(db.Close)
-
-		fn(ctx, t, db)
+	satellitedbtest.Run(t, func(db *satellitedb.DB) {
 	})
 }

--- a/satellite/satellitedb/satellitedbtest/utils.go
+++ b/satellite/satellitedb/satellitedbtest/utils.go
@@ -23,7 +23,7 @@ var (
 	testPostgres = flag.String("postgres-test-db", os.Getenv("STORJ_POSTGRES_TEST"), "PostgreSQL test database connection string")
 )
 
-// ForEach method will iterate over all supported databases. Will establish
+// Run method will iterate over all supported databases. Will establish
 // connection and will create tables for each DB.
 func Run(t *testing.T, test func(db *satellitedb.DB)) {
 	for _, dbInfo := range []struct {

--- a/satellite/satellitedb/satellitedbtest/utils.go
+++ b/satellite/satellitedb/satellitedbtest/utils.go
@@ -25,7 +25,7 @@ var (
 
 // ForEach method will iterate over all supported databases. Will establish
 // connection and will create tables for each DB.
-func ForEach(t *testing.T, test func(db *satellitedb.DB)) {
+func Run(t *testing.T, test func(db *satellitedb.DB)) {
 	for _, dbInfo := range []struct {
 		dbName    string
 		dbURL     string

--- a/satellite/satellitedb/utils.go
+++ b/satellite/satellitedb/utils.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package satellitedb
+
+import (
+	"flag"
+	"os"
+)
+
+const (
+	// postgres connstring that works with docker-compose
+	defaultPostgresConn = "postgres://storj:storj-pass@test-postgres/teststorj?sslmode=disable"
+	defaultSqliteConn   = "sqlite3://file::memory:?mode=memory&cache=shared"
+)
+
+var (
+	testPostgres = flag.String("postgres-test-db", os.Getenv("STORJ_POSTGRES_TEST"), "PostgreSQL test database connection string")
+)
+
+type basicLogger interface {
+	Log(args ...interface{})
+	Fatal(args ...interface{})
+}
+
+// ForEach method will iterate over all supported databases. Will establish
+// connection and will create tables for each DB.
+func ForEach(logger basicLogger, test func(db *DB)) {
+	for _, dbInfo := range []struct {
+		dbName    string
+		dbURL     string
+		dbMessage string
+	}{
+		{"Sqlite", defaultSqliteConn, ""},
+		{"Postgres", *testPostgres, "Postgres flag missing, example: -postgres-test-db=" + defaultPostgresConn},
+	} {
+		if dbInfo.dbURL == "" {
+			logger.Log("Database", dbInfo.dbName, "connection string not provided.", dbInfo.dbMessage)
+			continue
+		}
+
+		logger.Log("Start testing", dbInfo.dbName)
+
+		db, err := NewDB(dbInfo.dbURL)
+		if err != nil {
+			logger.Fatal(err)
+		}
+
+		defer func() {
+			err := db.Close()
+			if err != nil {
+				logger.Fatal(err)
+			}
+		}()
+
+		err = db.CreateTables()
+		if err != nil {
+			logger.Fatal(err)
+		}
+
+		test(db)
+
+		logger.Log("Stop testing", dbInfo.dbName)
+	}
+}


### PR DESCRIPTION
Method `ForEach` was created to move DB creation from specific packages (e.g. bwagreement) and simplify testing with all supported DBs. PR contains also changes in bwagreement package to show how method can be used.