### PR TITLE
moves node selection config setup from uplink to satellite

### DIFF
--- a/internal/testplanet/node.go
+++ b/internal/testplanet/node.go
@@ -122,9 +122,9 @@ func (node *Node) Shutdown() error {
 }
 
 // NewNodeClient creates a node client for this node
-func (n *Node) NewNodeClient() (node.Client, error) { //nolint renaming to node would conflict with package name; rename Node to Peer to resolve
+func (node *Node) NewNodeClient() (node.Client, error) { //nolint renaming to node would conflict with package name; rename Node to Peer to resolve
 	// TODO: handle disconnect verification
-	return node.NewNodeClient(n.Identity, n.Info, n.Kademlia)
+	return node.NewNodeClient()
 }
 
 // DialPointerDB dials destination with apikey and returns pointerdb Client

--- a/internal/testplanet/node.go
+++ b/internal/testplanet/node.go
@@ -122,9 +122,9 @@ func (node *Node) Shutdown() error {
 }
 
 // NewNodeClient creates a node client for this node
-func (node *Node) NewNodeClient() (node.Client, error) { //nolint renaming to node would conflict with package name; rename Node to Peer to resolve
+func (n *Node) NewNodeClient() (node.Client, error) { //nolint renaming to node would conflict with package name; rename Node to Peer to resolve
 	// TODO: handle disconnect verification
-	return node.NewNodeClient()
+	return node.NewNodeClient(n.Identity, n.Info, n.Kademlia)
 }
 
 // DialPointerDB dials destination with apikey and returns pointerdb Client

--- a/internal/testplanet/planet.go
+++ b/internal/testplanet/planet.go
@@ -114,7 +114,14 @@ func New(t zaptest.TestingT, satelliteCount, storageNodeCount, uplinkCount int) 
 			}
 		}(node)
 
-		overlayServer := overlay.NewServer(node.Log.Named("overlay"), node.Overlay, node.Kademlia)
+		ns := &pb.NodeStats{
+			UptimeCount:       0,
+			UptimeRatio:       0,
+			AuditSuccessRatio: 0,
+			AuditCount:        0,
+		}
+
+		overlayServer := overlay.NewServer(node.Log.Named("overlay"), node.Overlay, node.Kademlia, ns)
 		pb.RegisterOverlayServer(node.Provider.GRPC(), overlayServer)
 
 		node.Dependencies = append(node.Dependencies,

--- a/pkg/datarepair/repairer/config.go
+++ b/pkg/datarepair/repairer/config.go
@@ -10,9 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"storj.io/storj/pkg/datarepair/queue"
-	"storj.io/storj/pkg/miniogw"
 	"storj.io/storj/pkg/overlay"
-	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/pointerdb/pdbclient"
 	"storj.io/storj/pkg/provider"
 	"storj.io/storj/pkg/storage/ec"
@@ -29,8 +27,6 @@ type Config struct {
 	PointerDBAddr string        `help:"Address to contact pointerdb server through"`
 	MaxBufferMem  int           `help:"maximum buffer memory (in bytes) to be allocated for read buffers" default:"0x400000"`
 	APIKey        string        `help:"repairer-specific pointerdb access credential"`
-
-	miniogw.NodeSelectionConfig
 }
 
 // Run runs the repair service with configured values
@@ -79,12 +75,5 @@ func (c Config) getSegmentRepairer(ctx context.Context, identity *provider.FullI
 
 	ec := ecclient.NewClient(identity, c.MaxBufferMem)
 
-	ns := &pb.NodeStats{
-		UptimeRatio:       c.UptimeRatio,
-		AuditSuccessRatio: c.AuditSuccessRatio,
-		UptimeCount:       c.UptimeCount,
-		AuditCount:        c.AuditCount,
-	}
-
-	return segments.NewSegmentRepairer(oc, ec, pdb, ns), nil
+	return segments.NewSegmentRepairer(oc, ec, pdb), nil
 }

--- a/pkg/metainfo/kvmetainfo/buckets_test.go
+++ b/pkg/metainfo/kvmetainfo/buckets_test.go
@@ -357,7 +357,7 @@ func newDB(planet *testplanet.Planet) (*DB, error) {
 		return nil, err
 	}
 
-	segments := segments.NewSegmentStore(oc, ec, pdb, rs, int(8*memory.KB), &pb.NodeStats{})
+	segments := segments.NewSegmentStore(oc, ec, pdb, rs, int(8*memory.KB))
 
 	key := new(storj.Key)
 	copy(key[:], TestEncKey)

--- a/pkg/metainfo/kvmetainfo/buckets_test.go
+++ b/pkg/metainfo/kvmetainfo/buckets_test.go
@@ -16,7 +16,6 @@ import (
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testplanet"
 	"storj.io/storj/pkg/eestream"
-	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/storage/buckets"
 	"storj.io/storj/pkg/storage/ec"
 	"storj.io/storj/pkg/storage/segments"

--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -36,15 +36,6 @@ type RSConfig struct {
 	MaxThreshold     int `help:"the largest amount of pieces to encode to. n." default:"95"`
 }
 
-// NodeSelectionConfig is a configuration struct to determine the minimum
-// values for nodes to select
-type NodeSelectionConfig struct {
-	UptimeRatio       float64 `help:"a node's ratio of being up/online vs. down/offline" default:"0"`
-	UptimeCount       int64   `help:"the number of times a node's uptime has been checked" default:"0"`
-	AuditSuccessRatio float64 `help:"a node's ratio of successful audits" default:"0"`
-	AuditCount        int64   `help:"the number of times a node has been audited" default:"0"`
-}
-
 // EncryptionConfig is a configuration struct that keeps details about
 // encrypting segments
 type EncryptionConfig struct {
@@ -82,7 +73,6 @@ type Config struct {
 	Client   ClientConfig
 	RS       RSConfig
 	Enc      EncryptionConfig
-	Node     NodeSelectionConfig
 }
 
 // Run starts a Minio Gateway given proper config
@@ -157,14 +147,7 @@ func (c Config) GetMetainfo(ctx context.Context, identity *provider.FullIdentity
 		return nil, nil, err
 	}
 
-	ns := &pb.NodeStats{
-		UptimeCount:       c.Node.UptimeCount,
-		UptimeRatio:       c.Node.UptimeRatio,
-		AuditSuccessRatio: c.Node.AuditSuccessRatio,
-		AuditCount:        c.Node.AuditCount,
-	}
-
-	segments := segments.NewSegmentStore(oc, ec, pdb, rs, c.Client.MaxInlineSize, ns)
+	segments := segments.NewSegmentStore(oc, ec, pdb, rs, c.Client.MaxInlineSize)
 
 	if c.RS.ErasureShareSize*c.RS.MinThreshold%c.Enc.BlockSize != 0 {
 		err = Error.New("EncryptionBlockSize must be a multiple of ErasureShareSize * RS MinThreshold")

--- a/pkg/miniogw/config.go
+++ b/pkg/miniogw/config.go
@@ -15,7 +15,6 @@ import (
 	"storj.io/storj/pkg/eestream"
 	"storj.io/storj/pkg/metainfo/kvmetainfo"
 	"storj.io/storj/pkg/overlay"
-	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/pointerdb/pdbclient"
 	"storj.io/storj/pkg/provider"
 	"storj.io/storj/pkg/storage/buckets"

--- a/pkg/miniogw/gateway_test.go
+++ b/pkg/miniogw/gateway_test.go
@@ -682,7 +682,7 @@ func initEnv(planet *testplanet.Planet) (minio.ObjectLayer, storj.Metainfo, stre
 		return nil, nil, nil, err
 	}
 
-	segments := segments.NewSegmentStore(oc, ec, pdb, rs, int(8*memory.KB), &pb.NodeStats{})
+	segments := segments.NewSegmentStore(oc, ec, pdb, rs, int(8*memory.KB))
 
 	key := new(storj.Key)
 	copy(key[:], TestEncKey)

--- a/pkg/overlay/client.go
+++ b/pkg/overlay/client.go
@@ -75,14 +75,8 @@ func (o *Overlay) Choose(ctx context.Context, op Options) ([]*pb.Node, error) {
 	// TODO(coyle): We will also need to communicate with the reputation service here
 	resp, err := o.client.FindStorageNodes(ctx, &pb.FindStorageNodesRequest{
 		Opts: &pb.OverlayOptions{
-			Amount:       int64(op.Amount),
-			Restrictions: &pb.NodeRestrictions{FreeDisk: op.Space, FreeBandwidth: op.Bandwidth},
-			MinStats: &pb.NodeStats{
-				UptimeRatio:       op.Uptime,
-				UptimeCount:       op.UptimeCount,
-				AuditSuccessRatio: op.AuditSuccess,
-				AuditCount:        op.AuditCount,
-			},
+			Amount:        int64(op.Amount),
+			Restrictions:  &pb.NodeRestrictions{FreeDisk: op.Space, FreeBandwidth: op.Bandwidth},
 			ExcludedNodes: exIDs,
 		},
 	})

--- a/pkg/overlay/config.go
+++ b/pkg/overlay/config.go
@@ -84,7 +84,7 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) (
 		AuditSuccessRatio: c.Node.AuditSuccessRatio,
 		AuditCount:        c.Node.AuditCount,
 	}
-	
+
 	srv := NewServer(zap.L(), cache, kad, ns)
 	pb.RegisterOverlayServer(server.GRPC(), srv)
 

--- a/pkg/overlay/server.go
+++ b/pkg/overlay/server.go
@@ -26,19 +26,21 @@ var ServerError = errs.Class("Server Error")
 
 // Server implements our overlay RPC service
 type Server struct {
-	logger  *zap.Logger
-	dht     dht.DHT
-	cache   *Cache
-	metrics *monkit.Registry
+	logger    *zap.Logger
+	dht       dht.DHT
+	cache     *Cache
+	metrics   *monkit.Registry
+	nodeStats *pb.NodeStats
 }
 
 // NewServer creates a new Overlay Server
-func NewServer(log *zap.Logger, cache *Cache, dht dht.DHT) *Server {
+func NewServer(log *zap.Logger, cache *Cache, dht dht.DHT, nodeStats *pb.NodeStats) *Server {
 	return &Server{
-		dht:     dht,
-		cache:   cache,
-		logger:  log,
-		metrics: monkit.Default,
+		dht:       dht,
+		cache:     cache,
+		logger:    log,
+		metrics:   monkit.Default,
+		nodeStats: nodeStats,
 	}
 }
 
@@ -75,7 +77,7 @@ func (o *Server) FindStorageNodes(ctx context.Context, req *pb.FindStorageNodesR
 
 	excluded := opts.ExcludedNodes
 	restrictions := opts.GetRestrictions()
-	reputation := opts.GetMinStats()
+	reputation := o.nodeStats
 
 	var startID storj.NodeID
 	result := []*pb.Node{}

--- a/pkg/overlay/server_test.go
+++ b/pkg/overlay/server_test.go
@@ -31,16 +31,7 @@ func TestServer(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	satellite := planet.Satellites[0]
-
-
-	ns := &pb.NodeStats{
-		UptimeCount:       0,
-		UptimeRatio:       0,
-		AuditSuccessRatio: 0,
-		AuditCount:        0,
-	}
-	
-	server := overlay.NewServer(satellite.Log.Named("overlay"), satellite.Overlay, satellite.Kademlia, ns)
+	server := overlay.NewServer(satellite.Log.Named("overlay"), satellite.Overlay, satellite.Kademlia, &pb.NodeStats{})
 	// TODO: handle cleanup
 
 	{ // FindStorageNodes

--- a/pkg/overlay/server_test.go
+++ b/pkg/overlay/server_test.go
@@ -31,7 +31,16 @@ func TestServer(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	satellite := planet.Satellites[0]
-	server := overlay.NewServer(satellite.Log.Named("overlay"), satellite.Overlay, satellite.Kademlia)
+
+
+	ns := &pb.NodeStats{
+		UptimeCount:       0,
+		UptimeRatio:       0,
+		AuditSuccessRatio: 0,
+		AuditCount:        0,
+	}
+	
+	server := overlay.NewServer(satellite.Log.Named("overlay"), satellite.Overlay, satellite.Kademlia, ns)
 	// TODO: handle cleanup
 
 	{ // FindStorageNodes

--- a/pkg/storage/segments/repairer.go
+++ b/pkg/storage/segments/repairer.go
@@ -24,8 +24,8 @@ type Repairer struct {
 }
 
 // NewSegmentRepairer creates a new instance of SegmentRepairer
-func NewSegmentRepairer(oc overlay.Client, ec ecclient.Client, pdb pdbclient.Client, nodeStats *pb.NodeStats) *Repairer {
-	return &Repairer{oc: oc, ec: ec, pdb: pdb, nodeStats: nodeStats}
+func NewSegmentRepairer(oc overlay.Client, ec ecclient.Client, pdb pdbclient.Client) *Repairer {
+	return &Repairer{oc: oc, ec: ec, pdb: pdb}
 }
 
 // Repair retrieves an at-risk segment and repairs and stores lost pieces on new nodes

--- a/pkg/storage/segments/repairer_test.go
+++ b/pkg/storage/segments/repairer_test.go
@@ -27,7 +27,7 @@ func TestNewSegmentRepairer(t *testing.T) {
 	mockEC := mock_ecclient.NewMockClient(ctrl)
 	mockPDB := mock_pointerdb.NewMockClient(ctrl)
 
-	ss := NewSegmentRepairer(mockOC, mockEC, mockPDB, &pb.NodeStats{})
+	ss := NewSegmentRepairer(mockOC, mockEC, mockPDB)
 	assert.NotNil(t, ss)
 }
 

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -59,12 +59,11 @@ type segmentStore struct {
 	pdb           pdbclient.Client
 	rs            eestream.RedundancyStrategy
 	thresholdSize int
-	nodeStats     *pb.NodeStats
 }
 
 // NewSegmentStore creates a new instance of segmentStore
-func NewSegmentStore(oc overlay.Client, ec ecclient.Client, pdb pdbclient.Client, rs eestream.RedundancyStrategy, threshold int, nodeStats *pb.NodeStats) Store {
-	return &segmentStore{oc: oc, ec: ec, pdb: pdb, rs: rs, thresholdSize: threshold, nodeStats: nodeStats}
+func NewSegmentStore(oc overlay.Client, ec ecclient.Client, pdb pdbclient.Client, rs eestream.RedundancyStrategy, threshold int) Store {
+	return &segmentStore{oc: oc, ec: ec, pdb: pdb, rs: rs, thresholdSize: threshold}
 }
 
 // Meta retrieves the metadata of the segment
@@ -116,14 +115,10 @@ func (s *segmentStore) Put(ctx context.Context, data io.Reader, expiration time.
 		// uses overlay client to request a list of nodes according to configured standards
 		nodes, err := s.oc.Choose(ctx,
 			overlay.Options{
-				Amount:       s.rs.TotalCount(),
-				Bandwidth:    sizedReader.Size() / int64(s.rs.TotalCount()),
-				Space:        sizedReader.Size() / int64(s.rs.TotalCount()),
-				Uptime:       s.nodeStats.UptimeRatio,
-				UptimeCount:  s.nodeStats.UptimeCount,
-				AuditSuccess: s.nodeStats.AuditSuccessRatio,
-				AuditCount:   s.nodeStats.AuditCount,
-				Excluded:     nil,
+				Amount:    s.rs.TotalCount(),
+				Bandwidth: sizedReader.Size() / int64(s.rs.TotalCount()),
+				Space:     sizedReader.Size() / int64(s.rs.TotalCount()),
+				Excluded:  nil,
 			})
 		if err != nil {
 			return Meta{}, Error.Wrap(err)

--- a/pkg/storage/segments/store_test.go
+++ b/pkg/storage/segments/store_test.go
@@ -41,7 +41,7 @@ func TestNewSegmentStore(t *testing.T) {
 		ErasureScheme: mock_eestream.NewMockErasureScheme(ctrl),
 	}
 
-	ss := NewSegmentStore(mockOC, mockEC, mockPDB, rs, 10, &pb.NodeStats{})
+	ss := NewSegmentStore(mockOC, mockEC, mockPDB, rs, 10)
 	assert.NotNil(t, ss)
 }
 
@@ -56,7 +56,7 @@ func TestSegmentStoreMeta(t *testing.T) {
 		ErasureScheme: mock_eestream.NewMockErasureScheme(ctrl),
 	}
 
-	ss := segmentStore{mockOC, mockEC, mockPDB, rs, 10, &pb.NodeStats{}}
+	ss := segmentStore{mockOC, mockEC, mockPDB, rs, 10}
 	assert.NotNil(t, ss)
 
 	var mExp time.Time
@@ -105,7 +105,7 @@ func TestSegmentStorePutRemote(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -161,7 +161,7 @@ func TestSegmentStorePutInline(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -207,7 +207,7 @@ func TestSegmentStoreGetInline(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -254,7 +254,7 @@ func TestSegmentStoreGetRemote(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -317,7 +317,7 @@ func TestSegmentStoreDeleteInline(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -367,7 +367,7 @@ func TestSegmentStoreDeleteRemote(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
 		assert.NotNil(t, ss)
 
 		calls := []*gomock.Call{
@@ -429,7 +429,7 @@ func TestSegmentStoreList(t *testing.T) {
 			ErasureScheme: mockES,
 		}
 
-		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize, &pb.NodeStats{}}
+		ss := segmentStore{mockOC, mockEC, mockPDB, rs, tt.thresholdSize}
 		assert.NotNil(t, ss)
 
 		ti := time.Unix(0, 0).UTC()


### PR DESCRIPTION
- removes node selection config from uplink
- adds node selection config to overlay server config
- removes passing in nodeStats from oc.Choose inside segment Put
- adds min node stats placeholder (all set to zero) to test planet