### PR TITLE
Updates refresh function

### DIFF
--- a/pkg/discovery/config.go
+++ b/pkg/discovery/config.go
@@ -60,6 +60,13 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) (err error) 
 	ticker := time.NewTicker(c.RefreshInterval)
 	defer ticker.Stop()
 
+	// Bootstrap the cache with initial kademlia Seen
+	err = discovery.Bootstrap(ctx)
+	if err != nil {
+		discovery.log.Error("error bootstrapping cache", zap.Error(err))
+		return Error.Wrap(err)
+	}
+
 	go func() {
 		for {
 			select {

--- a/pkg/overlay/cache_test.go
+++ b/pkg/overlay/cache_test.go
@@ -99,6 +99,14 @@ func testCache(ctx context.Context, t *testing.T, store storage.KeyValueStore, s
 		}
 	}
 
+	// 	{ // List
+	// 		list, err := cache.List(ctx, nil, 0)
+	// 		assert.NoError(t, err)
+	// 		assert.Equal(t, list[0].Id, valid2ID)
+	// 		assert.Equal(t, list[1].Id, valid1ID)
+	// 		assert.Equal(t, list[2].Id, valid2ID)
+	// 	}
+
 	{ // Delete
 		// Test standard delete
 		err := cache.Delete(ctx, valid1ID)

--- a/pkg/overlay/client.go
+++ b/pkg/overlay/client.go
@@ -5,6 +5,7 @@ package overlay
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/zeebo/errs"
 
@@ -89,7 +90,9 @@ func (client *client) Choose(ctx context.Context, op Options) ([]*pb.Node, error
 
 // Lookup provides a Node with the given ID
 func (client *client) Lookup(ctx context.Context, nodeID storj.NodeID) (*pb.Node, error) {
+	fmt.Printf("\n LOOKING FOR %+v\n", nodeID)
 	resp, err := client.conn.Lookup(ctx, &pb.LookupRequest{NodeId: nodeID})
+	fmt.Printf("\nOVERLAY LOOKUP %+v\n ERROR %+v\n", resp, err)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/overlay/client_test.go
+++ b/pkg/overlay/client_test.go
@@ -4,6 +4,7 @@
 package overlay_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -144,6 +145,7 @@ func TestLookup(t *testing.T) {
 
 	for _, v := range cases {
 		n, err := oc.Lookup(ctx, v.nodeID)
+		fmt.Printf("\nN %+v\n ERROR %+v\n", n, err)
 		if v.expectErr {
 			assert.Error(t, err)
 		} else {


### PR DESCRIPTION
First pass at a refresh function that PINGs nodes to check uptime. This only checks nodes that are in Kademlia. We should check all nodes that are in the cache, but I don't have a good way to grab the entire cache right now.