### PR TITLE
Run windows tests only when windows is in commit message.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ matrix:
     
     ### windows tests ###
     - env: MODE=windows-tests
+      if: commit_message !~ /windows/
       os: windows
       services:
         - redis

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
     
     ### windows tests ###
     - env: MODE=windows-tests
-      if: commit_message =~ /windows/
+      if: commit_message =~ /(?i:windows)/
       os: windows
       services:
         - redis

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
     
     ### windows tests ###
     - env: MODE=windows-tests
-      if: commit_message !~ /windows/
+      if: commit_message =~ /windows/
       os: windows
       services:
         - redis


### PR DESCRIPTION
Disable windows tests, they are using up quite a lot of resources in Travis, so make them run only on demand.