### PR TITLE
Skip TestUploadDownload

### DIFF
--- a/pkg/miniogw/integration_test.go
+++ b/pkg/miniogw/integration_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestUploadDownload(t *testing.T) {
+	t.Skip("disable because, keeps stalling Travis intermittently")
+
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
 


### PR DESCRIPTION
Skipping TestUploadDownload because it stalling Travis tests.