### PR TITLE
Fix ignored overridden flag in user config

### DIFF
--- a/pkg/process/exec_conf.go
+++ b/pkg/process/exec_conf.go
@@ -80,12 +80,12 @@ func saveConfig(flagset *pflag.FlagSet, outfile string, overrides map[string]int
 		}
 
 		var overriddenValue interface{}
-		var overriddenExist bool
+		var overrideExist bool
 		if overrides != nil {
-			overriddenValue, overriddenExist = overrides[k]
+			overriddenValue, overrideExist = overrides[k]
 		}
 
-		if !saveAllDefaults && !readBoolAnnotation(f, "user") && !f.Changed && !overriddenExist {
+		if !saveAllDefaults && !readBoolAnnotation(f, "user") && !f.Changed && !overrideExist {
 			continue
 		}
 

--- a/pkg/process/exec_conf.go
+++ b/pkg/process/exec_conf.go
@@ -78,15 +78,20 @@ func saveConfig(flagset *pflag.FlagSet, outfile string, overrides map[string]int
 		if readBoolAnnotation(f, "setup") {
 			continue
 		}
-		if !saveAllDefaults && !readBoolAnnotation(f, "user") && !f.Changed {
+
+		var overriddenValue interface{}
+		var overriddenExist bool
+		if overrides != nil {
+			overriddenValue, overriddenExist = overrides[k]
+		}
+
+		if !saveAllDefaults && !readBoolAnnotation(f, "user") && !f.Changed && !overriddenExist {
 			continue
 		}
 
 		value := f.Value.String()
-		if overrides != nil {
-			if v, ok := overrides[k]; ok {
-				value = fmt.Sprintf("%v", v)
-			}
+		if overriddenValue != nil {
+			value = fmt.Sprintf("%v", overriddenValue)
 		}
 		if f.Usage != "" {
 			fmt.Fprintf(w, "# %s\n", f.Usage)


### PR DESCRIPTION
Flag overridden in storage node was ignored because it was not from the user flags list. If flag is set by `override` param then it's always set in config file.