### PR TITLE
Verify bucket exists before starting multipart upload

### DIFF
--- a/pkg/miniogw/multipart.go
+++ b/pkg/miniogw/multipart.go
@@ -21,6 +21,12 @@ import (
 func (layer *gatewayLayer) NewMultipartUpload(ctx context.Context, bucket, object string, metadata map[string]string) (uploadID string, err error) {
 	defer mon.Task()(&ctx)(&err)
 
+	// Check that the bucket exists
+	_, err = layer.gateway.metainfo.GetBucket(ctx, bucket)
+	if err != nil {
+		return "", convertError(err, bucket, "")
+	}
+
 	uploads := layer.gateway.multipart
 
 	upload, err := uploads.Create(bucket, object, metadata)


### PR DESCRIPTION
If the bucket does not exist, the multipart upload should fail fast with "NoSuchBucket" error.

Without this fix, the goroutine of the multipart upload starts generating tons of errors on captplanet and returning a confusing "Connection was closed before we received a valid response from endpoint URL" to the S3 client.