### PR TITLE
Validate farmers wallet and email configuration

### DIFF
--- a/cmd/storagenode/main.go
+++ b/cmd/storagenode/main.go
@@ -94,10 +94,15 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	farmerConfig := runCfg.Kademlia.Farmer
 	if err := isFarmerEmailValid(farmerConfig.Email); err != nil {
 		zap.S().Warn(err)
+	} else {
+		zap.S().Info("Farmer email: ", farmerConfig.Email)
 	}
 	if err := isFarmerWalletValid(farmerConfig.Wallet); err != nil {
 		zap.S().Fatal(err)
+	} else {
+		zap.S().Info("Farmer wallet: ", farmerConfig.Wallet)
 	}
+
 	return runCfg.Identity.Run(process.Ctx(cmd), nil, runCfg.Kademlia, runCfg.Storage)
 }
 

--- a/cmd/storagenode/main.go
+++ b/cmd/storagenode/main.go
@@ -235,7 +235,7 @@ func isFarmerWalletValid(wallet string) error {
 	if wallet == "" {
 		return fmt.Errorf("Farmer wallet address isn't specified")
 	}
-	r := regexp.MustCompile("^(0x[a-fA-F0-9]{40})$")
+	r := regexp.MustCompile("^0x[a-fA-F0-9]{40}$")
 	if match := r.MatchString(wallet); !match {
 		return fmt.Errorf("Farmer wallet address isn't valid")
 	}

--- a/cmd/storagenode/main.go
+++ b/cmd/storagenode/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 
 	"storj.io/storj/internal/fpath"
 	"storj.io/storj/pkg/cfgstruct"
@@ -92,10 +93,10 @@ func init() {
 func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	farmerConfig := runCfg.Kademlia.Farmer
 	if err := isFarmerEmailValid(farmerConfig.Email); err != nil {
-		fmt.Println("Warning!", err)
+		zap.S().Warn(err)
 	}
 	if err := isFarmerWalletValid(farmerConfig.Wallet); err != nil {
-		return err
+		zap.S().Fatal(err)
 	}
 	return runCfg.Identity.Run(process.Ctx(cmd), nil, runCfg.Kademlia, runCfg.Storage)
 }


### PR DESCRIPTION
Adds farmer wallet and mail validation during storage node startup.

![image](https://user-images.githubusercontent.com/7313031/50166065-83e3f880-02e6-11e9-977b-09fe72a749a0.png)

https://storjlabs.atlassian.net/browse/V3-994