### PR TITLE
adds AddObserver function for use in tests and easier listener management

### DIFF
--- a/pkg/transport/transport_test.go
+++ b/pkg/transport/transport_test.go
@@ -13,9 +13,14 @@ import (
 
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testplanet"
+	"storj.io/storj/pkg/overlay"
 	"storj.io/storj/pkg/pb"
+	"storj.io/storj/pkg/statdb"
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/pkg/transport"
+	"storj.io/storj/satellite"
+	"storj.io/storj/satellite/satellitedb/satellitedbtest"
+	"storj.io/storj/storage"
 )
 
 func TestDialNode(t *testing.T) {
@@ -96,3 +101,44 @@ func TestDialNode(t *testing.T) {
 		assert.NoError(t, conn.Close())
 	}
 }
+
+func testCache(ctx context.Context, t *testing.T, store storage.KeyValueStore, sdb statdb.DB, planet *testplanet.Planet) {
+	cache := overlay.NewCache(store, sdb)
+
+	{ // test init with observers
+		client := transport.NewClient(planet.StorageNodes[0].Identity, cache)
+		assert.NotNil(t, client.Observers())
+		assert.NotNil(t, client.Observers()[0])
+	}
+
+	{ // test AddObserver
+		tester := &Tester{}
+		client := transport.NewClient(planet.StorageNodes[0].Identity, cache)
+		assert.NotNil(t, client.Observers())
+		assert.Equal(t, len(client.Observers()), 1)
+		client.AddObserver(tester)
+		assert.Equal(t, len(client.Observers()), 2)
+	}
+}
+
+func TestObservers(t *testing.T) {
+	ctx := testcontext.New(t)
+	defer ctx.Cleanup()
+
+	planet, err := testplanet.New(t, 1, 4, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctx.Check(planet.Shutdown)
+	planet.Start(ctx)
+
+	satellitedbtest.Run(t, func(t *testing.T, db satellite.DB) {
+		testCache(ctx, t, db.OverlayCache(), db.StatDB(), planet)
+	})
+}
+
+type Tester struct{}
+
+func (tester *Tester) ConnSuccess(ctx context.Context, node *pb.Node) {}
+
+func (tester *Tester) ConnFailure(ctx context.Context, node *pb.Node, err error) {}


### PR DESCRIPTION
Adds the AddObserver() method to transport client for adding observers after instantiation