### PR TITLE
prepare key generation for launch

### DIFF
--- a/cmd/identity/keys.go
+++ b/cmd/identity/keys.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2018 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/spf13/cobra"
+	"storj.io/storj/pkg/cfgstruct"
+	"storj.io/storj/pkg/identity"
+	"storj.io/storj/pkg/process"
+	"storj.io/storj/pkg/storj"
+)
+
+var (
+	keysCmd = &cobra.Command{
+		Use:   "keys",
+		Short: "Manage keys",
+	}
+	keyGenerateCmd = &cobra.Command{
+		Use:   "generate",
+		Short: "generate lots of keys",
+		RunE:  cmdKeyGenerate,
+	}
+
+	keyCfg struct {
+		MinDifficulty int    `help:"minimum difficulty to output" default:"18"`
+		Concurrency   int    `help:"worker concurrency" default:"4"`
+		OutputDir     string `help:"output directory to place keys" default:"."`
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(keysCmd)
+	keysCmd.AddCommand(keyGenerateCmd)
+	cfgstruct.Bind(keyGenerateCmd.Flags(), &keyCfg)
+}
+
+func cmdKeyGenerate(cmd *cobra.Command, args []string) (err error) {
+	ctx := process.Ctx(cmd)
+	err = os.MkdirAll(keyCfg.OutputDir, 0755)
+	if err != nil {
+		return err
+	}
+	counter := new(uint32)
+	return identity.GenerateKeys(ctx, uint16(keyCfg.MinDifficulty), keyCfg.Concurrency,
+		func(k *ecdsa.PrivateKey, id storj.NodeID) (done bool, err error) {
+			data, err := x509.MarshalECPrivateKey(k)
+			if err != nil {
+				return false, err
+			}
+			difficulty, err := id.Difficulty()
+			if err != nil {
+				return false, err
+			}
+			filename := fmt.Sprintf("gen-%02d-%d.key", difficulty, atomic.AddUint32(counter, 1))
+			fmt.Println("writing", filename)
+			err = ioutil.WriteFile(filepath.Join(keyCfg.OutputDir, filename), data, 0644)
+			return false, err
+		})
+}

--- a/cmd/identity/keys.go
+++ b/cmd/identity/keys.go
@@ -45,7 +45,7 @@ func init() {
 
 func cmdKeyGenerate(cmd *cobra.Command, args []string) (err error) {
 	ctx := process.Ctx(cmd)
-	err = os.MkdirAll(keyCfg.OutputDir, 0755)
+	err = os.MkdirAll(keyCfg.OutputDir, 0700)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func cmdKeyGenerate(cmd *cobra.Command, args []string) (err error) {
 			}
 			filename := fmt.Sprintf("gen-%02d-%d.key", difficulty, atomic.AddUint32(counter, 1))
 			fmt.Println("writing", filename)
-			err = ioutil.WriteFile(filepath.Join(keyCfg.OutputDir, filename), data, 0644)
+			err = ioutil.WriteFile(filepath.Join(keyCfg.OutputDir, filename), data, 0600)
 			return false, err
 		})
 }

--- a/pkg/identity/certificate_authority.go
+++ b/pkg/identity/certificate_authority.go
@@ -13,6 +13,8 @@ import (
 	"encoding/pem"
 	"io/ioutil"
 	"log"
+	"sync"
+	"sync/atomic"
 
 	"github.com/zeebo/errs"
 
@@ -20,6 +22,8 @@ import (
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/pkg/utils"
 )
+
+const minimumLoggableDifficulty = 8
 
 // PeerCertificateAuthority represents the CA which is used to validate peer identities
 type PeerCertificateAuthority struct {
@@ -80,32 +84,66 @@ type FullCAConfig struct {
 func NewCA(ctx context.Context, opts NewCAOptions) (_ *FullCertificateAuthority, err error) {
 	defer mon.Task()(&ctx)(&err)
 	var (
-		highscore uint32
+		highscore = new(uint32)
+
+		mu          sync.Mutex
+		selectedKey *ecdsa.PrivateKey
+		selectedID  storj.NodeID
 	)
 
 	if opts.Concurrency < 1 {
 		opts.Concurrency = 1
 	}
-	ctx, cancel := context.WithCancel(ctx)
 
 	log.Printf("Generating a certificate matching a difficulty of %d\n", opts.Difficulty)
-	eC := make(chan error)
-	caC := make(chan FullCertificateAuthority, 1)
-	for i := 0; i < int(opts.Concurrency); i++ {
-		go newCAWorker(ctx, i, &highscore, opts.Difficulty, opts.ParentCert, opts.ParentKey, caC, eC)
+	err = GenerateKeys(ctx, minimumLoggableDifficulty, int(opts.Concurrency),
+		func(k *ecdsa.PrivateKey, id storj.NodeID) (done bool, err error) {
+			difficulty, err := id.Difficulty()
+			if err != nil {
+				return false, err
+			}
+			if difficulty >= opts.Difficulty {
+				mu.Lock()
+				if selectedKey == nil {
+					log.Printf("Found a certificate matching difficulty of %d\n", difficulty)
+					selectedKey = k
+					selectedID = id
+				}
+				mu.Unlock()
+				return true, nil
+			}
+			for {
+				hs := atomic.LoadUint32(highscore)
+				if uint32(difficulty) <= hs {
+					return false, nil
+				}
+				if atomic.CompareAndSwapUint32(highscore, hs, uint32(difficulty)) {
+					log.Printf("Found a certificate matching difficulty of %d\n", difficulty)
+					return false, nil
+				}
+			}
+		})
+	if err != nil {
+		return nil, err
 	}
 
-	select {
-	case ca := <-caC:
-		cancel()
-		return &ca, nil
-	case err := <-eC:
-		cancel()
+	ct, err := peertls.CATemplate()
+	if err != nil {
 		return nil, err
-	case <-ctx.Done():
-		cancel()
-		return nil, ctx.Err()
 	}
+	c, err := peertls.NewCert(selectedKey, opts.ParentKey, ct, opts.ParentCert)
+	if err != nil {
+		return nil, err
+	}
+	ca := &FullCertificateAuthority{
+		Cert: c,
+		Key:  selectedKey,
+		ID:   selectedID,
+	}
+	if opts.ParentCert != nil {
+		ca.RestChain = []*x509.Certificate{opts.ParentCert}
+	}
+	return ca, nil
 }
 
 // Status returns the status of the CA cert/key files for the config
@@ -255,11 +293,7 @@ func (ca *FullCertificateAuthority) NewIdentity() (*FullIdentity, error) {
 	if err != nil {
 		return nil, err
 	}
-	pk, ok := leafKey.(*ecdsa.PrivateKey)
-	if !ok {
-		return nil, peertls.ErrUnsupportedKey.New("%T", leafKey)
-	}
-	leafCert, err := peertls.NewCert(pk, ca.Key, leafTemplate, ca.Cert)
+	leafCert, err := peertls.NewCert(leafKey, ca.Key, leafTemplate, ca.Cert)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identity/generate.go
+++ b/pkg/identity/generate.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package identity
+
+import (
+	"context"
+	"crypto/ecdsa"
+
+	"storj.io/storj/pkg/peertls"
+	"storj.io/storj/pkg/storj"
+)
+
+// GenerateKey generates a private key with a node id with difficulty at least
+// minDifficulty. No parallelism is used.
+func GenerateKey(ctx context.Context, minDifficulty uint16) (
+	k *ecdsa.PrivateKey, id storj.NodeID, err error) {
+	var d uint16
+	for {
+		err = ctx.Err()
+		if err != nil {
+			break
+		}
+		k, err = peertls.NewKey()
+		if err != nil {
+			break
+		}
+		id, err = NodeIDFromECDSAKey(&k.PublicKey)
+		if err != nil {
+			break
+		}
+		d, err = id.Difficulty()
+		if err != nil {
+			break
+		}
+		if d >= minDifficulty {
+			return k, id, nil
+		}
+	}
+	return k, id, storj.ErrNodeID.Wrap(err)
+}
+
+// GenerateKeys continues to generate keys until found returns done == false,
+// or the ctx is canceled.
+func GenerateKeys(ctx context.Context, minDifficulty uint16, concurrency int,
+	found func(*ecdsa.PrivateKey, storj.NodeID) (done bool, err error)) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	errchan := make(chan error, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			for {
+				k, id, err := GenerateKey(ctx, minDifficulty)
+				if err != nil {
+					errchan <- err
+					return
+				}
+				done, err := found(k, id)
+				if err != nil {
+					errchan <- err
+					return
+				}
+				if done {
+					errchan <- nil
+					return
+				}
+			}
+		}()
+	}
+
+	return <-errchan
+}

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -72,11 +72,7 @@ func TestFullIdentityFromPEM(t *testing.T) {
 	assert.NoError(t, pem.Encode(chainPEM, peertls.NewCertBlock(leafCert.Raw)))
 	assert.NoError(t, pem.Encode(chainPEM, peertls.NewCertBlock(caCert.Raw)))
 
-	leafECKey, ok := leafKey.(*ecdsa.PrivateKey)
-	assert.True(t, ok)
-	assert.NotEmpty(t, leafECKey)
-
-	leafKeyBytes, err := x509.MarshalECPrivateKey(leafECKey)
+	leafKeyBytes, err := x509.MarshalECPrivateKey(leafKey)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, leafKeyBytes)
 

--- a/pkg/peertls/peertls.go
+++ b/pkg/peertls/peertls.go
@@ -57,13 +57,8 @@ var (
 type PeerCertVerificationFunc func([][]byte, [][]*x509.Certificate) error
 
 // NewKey returns a new PrivateKey
-func NewKey() (crypto.PrivateKey, error) {
-	k, err := ecdsa.GenerateKey(authECCurve, rand.Reader)
-	if err != nil {
-		return nil, ErrGenerate.New("failed to generate private key: %v", err)
-	}
-
-	return k, nil
+func NewKey() (*ecdsa.PrivateKey, error) {
+	return ecdsa.GenerateKey(authECCurve, rand.Reader)
 }
 
 // VerifyPeerFunc combines multiple `*tls.Config#VerifyPeerCertificate`

--- a/pkg/peertls/peertls_test.go
+++ b/pkg/peertls/peertls_test.go
@@ -36,7 +36,7 @@ func TestNewCert_CA(t *testing.T) {
 	caCert, err := peertls.NewCert(caKey, nil, caTemplate, nil)
 	assert.NoError(t, err)
 
-	assert.NotEmpty(t, caKey.(*ecdsa.PrivateKey))
+	assert.NotEmpty(t, caKey)
 	assert.NotEmpty(t, caCert)
 	assert.NotEmpty(t, caCert.PublicKey.(*ecdsa.PublicKey))
 
@@ -63,7 +63,7 @@ func TestNewCert_Leaf(t *testing.T) {
 	leafCert, err := peertls.NewCert(leafKey, caKey, leafTemplate, caCert)
 	assert.NoError(t, err)
 
-	assert.NotEmpty(t, caKey.(*ecdsa.PrivateKey))
+	assert.NotEmpty(t, caKey)
 	assert.NotEmpty(t, leafCert)
 	assert.NotEmpty(t, leafCert.PublicKey.(*ecdsa.PublicKey))
 

--- a/pkg/storj/node.go
+++ b/pkg/storj/node.go
@@ -94,13 +94,15 @@ func (id NodeID) Less(b NodeID) bool {
 // Difficulty returns the number of trailing zero bits in a node ID
 func (id NodeID) Difficulty() (uint16, error) {
 	idLen := len(id)
-	for i := 1; i < idLen; i++ {
-		b := id[idLen-i]
+	var b byte
+	var zeroBits int
+	for i := 1; i <= idLen; i++ {
+		b = id[idLen-i]
 
 		if b != 0 {
-			zeroBits := bits.TrailingZeros16(uint16(b))
+			zeroBits = bits.TrailingZeros16(uint16(b))
 			if zeroBits == 16 {
-				zeroBits = 0
+				panic("impossible codepath")
 			}
 
 			return uint16((i-1)*8 + zeroBits), nil

--- a/pkg/storj/node.go
+++ b/pkg/storj/node.go
@@ -102,7 +102,8 @@ func (id NodeID) Difficulty() (uint16, error) {
 		if b != 0 {
 			zeroBits = bits.TrailingZeros16(uint16(b))
 			if zeroBits == 16 {
-				panic("impossible codepath")
+				// we already checked that b != 0.
+				return 0, ErrNodeID.New("impossible codepath!")
 			}
 
 			return uint16((i-1)*8 + zeroBits), nil

--- a/pkg/storj/node_test.go
+++ b/pkg/storj/node_test.go
@@ -4,6 +4,7 @@
 package storj_test
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,9 +18,46 @@ func TestNodeID_Difficulty(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, uint16(0), difficulty)
 
-	// node id with difficulty 13
-	node13 := storj.NodeID{253, 160, 157, 107, 237, 151, 13, 122, 56, 254, 115, 137, 205, 43, 27, 150, 32, 207, 14, 161, 252, 218, 36, 4, 211, 83, 195, 250, 17, 61, 224, 0}
-	difficulty, err = node13.Difficulty()
-	assert.NoError(t, err)
-	assert.Equal(t, uint16(13), difficulty)
+	for _, testcase := range []struct {
+		id         string
+		difficulty uint16
+	}{
+		{"0da09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113de0f1", 0},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113de0fe", 1},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113de0fc", 2},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113de0f8", 3},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113de030", 4},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113de0e0", 5},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113de0c0", 6},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113de080", 7},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113de500", 8},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113dee00", 9},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113dec00", 10},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113de800", 11},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113d7000", 12},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113de000", 13},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113dc000", 14},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113d8000", 15},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa11390000", 16},
+		{"fda09d6bed970d7a38fe7389cd2b1b9620cf0ea1fcda2404d353c3fa113e0000", 17},
+	} {
+
+		decoded, err := hex.DecodeString(testcase.id)
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+
+		var nodeid storj.NodeID
+		n := copy(nodeid[:], decoded)
+		if !assert.Equal(t, n, len(nodeid)) {
+			t.Fatal()
+		}
+
+		difficulty, err := nodeid.Difficulty()
+		if !assert.NoError(t, err) {
+			t.Fatal()
+		}
+
+		assert.Equal(t, testcase.difficulty, difficulty)
+	}
 }


### PR DESCRIPTION
this PR includes four commits:

 * first commit is a huge change - it changes id generation to be sha256 instead of sha3. keccak (sha3) is not only not asic-resistent, it's asic friendly, which is kind of not what you want for a PoW scheme. let's just use the tried and true thing.
 * second commit restructures the id generation code to prepare for the third commit
 * third commit is a tool that just generates keys until it's shut down, storing them indexed by their trailing zero count (the minimum difficulty they would pass)
 * fourth commit adds more difficulty tests