### PR TITLE
remove node startup log in piecestore server

### DIFF
--- a/pkg/piecestore/psserver/server.go
+++ b/pkg/piecestore/psserver/server.go
@@ -80,7 +80,6 @@ func (c Config) Run(ctx context.Context, server *provider.Provider) (err error) 
 		log.Fatal(s.Stop(ctx))
 	}()
 
-	s.log.Info("Started Node", zap.String("ID", fmt.Sprint(server.Identity().ID)))
 	return server.Run(ctx)
 }
 


### PR DESCRIPTION
We log each node's ID on startup in `pkg/server/config.go`. The log statement in piecestore is redundant