### PR TITLE
fix `defaultConfDir` initialization

### DIFF
--- a/cmd/captplanet/main.go
+++ b/cmd/captplanet/main.go
@@ -29,7 +29,7 @@ var (
 		Short: "Captain Planet! With our powers combined!",
 	}
 
-	defaultConfDir string
+	defaultConfDir = fpath.ApplicationDir("storj", "capt")
 )
 
 func main() {
@@ -38,7 +38,6 @@ func main() {
 }
 
 func init() {
-	defaultConfDir = fpath.ApplicationDir("storj", "capt")
 	runCmd.Flags().String("config",
 		filepath.Join(defaultConfDir, "config.yaml"), "path to configuration")
 	setupCmd.Flags().String("config",


### PR DESCRIPTION
[`init` functions don't necessarily run in the order one might expect](https://medium.com/golangspec/init-functions-in-go-eac191b3860a). It is currently the case that main.go's init is run first because its file name is first in lexical order for that package but that may not always be the case.