### PR TITLE
Reduce ranger test output

### DIFF
--- a/pkg/ranger/content_test.go
+++ b/pkg/ranger/content_test.go
@@ -82,9 +82,7 @@ func Test_isZeroTime(t *testing.T) {
 			name:     "Valid",
 			t:        time.Now().UTC(),
 			expected: false,
-		},
-
-		{
+		}, {
 			name:     "Zero time",
 			t:        time.Unix(0, 0).UTC(),
 			expected: true,
@@ -149,56 +147,42 @@ func Test_checkPreconditions(t *testing.T) {
 			requestHeaderMap:    map[string]string{"If-Match": "\t\t"},
 			expectedDone:        true,
 			expectedRangeHeader: "",
-		},
-
-		{
+		}, {
 			name:                "No If-Match header",
 			requestHeaderMap:    map[string]string{"If-Unmodified-Since": "Thursday, 18-Jul-18 12:20:25 EEST"},
 			expectedDone:        true,
 			modtime:             time.Unix(1531999477, 0).UTC(),
 			expectedRangeHeader: "",
-		},
-
-		{
+		}, {
 			name:                "Any If-Match header with GET request",
 			requestMethod:       http.MethodGet, //By default method is GET. Wrote for clarity
 			requestHeaderMap:    map[string]string{"If-None-Match": "*"},
 			expectedDone:        true,
 			expectedRangeHeader: "",
-		},
-
-		{
+		}, {
 			name:                "Any If-Match header with HEAD request",
 			requestHeaderMap:    map[string]string{"If-None-Match": "*"},
 			requestMethod:       http.MethodHead,
 			expectedDone:        true,
 			expectedRangeHeader: "",
-		},
-
-		{
+		}, {
 			name:                "Any If-Match header with PUT request",
 			requestHeaderMap:    map[string]string{"If-None-Match": "*"},
 			requestMethod:       http.MethodPut,
 			expectedDone:        true,
 			expectedRangeHeader: "",
-		},
-
-		{
+		}, {
 			name:                "Empty request",
 			requestHeaderMap:    map[string]string{},
 			expectedDone:        false,
 			expectedRangeHeader: "",
-		},
-
-		{
+		}, {
 			name:                "Empty modified request",
 			requestHeaderMap:    map[string]string{"If-Modified-Since": "Thursday, 20-Jul-18 12:20:25 EEST"},
 			modtime:             time.Unix(1531999477, 0).UTC(),
 			expectedDone:        true,
 			expectedRangeHeader: "",
-		},
-
-		{
+		}, {
 			name:                "Empty unmodified request",
 			requestHeaderMap:    map[string]string{"Range": "aaa", "If-Range": "\"abcde\""},
 			expectedDone:        false,
@@ -235,40 +219,28 @@ func Test_checkIfMatch(t *testing.T) {
 			name:             "No If-Match header",
 			requestHeaderMap: map[string]string{},
 			expectedResult:   condNone,
-		},
-
-		{
+		}, {
 			name:             "Empty If-Match with trailing spaces",
 			requestHeaderMap: map[string]string{"If-Match": "\t\t"},
 			expectedResult:   condFalse,
-		},
-
-		{
+		}, {
 			name:             "Starts with coma",
 			requestHeaderMap: map[string]string{"If-Match": ","},
 			expectedResult:   condFalse,
-		},
-
-		{
+		}, {
 			name:             "Anything match",
 			requestHeaderMap: map[string]string{"If-Match": "*"},
 			expectedResult:   condTrue,
-		},
-
-		{
+		}, {
 			name:             "Empty If-Match ETag",
 			requestHeaderMap: map[string]string{"If-Match": "abcd"},
 			expectedResult:   condFalse,
-		},
-
-		{
+		}, {
 			name:             "First ETag match",
 			requestHeaderMap: map[string]string{"If-Match": "\"testETag\", \"testETag\""},
 			writerHeaderMap:  map[string]string{"Etag": "\"testETag\""},
 			expectedResult:   condTrue,
-		},
-
-		{
+		}, {
 			name:             "Separated ETag match",
 			requestHeaderMap: map[string]string{"If-Match": "\"wrongETag\", \"correctETag\""},
 			writerHeaderMap:  map[string]string{"Etag": "\"correctETag\""},
@@ -305,30 +277,22 @@ func Test_checkIfUnmodifiedSince(t *testing.T) {
 			headerMap:      map[string]string{},
 			modtime:        time.Now().UTC(),
 			expectedResult: condNone,
-		},
-
-		{
+		}, {
 			name:           "Zero time",
 			headerMap:      map[string]string{"If-Unmodified-Since": "Thursday, 18-Jul-18 12:20:25 EEST"},
 			modtime:        time.Unix(0, 0).UTC(),
 			expectedResult: condNone,
-		},
-
-		{
+		}, {
 			name:           "Is modified",
 			headerMap:      map[string]string{"If-Unmodified-Since": "Thursday, 20-Jul-18 12:20:25 EEST"},
 			modtime:        time.Unix(1531999477, 0).UTC(),
 			expectedResult: condTrue,
-		},
-
-		{
+		}, {
 			name:           "Is not modified",
 			headerMap:      map[string]string{"If-Unmodified-Since": "Thursday, 18-Jul-18 12:20:25 EEST"},
 			modtime:        time.Unix(1531999477, 0).UTC(),
 			expectedResult: condFalse,
-		},
-
-		{
+		}, {
 			name:           "Malformed RFC time",
 			headerMap:      map[string]string{"If-Unmodified-Since": "abcdefg"},
 			modtime:        time.Unix(1531999477, 0).UTC(),
@@ -359,40 +323,28 @@ func Test_checkIfNoneMatch(t *testing.T) {
 			name:             "No If-None-Match header",
 			requestHeaderMap: map[string]string{},
 			expectedResult:   condNone,
-		},
-
-		{
+		}, {
 			name:             "Empty If-None-Match with trailing spaces",
 			requestHeaderMap: map[string]string{"If-None-Match": "\t\t"},
 			expectedResult:   condTrue,
-		},
-
-		{
+		}, {
 			name:             "Starts with coma",
 			requestHeaderMap: map[string]string{"If-None-Match": ","},
 			expectedResult:   condTrue,
-		},
-
-		{
+		}, {
 			name:             "Anything match",
 			requestHeaderMap: map[string]string{"If-None-Match": "*"},
 			expectedResult:   condFalse,
-		},
-
-		{
+		}, {
 			name:             "Empty If-None-Match ETag",
 			requestHeaderMap: map[string]string{"If-None-Match": "abcd"},
 			expectedResult:   condTrue,
-		},
-
-		{
+		}, {
 			name:             "First ETag match",
 			requestHeaderMap: map[string]string{"If-None-Match": "\"testETag\", \"testETag\""},
 			writerHeaderMap:  map[string]string{"Etag": "\"testETag\""},
 			expectedResult:   condFalse,
-		},
-
-		{
+		}, {
 			name:             "Separated ETag match",
 			requestHeaderMap: map[string]string{"If-None-Match": "\"wrongETag\", \"correctETag\""},
 			writerHeaderMap:  map[string]string{"Etag": "\"correctETag\""},
@@ -430,31 +382,23 @@ func Test_checkIfModifiedSince(t *testing.T) {
 			requestMethod:  "PUT",
 			headerMap:      map[string]string{},
 			expectedResult: condNone,
-		},
-
-		{
+		}, {
 			name:           "No If-Modified-Since header",
 			requestMethod:  "GET",
 			expectedResult: condNone,
-		},
-
-		{
+		}, {
 			name:           "Malformed If-Modified-Since header",
 			requestMethod:  "GET",
 			headerMap:      map[string]string{"If-Modified-Since": "aaaa"},
 			modtime:        time.Unix(1531999477, 0).UTC(),
 			expectedResult: condNone,
-		},
-
-		{
+		}, {
 			name:           "Is not modified before",
 			requestMethod:  "GET",
 			headerMap:      map[string]string{"If-Modified-Since": "Thursday, 20-Jul-18 12:20:25 EEST"},
 			modtime:        time.Unix(1531999477, 0).UTC(),
 			expectedResult: condFalse,
-		},
-
-		{
+		}, {
 			name:           "Modified before",
 			requestMethod:  "GET",
 			headerMap:      map[string]string{"If-Modified-Since": "Thursday, 18-Jul-18 12:20:25 EEST"},
@@ -488,22 +432,16 @@ func Test_checkIfRange(t *testing.T) {
 			name:           "Unacceptable Method",
 			requestMethod:  "PUT",
 			expectedResult: condNone,
-		},
-
-		{
+		}, {
 			name:           "No If-Range header",
 			requestMethod:  "GET",
 			expectedResult: condNone,
-		},
-
-		{
+		}, {
 			name:             "Not matching ETags",
 			requestMethod:    "GET",
 			requestHeaderMap: map[string]string{"If-Range": "\"abcde\""},
 			expectedResult:   condFalse,
-		},
-
-		{
+		}, {
 			name:             "Matching ETags",
 			requestMethod:    "GET",
 			requestHeaderMap: map[string]string{"If-Range": "\"abcde\""},
@@ -519,25 +457,19 @@ func Test_checkIfRange(t *testing.T) {
 			requestHeaderMap: map[string]string{"If-Range": "a"},
 			modtime:          time.Unix(0, 0).UTC(),
 			expectedResult:   condFalse,
-		},
-
-		{
+		}, {
 			name:             "Malformed header time",
 			requestMethod:    "GET",
 			requestHeaderMap: map[string]string{"If-Range": "aaa"},
 			modtime:          time.Unix(1531999477, 0).UTC(),
 			expectedResult:   condFalse,
-		},
-
-		{
+		}, {
 			name:             "Equal time",
 			requestMethod:    "GET",
 			requestHeaderMap: map[string]string{"If-Range": "Thu, 19 Jul 2018 14:12:03 GMT"},
 			modtime:          time.Unix(1532009523, 0).UTC(),
 			expectedResult:   condTrue,
-		},
-
-		{
+		}, {
 			name:             "Equal time",
 			requestMethod:    "GET",
 			requestHeaderMap: map[string]string{"If-Range": "Thu, 18 Jul 2018 14:12:03 GMT"},
@@ -576,9 +508,7 @@ func Test_writeNotModified(t *testing.T) {
 				"Content-Length": "23",
 				"Etag":           "",
 			},
-		},
-
-		{
+		}, {
 			name: "Existing ETag",
 			writerHeaderMap: map[string]string{
 				"Content-Type":   "a",
@@ -616,29 +546,21 @@ func Test_scanETag(t *testing.T) {
 			name: "Empty ETag", s: "",
 			expectedEtag:   "",
 			expectedRemain: "",
-		},
-
-		{
+		}, {
 			name: "Empty ETag with W", s: "W/",
 			expectedEtag:   "",
 			expectedRemain: "",
-		},
-
-		{
+		}, {
 			name:           "Malformed ETag",
 			s:              "asdf",
 			expectedEtag:   "",
 			expectedRemain: "",
-		},
-
-		{
+		}, {
 			name:           "Valid ETag",
 			s:              "\"abcdef\"",
 			expectedEtag:   "\"abcdef\"",
 			expectedRemain: "",
-		},
-
-		{
+		}, {
 			name:           "Valid ETag with W/",
 			s:              "W/\"aaaa\"",
 			expectedEtag:   "W/\"aaaa\"",
@@ -712,16 +634,12 @@ func Test_etagWeakMatch(t *testing.T) {
 			a:             "",
 			b:             "",
 			expectedMatch: true,
-		},
-
-		{
+		}, {
 			name:          "Not equal ETags",
 			a:             "W/a",
 			b:             "W/b",
 			expectedMatch: false,
-		},
-
-		{
+		}, {
 			name:          "Equal ETags",
 			a:             "W/a",
 			b:             "W/a",
@@ -873,9 +791,7 @@ func Test_countingWriter_Write(t *testing.T) {
 			arrayHolder:    "abcd",
 			expectedLength: 4,
 			expectingError: false,
-		},
-
-		{
+		}, {
 			name:           "",
 			arrayHolder:    "",
 			expectedLength: 0,
@@ -927,9 +843,7 @@ func Test_sumRangesSize(t *testing.T) {
 				{length: 5},
 			},
 			expectedSize: 15,
-		},
-
-		{
+		}, {
 			ranges: []httpRange{
 				{length: 0},
 				{length: 0},

--- a/pkg/ranger/content_test.go
+++ b/pkg/ranger/content_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestServeContent(t *testing.T) {
 	for _, tt := range []struct {
-		testName         string
 		requestMethod    string
 		requestHeaderMap map[string]string
 		writerHeaderMap  map[string]string

--- a/pkg/ranger/file_test.go
+++ b/pkg/ranger/file_test.go
@@ -8,23 +8,15 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strconv"
 	"testing"
+
+	"storj.io/storj/internal/testcontext"
 )
 
 func TestFileRanger(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "storj-fileranger")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		err := os.RemoveAll(tempdir)
-		if err != nil {
-			_ = err // TODO: figure out what is holding the folder open
-			// t.Fatal(err)
-		}
-	}()
+	ctx := testcontext.New(t)
+	defer ctx.Cleanup()
 
 	for i, example := range []struct {
 		data                 string
@@ -45,7 +37,7 @@ func TestFileRanger(t *testing.T) {
 		{"abcdef", 6, -1, 7, "abcde", true},
 		{"abcdef", 6, 0, -1, "abcde", true},
 	} {
-		fh, err := os.Create(filepath.Join(tempdir, "test"+strconv.Itoa(i)))
+		fh, err := os.Create(ctx.File(strconv.Itoa(i)))
 		if err != nil {
 			t.Fatalf("failed making tempfile")
 		}

--- a/pkg/ranger/http_test.go
+++ b/pkg/ranger/http_test.go
@@ -43,21 +43,22 @@ func TestHTTPRanger(t *testing.T) {
 		{"abcdef", 6, -1, 7, "abcde", "ranger error: negative offset"},
 		{"abcdef", 6, 0, -1, "abcde", "ranger error: negative length"},
 	} {
-		errTag := fmt.Sprintf("Test case #%d", i)
+		tag := fmt.Sprintf("#%d. %+v", i, tt)
+
 		content = tt.data
 		rr, err := HTTPRanger(ts.URL)
-		if assert.NoError(t, err, errTag) {
-			assert.Equal(t, tt.size, rr.Size(), errTag)
+		if assert.NoError(t, err, tag) {
+			assert.Equal(t, tt.size, rr.Size(), tag)
 		}
 		r, err := rr.Range(context.Background(), tt.offset, tt.length)
 		if tt.errString != "" {
-			assert.EqualError(t, err, tt.errString, errTag)
+			assert.EqualError(t, err, tt.errString, tag)
 			continue
 		}
-		assert.NoError(t, err, errTag)
+		assert.NoError(t, err, tag)
 		data, err := ioutil.ReadAll(r)
-		if assert.NoError(t, err, errTag) {
-			assert.Equal(t, []byte(tt.substr), data, errTag)
+		if assert.NoError(t, err, tag) {
+			assert.Equal(t, []byte(tt.substr), data, tag)
 		}
 	}
 }
@@ -106,19 +107,20 @@ func TestHTTPRangerSize(t *testing.T) {
 		{"abcdef", 6, -1, 7, "abcde", "ranger error: negative offset"},
 		{"abcdef", 6, 0, -1, "abcde", "ranger error: negative length"},
 	} {
-		errTag := fmt.Sprintf("Test case #%d", i)
+		tag := fmt.Sprintf("#%d. %+v", i, tt)
+
 		content = tt.data
 		rr := HTTPRangerSize(ts.URL, tt.size)
-		assert.Equal(t, tt.size, rr.Size(), errTag)
+		assert.Equal(t, tt.size, rr.Size(), tag)
 		r, err := rr.Range(context.Background(), tt.offset, tt.length)
 		if tt.errString != "" {
-			assert.EqualError(t, err, tt.errString, errTag)
+			assert.EqualError(t, err, tt.errString, tag)
 			continue
 		}
-		assert.NoError(t, err, errTag)
+		assert.NoError(t, err, tag)
 		data, err := ioutil.ReadAll(r)
-		if assert.NoError(t, err, errTag) {
-			assert.Equal(t, []byte(tt.substr), data, errTag)
+		if assert.NoError(t, err, tag) {
+			assert.Equal(t, []byte(tt.substr), data, tag)
 		}
 	}
 }

--- a/pkg/ranger/reader_test.go
+++ b/pkg/ranger/reader_test.go
@@ -6,6 +6,7 @@ package ranger
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -73,8 +74,7 @@ func TestConcatReader(t *testing.T) {
 		{[]string{"abcdef", "ghijkl"}, 12, 7, 4, "hijk"},
 		{[]string{"abcdef", "ghijkl"}, 12, 7, 5, "hijkl"},
 		{[]string{"abcdef", "ghijkl", "mnopqr"}, 18, 7, 7, "hijklmn"},
-		{[]string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"},
-			12, 7, 3, "hij"},
+		{[]string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"}, 12, 7, 3, "hij"},
 	} {
 		var readers []Ranger
 		for _, data := range example.data {
@@ -115,8 +115,7 @@ func TestSubranger(t *testing.T) {
 		{"abcdefghijkl", 8, 4, 0, 3, "ijk"},
 		{"abcdefghijkl", 8, 4, 1, 3, "jkl"},
 	} {
-		rr, err := Subrange(ByteRanger([]byte(example.data)),
-			example.offset1, example.length1)
+		rr, err := Subrange(ByteRanger([]byte(example.data)), example.offset1, example.length1)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -127,6 +126,7 @@ func TestSubranger(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
+
 		data, err := ioutil.ReadAll(r)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
@@ -138,20 +138,19 @@ func TestSubranger(t *testing.T) {
 }
 
 func TestSubrangerError(t *testing.T) {
-	for _, tt := range []struct {
-		name           string
-		data           string
-		offset, length int64
+	for i, tt := range []struct {
+		data   string
+		offset int64
+		length int64
 	}{
-		{name: "Negative offset", data: "abcd", offset: -1},
-		{name: "Offset is bigger than DataSize", data: "abcd", offset: 5},
-		{name: "Length and offset is bigger than DataSize", data: "abcd", offset: 4, length: 1},
+		{data: "abcd", offset: -1},           // Negative offset
+		{data: "abcd", offset: 5},            // Offset is bigger than data size
+		{data: "abcd", offset: 4, length: 1}, // LSength and offset is bigger than DataSize
 	} {
-		t.Run(tt.name, func(t *testing.T) {
-			rr, err := Subrange(ByteRanger([]byte(tt.data)), tt.offset, tt.length)
-			assert.Nil(t, rr)
-			assert.NotNil(t, err)
-		})
+		tag := fmt.Sprintf("#%d. %+v", i, tt)
 
+		rr, err := Subrange(ByteRanger([]byte(tt.data)), tt.offset, tt.length)
+		assert.Nil(t, rr, tag)
+		assert.NotNil(t, err, tag)
 	}
 }

--- a/pkg/ranger/readerat_test.go
+++ b/pkg/ranger/readerat_test.go
@@ -5,35 +5,27 @@ package ranger
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRange(t *testing.T) {
-	for _, tt := range []struct {
-		name   string
+	for i, tt := range []struct {
 		offset int64
 		length int64
 		size   int64
 	}{
-		{
-			name:   "Negative offset",
-			offset: -2,
-		},
-
-		{
-			name:   "Negative length",
-			offset: 2,
-			length: -1,
-		},
+		{offset: -2, size: 0},
+		{offset: 2, length: -1, size: 0},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
-			rr := readerAtRanger{size: tt.size}
-			closer, err := rr.Range(context.Background(), tt.offset, tt.length)
-			assert.Nil(t, closer)
-			assert.NotNil(t, err)
-		})
+		tag := fmt.Sprintf("#%d. %+v", i, tt)
+
+		rr := readerAtRanger{size: tt.size}
+		closer, err := rr.Range(context.Background(), tt.offset, tt.length)
+		assert.Nil(t, closer, tag)
+		assert.NotNil(t, err, tag)
 	}
 }
 


### PR DESCRIPTION
Reduce number of subtests to make the output in tests more concise.