### PR TITLE
Do not error if Discovery can not find Node

### DIFF
--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -71,7 +71,7 @@ func (d *Discovery) Discovery(ctx context.Context) error {
 		return DiscoveryError.Wrap(err)
 	}
 	_, err = d.kad.FindNode(ctx, r)
-	if err != nil {
+	if err != nil && !kademlia.NodeNotFound.Has(err) {
 		return DiscoveryError.Wrap(err)
 	}
 	return nil


### PR DESCRIPTION
Discovery may not find the node we are looking for and this shouldn't be an error.