### PR TITLE
Data repairer should use the redundancy strategy from segment's pointer

### DIFF
--- a/pkg/datarepair/repairer/config.go
+++ b/pkg/datarepair/repairer/config.go
@@ -7,18 +7,16 @@ import (
 	"context"
 	"time"
 
-	"github.com/vivint/infectious"
 	"go.uber.org/zap"
 
 	"storj.io/storj/pkg/datarepair/queue"
-	"storj.io/storj/pkg/eestream"
 	"storj.io/storj/pkg/miniogw"
 	"storj.io/storj/pkg/overlay"
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/pointerdb/pdbclient"
 	"storj.io/storj/pkg/provider"
-	ecclient "storj.io/storj/pkg/storage/ec"
-	segment "storj.io/storj/pkg/storage/segments"
+	"storj.io/storj/pkg/storage/ec"
+	"storj.io/storj/pkg/storage/segments"
 	"storj.io/storj/storage/redis"
 )
 
@@ -33,19 +31,6 @@ type Config struct {
 	APIKey        string        `help:"repairer-specific pointerdb access credential"`
 
 	miniogw.NodeSelectionConfig
-
-	// TODO: this is a huge bug that these are required here. these values should
-	// all come from the pointer for each repair. these need to be removed from the
-	// config
-	MinThreshold     int `help:"TODO: remove" default:"29"`
-	RepairThreshold  int `help:"TODO: remove" default:"35"`
-	SuccessThreshold int `help:"TODO: remove" default:"80"`
-	MaxThreshold     int `help:"TODO: remove" default:"95"`
-	ErasureShareSize int `help:"TODO: remove" default:"1024"`
-
-	// TODO: the repairer shouldn't need to worry about inlining, as it is only
-	// repairing non-inlined things.
-	MaxInlineSize int `help:"TODO: remove" default:"4096"`
 }
 
 // Run runs the repairer with configured values
@@ -57,12 +42,12 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) (err error) 
 
 	queue := queue.NewQueue(redisQ)
 
-	ss, err := c.getSegmentStore(ctx, server.Identity())
+	sr, err := c.getSegmentRepairer(ctx, server.Identity())
 	if err != nil {
 		return Error.Wrap(err)
 	}
 
-	repairer := newRepairer(queue, ss, c.Interval, c.MaxRepair)
+	repairer := newRepairer(queue, sr, c.Interval, c.MaxRepair)
 
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -77,8 +62,8 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) (err error) 
 	return server.Run(ctx)
 }
 
-// getSegmentStore creates a new segment store from storeConfig values
-func (c Config) getSegmentStore(ctx context.Context, identity *provider.FullIdentity) (ss segment.Store, err error) {
+// getSegmentRepairer creates a new segment repairer from storeConfig values
+func (c Config) getSegmentRepairer(ctx context.Context, identity *provider.FullIdentity) (ss segments.Repairer, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	var oc overlay.Client
@@ -93,14 +78,6 @@ func (c Config) getSegmentStore(ctx context.Context, identity *provider.FullIden
 	}
 
 	ec := ecclient.NewClient(identity, c.MaxBufferMem)
-	fc, err := infectious.NewFEC(c.MinThreshold, c.MaxThreshold)
-	if err != nil {
-		return nil, err
-	}
-	rs, err := eestream.NewRedundancyStrategy(eestream.NewRSScheme(fc, c.ErasureShareSize), c.RepairThreshold, c.SuccessThreshold)
-	if err != nil {
-		return nil, err
-	}
 
 	ns := &pb.NodeStats{
 		UptimeRatio:       c.UptimeRatio,
@@ -109,5 +86,5 @@ func (c Config) getSegmentStore(ctx context.Context, identity *provider.FullIden
 		AuditCount:        c.AuditCount,
 	}
 
-	return segment.NewSegmentStore(oc, ec, pdb, rs, c.MaxInlineSize, ns), nil
+	return segments.NewSegmentRepairer(oc, ec, pdb, ns), nil
 }

--- a/pkg/datarepair/repairer/repairer.go
+++ b/pkg/datarepair/repairer/repairer.go
@@ -11,56 +11,56 @@ import (
 
 	"storj.io/storj/internal/sync2"
 	"storj.io/storj/pkg/datarepair/queue"
-	"storj.io/storj/pkg/storage/segments"
+	"storj.io/storj/pkg/storj"
 	"storj.io/storj/storage"
 )
 
-// Repairer is the interface for the data repairer
-type Repairer interface {
-	Run(ctx context.Context) error
+// SegmentRepairer is a repairer for segments
+type SegmentRepairer interface {
+	Repair(ctx context.Context, path storj.Path, lostPieces []int32) (err error)
 }
 
-// repairer holds important values for data repair
-type repairer struct {
-	queue   queue.RepairQueue
-	sr      segments.Repairer
-	limiter *sync2.Limiter
-	ticker  *time.Ticker
+// repairService contains the information needed to run the repair service
+type repairService struct {
+	queue    queue.RepairQueue
+	repairer SegmentRepairer
+	limiter  *sync2.Limiter
+	ticker   *time.Ticker
 }
 
-func newRepairer(queue queue.RepairQueue, sr segments.Repairer, interval time.Duration, concurrency int) *repairer {
-	return &repairer{
-		queue:   queue,
-		sr:      sr,
-		limiter: sync2.NewLimiter(concurrency),
-		ticker:  time.NewTicker(interval),
+func newService(queue queue.RepairQueue, repairer SegmentRepairer, interval time.Duration, concurrency int) *repairService {
+	return &repairService{
+		queue:    queue,
+		repairer: repairer,
+		limiter:  sync2.NewLimiter(concurrency),
+		ticker:   time.NewTicker(interval),
 	}
 }
 
 // Run runs the repairer service
-func (r *repairer) Run(ctx context.Context) (err error) {
+func (service *repairService) Run(ctx context.Context) (err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	// wait for all repairs to complete
-	defer r.limiter.Wait()
+	defer service.limiter.Wait()
 
 	for {
-		err := r.process(ctx)
+		err := service.process(ctx)
 		if err != nil {
 			zap.L().Error("process", zap.Error(err))
 		}
 
 		select {
-		case <-r.ticker.C: // wait for the next interval to happen
-		case <-ctx.Done(): // or the repairer is canceled via context
+		case <-service.ticker.C: // wait for the next interval to happen
+		case <-ctx.Done(): // or the repairer service is canceled via context
 			return ctx.Err()
 		}
 	}
 }
 
-// process picks an item from repair queue and spawns a repairer
-func (r *repairer) process(ctx context.Context) error {
-	seg, err := r.queue.Dequeue()
+// process picks an item from repair queue and spawns a repair worker
+func (service *repairService) process(ctx context.Context) error {
+	seg, err := service.queue.Dequeue()
 	if err != nil {
 		if err == storage.ErrEmptyQueue {
 			return nil
@@ -68,8 +68,8 @@ func (r *repairer) process(ctx context.Context) error {
 		return err
 	}
 
-	r.limiter.Go(ctx, func() {
-		err := r.sr.Repair(ctx, seg.GetPath(), seg.GetLostPieces())
+	service.limiter.Go(ctx, func() {
+		err := service.repairer.Repair(ctx, seg.GetPath(), seg.GetLostPieces())
 		if err != nil {
 			zap.L().Error("Repair failed", zap.Error(err))
 		}

--- a/pkg/datarepair/repairer/repairer_test.go
+++ b/pkg/datarepair/repairer/repairer_test.go
@@ -1,4 +1,0 @@
-// Copyright (C) 2018 Storj Labs, Inc.
-// See LICENSE for copying information.
-
-package repairer

--- a/pkg/storage/segments/repairer.go
+++ b/pkg/storage/segments/repairer.go
@@ -1,0 +1,157 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package segments
+
+import (
+	"context"
+
+	"storj.io/storj/pkg/overlay"
+	"storj.io/storj/pkg/pb"
+	"storj.io/storj/pkg/piecestore/psclient"
+	"storj.io/storj/pkg/pointerdb/pdbclient"
+	"storj.io/storj/pkg/storage/ec"
+	"storj.io/storj/pkg/storj"
+	"storj.io/storj/pkg/utils"
+)
+
+// Repairer for segments
+type Repairer interface {
+	Repair(ctx context.Context, path storj.Path, lostPieces []int32) (err error)
+}
+
+type segmentRepairer struct {
+	oc        overlay.Client
+	ec        ecclient.Client
+	pdb       pdbclient.Client
+	nodeStats *pb.NodeStats
+}
+
+// NewSegmentRepairer creates a new instance of segmentRepairer
+func NewSegmentRepairer(oc overlay.Client, ec ecclient.Client, pdb pdbclient.Client, nodeStats *pb.NodeStats) Repairer {
+	return &segmentRepairer{oc: oc, ec: ec, pdb: pdb, nodeStats: nodeStats}
+}
+
+// Repair retrieves an at-risk segment and repairs and stores lost pieces on new nodes
+func (s *segmentRepairer) Repair(ctx context.Context, path storj.Path, lostPieces []int32) (err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	// Read the segment's pointer's info from the PointerDB
+	pr, originalNodes, pba, err := s.pdb.Get(ctx, path)
+	if err != nil {
+		return Error.Wrap(err)
+	}
+
+	if pr.GetType() != pb.Pointer_REMOTE {
+		return Error.New("cannot repair inline segment %s", psclient.PieceID(pr.GetInlineSegment()))
+	}
+
+	seg := pr.GetRemote()
+	pid := psclient.PieceID(seg.GetPieceId())
+
+	originalNodes, err = lookupAndAlignNodes(ctx, s.oc, originalNodes, seg)
+	if err != nil {
+		return Error.Wrap(err)
+	}
+
+	// Get the nodes list that needs to be excluded
+	var excludeNodeIDs storj.NodeIDList
+
+	// Count the number of nil nodes thats needs to be repaired
+	totalNilNodes := 0
+
+	healthyNodes := make([]*pb.Node, len(originalNodes))
+
+	// Populate healthyNodes with all nodes from originalNodes except those correlating to indices in lostPieces
+	for i, v := range originalNodes {
+		if v == nil {
+			totalNilNodes++
+			continue
+		}
+
+		excludeNodeIDs = append(excludeNodeIDs, v.Id)
+
+		// If node index exists in lostPieces, skip adding it to healthyNodes
+		if contains(lostPieces, i) {
+			totalNilNodes++
+		} else {
+			healthyNodes[i] = v
+		}
+	}
+
+	// Request Overlay for n-h new storage nodes
+	op := overlay.Options{Amount: totalNilNodes, Space: 0, Excluded: excludeNodeIDs}
+	newNodes, err := s.oc.Choose(ctx, op)
+	if err != nil {
+		return err
+	}
+
+	if totalNilNodes != len(newNodes) {
+		return Error.New("Number of new nodes from overlay (%d) does not equal total nil nodes (%d)", len(newNodes), totalNilNodes)
+	}
+
+	totalRepairCount := len(newNodes)
+
+	// Make a repair nodes list just with new unique ids
+	repairNodes := make([]*pb.Node, len(healthyNodes))
+	for i, vr := range healthyNodes {
+		// Check that totalRepairCount is non-negative
+		if totalRepairCount < 0 {
+			return Error.New("Total repair count (%d) less than zero", totalRepairCount)
+		}
+
+		// Find the nil nodes in the healthyNodes list
+		if vr == nil {
+			// Assign the item in repairNodes list with an item from the newNode list
+			totalRepairCount--
+			repairNodes[i] = newNodes[totalRepairCount]
+		}
+	}
+
+	// Check that all nil nodes have a replacement prepared
+	if totalRepairCount != 0 {
+		return Error.New("Failed to replace all nil nodes (%d). (%d) new nodes not inserted", len(newNodes), totalRepairCount)
+	}
+
+	rs, err := makeRedundancyStrategy(pr.GetRemote().GetRedundancy())
+	if err != nil {
+		return Error.Wrap(err)
+	}
+
+	signedMessage := s.pdb.SignedMessage()
+
+	// Download the segment using just the healthyNodes
+	rr, err := s.ec.Get(ctx, healthyNodes, rs, pid, pr.GetSegmentSize(), pba, signedMessage)
+	if err != nil {
+		return Error.Wrap(err)
+	}
+
+	r, err := rr.Range(ctx, 0, rr.Size())
+	if err != nil {
+		return Error.Wrap(err)
+	}
+	defer utils.LogClose(r)
+
+	// Upload the repaired pieces to the repairNodes
+	successfulNodes, err := s.ec.Put(ctx, repairNodes, rs, pid, r, convertTime(pr.GetExpirationDate()), pba, signedMessage)
+	if err != nil {
+		return Error.Wrap(err)
+	}
+
+	// Merge the successful nodes list into the healthy nodes list
+	for i, v := range healthyNodes {
+		if v == nil {
+			// copy the successfuNode info
+			healthyNodes[i] = successfulNodes[i]
+		}
+	}
+
+	metadata := pr.GetMetadata()
+	pointer, err := makeRemotePointer(healthyNodes, rs, pid, rr.Size(), pr.GetExpirationDate(), metadata)
+	if err != nil {
+		return err
+	}
+
+	// update the segment info in the pointerDB
+	return s.pdb.Put(ctx, path, pointer)
+}

--- a/pkg/storage/segments/repairer.go
+++ b/pkg/storage/segments/repairer.go
@@ -16,24 +16,20 @@ import (
 )
 
 // Repairer for segments
-type Repairer interface {
-	Repair(ctx context.Context, path storj.Path, lostPieces []int32) (err error)
-}
-
-type segmentRepairer struct {
+type Repairer struct {
 	oc        overlay.Client
 	ec        ecclient.Client
 	pdb       pdbclient.Client
 	nodeStats *pb.NodeStats
 }
 
-// NewSegmentRepairer creates a new instance of segmentRepairer
-func NewSegmentRepairer(oc overlay.Client, ec ecclient.Client, pdb pdbclient.Client, nodeStats *pb.NodeStats) Repairer {
-	return &segmentRepairer{oc: oc, ec: ec, pdb: pdb, nodeStats: nodeStats}
+// NewSegmentRepairer creates a new instance of SegmentRepairer
+func NewSegmentRepairer(oc overlay.Client, ec ecclient.Client, pdb pdbclient.Client, nodeStats *pb.NodeStats) *Repairer {
+	return &Repairer{oc: oc, ec: ec, pdb: pdb, nodeStats: nodeStats}
 }
 
 // Repair retrieves an at-risk segment and repairs and stores lost pieces on new nodes
-func (s *segmentRepairer) Repair(ctx context.Context, path storj.Path, lostPieces []int32) (err error) {
+func (s *Repairer) Repair(ctx context.Context, path storj.Path, lostPieces []int32) (err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	// Read the segment's pointer's info from the PointerDB

--- a/pkg/storage/segments/repairer_test.go
+++ b/pkg/storage/segments/repairer_test.go
@@ -1,0 +1,120 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package segments
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+
+	"storj.io/storj/internal/teststorj"
+	mock_overlay "storj.io/storj/pkg/overlay/mocks"
+	"storj.io/storj/pkg/pb"
+	"storj.io/storj/pkg/pointerdb/pdbclient/mocks"
+	"storj.io/storj/pkg/ranger"
+	"storj.io/storj/pkg/storage/ec/mocks"
+)
+
+func TestNewSegmentRepairer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockOC := mock_overlay.NewMockClient(ctrl)
+	mockEC := mock_ecclient.NewMockClient(ctrl)
+	mockPDB := mock_pointerdb.NewMockClient(ctrl)
+
+	ss := NewSegmentRepairer(mockOC, mockEC, mockPDB, &pb.NodeStats{})
+	assert.NotNil(t, ss)
+}
+
+func TestSegmentStoreRepairRemote(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ti := time.Unix(0, 0).UTC()
+	someTime, err := ptypes.TimestampProto(ti)
+	assert.NoError(t, err)
+
+	for _, tt := range []struct {
+		pathInput               string
+		thresholdSize           int
+		pointerType             pb.Pointer_DataType
+		size                    int64
+		metadata                []byte
+		lostPieces              []int32
+		newNodes                []*pb.Node
+		data                    string
+		strsize, offset, length int64
+		substr                  string
+		meta                    Meta
+	}{
+		{
+			"path/1/2/3",
+			10,
+			pb.Pointer_REMOTE,
+			int64(3),
+			[]byte("metadata"),
+			[]int32{},
+			[]*pb.Node{
+				teststorj.MockNode("1"),
+				teststorj.MockNode("2"),
+			},
+			"abcdefghijkl",
+			12,
+			1,
+			4,
+			"bcde",
+			Meta{},
+		},
+	} {
+		mockOC := mock_overlay.NewMockClient(ctrl)
+		mockEC := mock_ecclient.NewMockClient(ctrl)
+		mockPDB := mock_pointerdb.NewMockClient(ctrl)
+
+		sr := segmentRepairer{mockOC, mockEC, mockPDB, &pb.NodeStats{}}
+		assert.NotNil(t, sr)
+
+		calls := []*gomock.Call{
+			mockPDB.EXPECT().Get(
+				gomock.Any(), gomock.Any(),
+			).Return(&pb.Pointer{
+				Type: tt.pointerType,
+				Remote: &pb.RemoteSegment{
+					Redundancy: &pb.RedundancyScheme{
+						Type:             pb.RedundancyScheme_RS,
+						MinReq:           1,
+						Total:            2,
+						RepairThreshold:  1,
+						SuccessThreshold: 2,
+					},
+					PieceId:      "here's my piece id",
+					RemotePieces: []*pb.RemotePiece{},
+				},
+				CreationDate:   someTime,
+				ExpirationDate: someTime,
+				SegmentSize:    tt.size,
+				Metadata:       tt.metadata,
+			}, nil, nil, nil),
+			mockOC.EXPECT().BulkLookup(gomock.Any(), gomock.Any()),
+			mockOC.EXPECT().Choose(gomock.Any(), gomock.Any()).Return(tt.newNodes, nil),
+			mockPDB.EXPECT().SignedMessage(),
+			mockEC.EXPECT().Get(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+			).Return(ranger.ByteRanger([]byte(tt.data)), nil),
+			mockEC.EXPECT().Put(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+			).Return(tt.newNodes, nil),
+			mockPDB.EXPECT().Put(
+				gomock.Any(), gomock.Any(), gomock.Any(),
+			).Return(nil),
+		}
+		gomock.InOrder(calls...)
+
+		err := sr.Repair(ctx, tt.pathInput, tt.lostPieces)
+		assert.NoError(t, err)
+	}
+}

--- a/pkg/storage/segments/repairer_test.go
+++ b/pkg/storage/segments/repairer_test.go
@@ -75,7 +75,7 @@ func TestSegmentStoreRepairRemote(t *testing.T) {
 		mockEC := mock_ecclient.NewMockClient(ctrl)
 		mockPDB := mock_pointerdb.NewMockClient(ctrl)
 
-		sr := segmentRepairer{mockOC, mockEC, mockPDB, &pb.NodeStats{}}
+		sr := Repairer{mockOC, mockEC, mockPDB, &pb.NodeStats{}}
 		assert.NotNil(t, sr)
 
 		calls := []*gomock.Call{

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -21,9 +21,8 @@ import (
 	"storj.io/storj/pkg/piecestore/psclient"
 	"storj.io/storj/pkg/pointerdb/pdbclient"
 	"storj.io/storj/pkg/ranger"
-	ecclient "storj.io/storj/pkg/storage/ec"
+	"storj.io/storj/pkg/storage/ec"
 	"storj.io/storj/pkg/storj"
-	"storj.io/storj/pkg/utils"
 )
 
 var (
@@ -49,7 +48,6 @@ type ListItem struct {
 type Store interface {
 	Meta(ctx context.Context, path storj.Path) (meta Meta, err error)
 	Get(ctx context.Context, path storj.Path) (rr ranger.Ranger, meta Meta, err error)
-	Repair(ctx context.Context, path storj.Path, lostPieces []int32) (err error)
 	Put(ctx context.Context, data io.Reader, expiration time.Time, segmentInfo func() (storj.Path, []byte, error)) (meta Meta, err error)
 	Delete(ctx context.Context, path storj.Path) (err error)
 	List(ctx context.Context, prefix, startAfter, endBefore storj.Path, recursive bool, limit int, metaFlags uint32) (items []ListItem, more bool, err error)
@@ -66,14 +64,7 @@ type segmentStore struct {
 
 // NewSegmentStore creates a new instance of segmentStore
 func NewSegmentStore(oc overlay.Client, ec ecclient.Client, pdb pdbclient.Client, rs eestream.RedundancyStrategy, threshold int, nodeStats *pb.NodeStats) Store {
-	return &segmentStore{oc: oc, ec: ec, pdb: pdb, rs: rs, thresholdSize: threshold,
-		nodeStats: &pb.NodeStats{
-			UptimeRatio:       nodeStats.UptimeRatio,
-			UptimeCount:       nodeStats.UptimeCount,
-			AuditSuccessRatio: nodeStats.AuditSuccessRatio,
-			AuditCount:        nodeStats.AuditCount,
-		},
-	}
+	return &segmentStore{oc: oc, ec: ec, pdb: pdb, rs: rs, thresholdSize: threshold, nodeStats: nodeStats}
 }
 
 // Meta retrieves the metadata of the segment
@@ -176,40 +167,6 @@ func (s *segmentStore) Put(ctx context.Context, data io.Reader, expiration time.
 	return m, nil
 }
 
-// makeRemotePointer creates a pointer of type remote
-func makeRemotePointer(nodes []*pb.Node, rs eestream.RedundancyStrategy, pieceID psclient.PieceID, readerSize int64, exp *timestamp.Timestamp, metadata []byte) (pointer *pb.Pointer, err error) {
-	var remotePieces []*pb.RemotePiece
-	for i := range nodes {
-		if nodes[i] == nil {
-			continue
-		}
-		remotePieces = append(remotePieces, &pb.RemotePiece{
-			PieceNum: int32(i),
-			NodeId:   nodes[i].Id,
-		})
-	}
-
-	pointer = &pb.Pointer{
-		Type: pb.Pointer_REMOTE,
-		Remote: &pb.RemoteSegment{
-			Redundancy: &pb.RedundancyScheme{
-				Type:             pb.RedundancyScheme_RS,
-				MinReq:           int32(rs.RequiredCount()),
-				Total:            int32(rs.TotalCount()),
-				RepairThreshold:  int32(rs.RepairThreshold()),
-				SuccessThreshold: int32(rs.OptimalThreshold()),
-				ErasureShareSize: int32(rs.ErasureShareSize()),
-			},
-			PieceId:      string(pieceID),
-			RemotePieces: remotePieces,
-		},
-		SegmentSize:    readerSize,
-		ExpirationDate: exp,
-		Metadata:       metadata,
-	}
-	return pointer, nil
-}
-
 // Get retrieves a segment using erasure code, overlay, and pointerdb clients
 func (s *segmentStore) Get(ctx context.Context, path storj.Path) (rr ranger.Ranger, meta Meta, err error) {
 	defer mon.Task()(&ctx)(&err)
@@ -226,7 +183,7 @@ func (s *segmentStore) Get(ctx context.Context, path storj.Path) (rr ranger.Rang
 		seg := pr.GetRemote()
 		pid := psclient.PieceID(seg.GetPieceId())
 
-		nodes, err = s.lookupAndAlignNodes(ctx, nodes, seg)
+		nodes, err = lookupAndAlignNodes(ctx, s.oc, nodes, seg)
 		if err != nil {
 			return nil, Meta{}, Error.Wrap(err)
 		}
@@ -265,6 +222,91 @@ func (s *segmentStore) Get(ctx context.Context, path storj.Path) (rr ranger.Rang
 	return rr, convertMeta(pr), nil
 }
 
+// makeRemotePointer creates a pointer of type remote
+func makeRemotePointer(nodes []*pb.Node, rs eestream.RedundancyStrategy, pieceID psclient.PieceID, readerSize int64, exp *timestamp.Timestamp, metadata []byte) (pointer *pb.Pointer, err error) {
+	var remotePieces []*pb.RemotePiece
+	for i := range nodes {
+		if nodes[i] == nil {
+			continue
+		}
+		remotePieces = append(remotePieces, &pb.RemotePiece{
+			PieceNum: int32(i),
+			NodeId:   nodes[i].Id,
+		})
+	}
+
+	pointer = &pb.Pointer{
+		Type: pb.Pointer_REMOTE,
+		Remote: &pb.RemoteSegment{
+			Redundancy: &pb.RedundancyScheme{
+				Type:             pb.RedundancyScheme_RS,
+				MinReq:           int32(rs.RequiredCount()),
+				Total:            int32(rs.TotalCount()),
+				RepairThreshold:  int32(rs.RepairThreshold()),
+				SuccessThreshold: int32(rs.OptimalThreshold()),
+				ErasureShareSize: int32(rs.ErasureShareSize()),
+			},
+			PieceId:      string(pieceID),
+			RemotePieces: remotePieces,
+		},
+		SegmentSize:    readerSize,
+		ExpirationDate: exp,
+		Metadata:       metadata,
+	}
+	return pointer, nil
+}
+
+// Delete tells piece stores to delete a segment and deletes pointer from pointerdb
+func (s *segmentStore) Delete(ctx context.Context, path storj.Path) (err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	pr, nodes, _, err := s.pdb.Get(ctx, path)
+	if err != nil {
+		return Error.Wrap(err)
+	}
+
+	if pr.GetType() == pb.Pointer_REMOTE {
+		seg := pr.GetRemote()
+		pid := psclient.PieceID(seg.PieceId)
+
+		nodes, err = lookupAndAlignNodes(ctx, s.oc, nodes, seg)
+		if err != nil {
+			return Error.Wrap(err)
+		}
+
+		authorization := s.pdb.SignedMessage()
+		// ecclient sends delete request
+		err = s.ec.Delete(ctx, nodes, pid, authorization)
+		if err != nil {
+			return Error.Wrap(err)
+		}
+	}
+
+	// deletes pointer from pointerdb
+	return s.pdb.Delete(ctx, path)
+}
+
+// List retrieves paths to segments and their metadata stored in the pointerdb
+func (s *segmentStore) List(ctx context.Context, prefix, startAfter, endBefore storj.Path, recursive bool, limit int, metaFlags uint32) (items []ListItem, more bool, err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	pdbItems, more, err := s.pdb.List(ctx, prefix, startAfter, endBefore, recursive, limit, metaFlags)
+	if err != nil {
+		return nil, false, err
+	}
+
+	items = make([]ListItem, len(pdbItems))
+	for i, itm := range pdbItems {
+		items[i] = ListItem{
+			Path:     itm.Path,
+			Meta:     convertMeta(itm.Pointer),
+			IsPrefix: itm.IsPrefix,
+		}
+	}
+
+	return items, more, nil
+}
+
 func makeRedundancyStrategy(scheme *pb.RedundancyScheme) (eestream.RedundancyStrategy, error) {
 	fc, err := infectious.NewFEC(int(scheme.GetMinReq()), int(scheme.GetTotal()))
 	if err != nil {
@@ -296,164 +338,10 @@ func calcNeededNodes(rs *pb.RedundancyScheme) int32 {
 	return needed
 }
 
-// Delete tells piece stores to delete a segment and deletes pointer from pointerdb
-func (s *segmentStore) Delete(ctx context.Context, path storj.Path) (err error) {
-	defer mon.Task()(&ctx)(&err)
-
-	pr, nodes, _, err := s.pdb.Get(ctx, path)
-	if err != nil {
-		return Error.Wrap(err)
-	}
-
-	if pr.GetType() == pb.Pointer_REMOTE {
-		seg := pr.GetRemote()
-		pid := psclient.PieceID(seg.PieceId)
-
-		nodes, err = s.lookupAndAlignNodes(ctx, nodes, seg)
-		if err != nil {
-			return Error.Wrap(err)
-		}
-
-		authorization := s.pdb.SignedMessage()
-		// ecclient sends delete request
-		err = s.ec.Delete(ctx, nodes, pid, authorization)
-		if err != nil {
-			return Error.Wrap(err)
-		}
-	}
-
-	// deletes pointer from pointerdb
-	return s.pdb.Delete(ctx, path)
-}
-
-// Repair retrieves an at-risk segment and repairs and stores lost pieces on new nodes
-func (s *segmentStore) Repair(ctx context.Context, path storj.Path, lostPieces []int32) (err error) {
-	defer mon.Task()(&ctx)(&err)
-
-	// Read the segment's pointer's info from the PointerDB
-	pr, originalNodes, pba, err := s.pdb.Get(ctx, path)
-	if err != nil {
-		return Error.Wrap(err)
-	}
-
-	if pr.GetType() != pb.Pointer_REMOTE {
-		return Error.New("cannot repair inline segment %s", psclient.PieceID(pr.GetInlineSegment()))
-	}
-
-	seg := pr.GetRemote()
-	pid := psclient.PieceID(seg.GetPieceId())
-
-	originalNodes, err = s.lookupAndAlignNodes(ctx, originalNodes, seg)
-	if err != nil {
-		return Error.Wrap(err)
-	}
-
-	// Get the nodes list that needs to be excluded
-	var excludeNodeIDs storj.NodeIDList
-
-	// Count the number of nil nodes thats needs to be repaired
-	totalNilNodes := 0
-
-	healthyNodes := make([]*pb.Node, len(originalNodes))
-
-	// Populate healthyNodes with all nodes from originalNodes except those correlating to indices in lostPieces
-	for i, v := range originalNodes {
-		if v == nil {
-			totalNilNodes++
-			continue
-		}
-
-		excludeNodeIDs = append(excludeNodeIDs, v.Id)
-
-		// If node index exists in lostPieces, skip adding it to healthyNodes
-		if contains(lostPieces, i) {
-			totalNilNodes++
-		} else {
-			healthyNodes[i] = v
-		}
-	}
-
-	// Request Overlay for n-h new storage nodes
-	op := overlay.Options{Amount: totalNilNodes, Space: 0, Excluded: excludeNodeIDs}
-	newNodes, err := s.oc.Choose(ctx, op)
-	if err != nil {
-		return err
-	}
-
-	if totalNilNodes != len(newNodes) {
-		return Error.New("Number of new nodes from overlay (%d) does not equal total nil nodes (%d)", len(newNodes), totalNilNodes)
-	}
-
-	totalRepairCount := len(newNodes)
-
-	// Make a repair nodes list just with new unique ids
-	repairNodes := make([]*pb.Node, len(healthyNodes))
-	for i, vr := range healthyNodes {
-		// Check that totalRepairCount is non-negative
-		if totalRepairCount < 0 {
-			return Error.New("Total repair count (%d) less than zero", totalRepairCount)
-		}
-
-		// Find the nil nodes in the healthyNodes list
-		if vr == nil {
-			// Assign the item in repairNodes list with an item from the newNode list
-			totalRepairCount--
-			repairNodes[i] = newNodes[totalRepairCount]
-		}
-	}
-
-	// Check that all nil nodes have a replacement prepared
-	if totalRepairCount != 0 {
-		return Error.New("Failed to replace all nil nodes (%d). (%d) new nodes not inserted", len(newNodes), totalRepairCount)
-	}
-
-	rs, err := makeRedundancyStrategy(pr.GetRemote().GetRedundancy())
-	if err != nil {
-		return Error.Wrap(err)
-	}
-
-	signedMessage := s.pdb.SignedMessage()
-
-	// Download the segment using just the healthyNodes
-	rr, err := s.ec.Get(ctx, healthyNodes, rs, pid, pr.GetSegmentSize(), pba, signedMessage)
-	if err != nil {
-		return Error.Wrap(err)
-	}
-
-	r, err := rr.Range(ctx, 0, rr.Size())
-	if err != nil {
-		return Error.Wrap(err)
-	}
-	defer utils.LogClose(r)
-
-	// Upload the repaired pieces to the repairNodes
-	successfulNodes, err := s.ec.Put(ctx, repairNodes, rs, pid, r, convertTime(pr.GetExpirationDate()), pba, signedMessage)
-	if err != nil {
-		return Error.Wrap(err)
-	}
-
-	// Merge the successful nodes list into the healthy nodes list
-	for i, v := range healthyNodes {
-		if v == nil {
-			// copy the successfuNode info
-			healthyNodes[i] = successfulNodes[i]
-		}
-	}
-
-	metadata := pr.GetMetadata()
-	pointer, err := makeRemotePointer(healthyNodes, rs, pid, rr.Size(), pr.GetExpirationDate(), metadata)
-	if err != nil {
-		return err
-	}
-
-	// update the segment info in the pointerDB
-	return s.pdb.Put(ctx, path, pointer)
-}
-
 // lookupNodes, if necessary, calls Lookup to get node addresses from the overlay.
 // It also realigns the nodes to an indexed list of nodes based on the piece number.
 // Missing pieces are represented by a nil node.
-func (s *segmentStore) lookupAndAlignNodes(ctx context.Context, nodes []*pb.Node, seg *pb.RemoteSegment) (result []*pb.Node, err error) {
+func lookupAndAlignNodes(ctx context.Context, oc overlay.Client, nodes []*pb.Node, seg *pb.RemoteSegment) (result []*pb.Node, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	if nodes == nil {
@@ -463,7 +351,7 @@ func (s *segmentStore) lookupAndAlignNodes(ctx context.Context, nodes []*pb.Node
 			nodeIds = append(nodeIds, p.NodeId)
 		}
 		// Lookup the node info from node IDs
-		nodes, err = s.oc.BulkLookup(ctx, nodeIds)
+		nodes, err = oc.BulkLookup(ctx, nodeIds)
 		if err != nil {
 			return nil, Error.Wrap(err)
 		}
@@ -476,27 +364,6 @@ func (s *segmentStore) lookupAndAlignNodes(ctx context.Context, nodes []*pb.Node
 	}
 
 	return result, nil
-}
-
-// List retrieves paths to segments and their metadata stored in the pointerdb
-func (s *segmentStore) List(ctx context.Context, prefix, startAfter, endBefore storj.Path, recursive bool, limit int, metaFlags uint32) (items []ListItem, more bool, err error) {
-	defer mon.Task()(&ctx)(&err)
-
-	pdbItems, more, err := s.pdb.List(ctx, prefix, startAfter, endBefore, recursive, limit, metaFlags)
-	if err != nil {
-		return nil, false, err
-	}
-
-	items = make([]ListItem, len(pdbItems))
-	for i, itm := range pdbItems {
-		items[i] = ListItem{
-			Path:     itm.Path,
-			Meta:     convertMeta(itm.Pointer),
-			IsPrefix: itm.IsPrefix,
-		}
-	}
-
-	return items, more, nil
 }
 
 // contains checks if n exists in list

--- a/pkg/storage/segments/store_test.go
+++ b/pkg/storage/segments/store_test.go
@@ -21,7 +21,6 @@ import (
 	"storj.io/storj/pkg/pb"
 	pdb "storj.io/storj/pkg/pointerdb/pdbclient"
 	"storj.io/storj/pkg/pointerdb/pdbclient/mocks"
-	"storj.io/storj/pkg/ranger"
 	"storj.io/storj/pkg/storage/ec/mocks"
 	"storj.io/storj/pkg/storage/meta"
 	"storj.io/storj/pkg/storj"
@@ -226,101 +225,6 @@ func TestSegmentStoreGetInline(t *testing.T) {
 		gomock.InOrder(calls...)
 
 		_, _, err := ss.Get(ctx, tt.pathInput)
-		assert.NoError(t, err)
-	}
-}
-
-func TestSegmentStoreRepairRemote(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	ti := time.Unix(0, 0).UTC()
-	someTime, err := ptypes.TimestampProto(ti)
-	assert.NoError(t, err)
-
-	for _, tt := range []struct {
-		pathInput               string
-		thresholdSize           int
-		pointerType             pb.Pointer_DataType
-		size                    int64
-		metadata                []byte
-		lostPieces              []int32
-		newNodes                []*pb.Node
-		data                    string
-		strsize, offset, length int64
-		substr                  string
-		meta                    Meta
-	}{
-		{
-			"path/1/2/3",
-			10,
-			pb.Pointer_REMOTE,
-			int64(3),
-			[]byte("metadata"),
-			[]int32{},
-			[]*pb.Node{
-				teststorj.MockNode("1"),
-				teststorj.MockNode("2"),
-			},
-			"abcdefghijkl",
-			12,
-			1,
-			4,
-			"bcde",
-			Meta{},
-		},
-	} {
-		mockOC := mock_overlay.NewMockClient(ctrl)
-		mockEC := mock_ecclient.NewMockClient(ctrl)
-		mockPDB := mock_pointerdb.NewMockClient(ctrl)
-		mockES := mock_eestream.NewMockErasureScheme(ctrl)
-		rs := eestream.RedundancyStrategy{
-			ErasureScheme: mockES,
-		}
-
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
-		assert.NotNil(t, ss)
-
-		calls := []*gomock.Call{
-			mockPDB.EXPECT().Get(
-				gomock.Any(), gomock.Any(),
-			).Return(&pb.Pointer{
-				Type: tt.pointerType,
-				Remote: &pb.RemoteSegment{
-					Redundancy: &pb.RedundancyScheme{
-						Type:             pb.RedundancyScheme_RS,
-						MinReq:           1,
-						Total:            2,
-						RepairThreshold:  1,
-						SuccessThreshold: 2,
-					},
-					PieceId:      "here's my piece id",
-					RemotePieces: []*pb.RemotePiece{},
-				},
-				CreationDate:   someTime,
-				ExpirationDate: someTime,
-				SegmentSize:    tt.size,
-				Metadata:       tt.metadata,
-			}, nil, nil, nil),
-			mockOC.EXPECT().BulkLookup(gomock.Any(), gomock.Any()),
-			mockOC.EXPECT().Choose(gomock.Any(), gomock.Any()).Return(tt.newNodes, nil),
-			mockPDB.EXPECT().SignedMessage(),
-			mockEC.EXPECT().Get(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-			).Return(ranger.ByteRanger([]byte(tt.data)), nil),
-			mockEC.EXPECT().Put(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-			).Return(tt.newNodes, nil),
-			mockES.EXPECT().RequiredCount().Return(1),
-			mockES.EXPECT().TotalCount().Return(1),
-			mockES.EXPECT().ErasureShareSize().Return(1),
-			mockPDB.EXPECT().Put(
-				gomock.Any(), gomock.Any(), gomock.Any(),
-			).Return(nil),
-		}
-		gomock.InOrder(calls...)
-
-		err := ss.Repair(ctx, tt.pathInput, tt.lostPieces)
 		assert.NoError(t, err)
 	}
 }


### PR DESCRIPTION
With this PR:
- The data repairer no longer needs configuration for redundancy strategy and inline segment threshold
- When repairing a segment the redundancy strategy from the segment's pointer is used instead the one that was configured for the repairer
- A Segment Repairer is extracted from the existing Segment Store to achieve the above