### PR TITLE
unify logging messages

### DIFF
--- a/cmd/captplanet/run.go
+++ b/cmd/captplanet/run.go
@@ -99,7 +99,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 
 	// start satellite
 	go func() {
-		_, _ = fmt.Printf("starting satellite on %s\n",
+		_, _ = fmt.Printf("Starting satellite on %s\n",
 			runCfg.Satellite.Identity.Server.Address)
 
 		if runCfg.Satellite.Audit.SatelliteAddr == "" {
@@ -157,7 +157,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 			address := v.Identity.Server.Address
 			storagenode := fmt.Sprintf("%s:%s", identity.ID.String(), address)
 
-			_, _ = fmt.Printf("starting storage node %d %s (kad on %s)\n", i, storagenode, address)
+			_, _ = fmt.Printf("Starting storage node %d %s (kad on %s)\n", i, storagenode, address)
 			errch <- v.Identity.Run(ctx, nil, v.Kademlia, v.Storage)
 		}(i, v)
 	}


### PR DESCRIPTION
Different capital letter looks ugly.
```
root@kali:~# captplanet run
starting satellite on 127.0.0.1:7778
Starting s3-gateway on 127.0.0.1:7777
Access key: insecure-dev-access-key
Secret key: insecure-dev-secret-key
starting storage node 8 12KFuJC1Ks6v2uaj254Rx63WVq3d3EdYpcg1utDKLATA3CWWM2s:127.0.0.1:7796 (kad on 127.0.0.1:7796)
```