### PR TITLE
Set Identity Folder to Read Only after Identity Signature

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -13,7 +13,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -290,9 +289,7 @@ func (ic Config) Save(fi *FullIdentity) error {
 	if dataErr != nil {
 		return dataErr
 	}
-	//Set Identity Folder to Read-Only
-	err := os.Chmod(ic.CertPath, 0440)
-	return err
+	return nil
 }
 
 // SaveBackup saves the certificate of the config with a timestamped filename

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -291,7 +291,7 @@ func (ic Config) Save(fi *FullIdentity) error {
 		return dataErr
 	}
 	//Set Identity Folder to Read-Only
-	err := os.Chmod(ic.CertPath, 440)
+	err := os.Chmod(ic.CertPath, 0440)
 	return err
 }
 

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -285,10 +286,13 @@ func (ic Config) Save(fi *FullIdentity) error {
 		return writeErr
 	}
 
-	return utils.CombineErrors(
-		writeChainDataErr,
-		writeKeyDataErr,
-	)
+	dataErr := utils.CombineErrors(writeChainDataErr, writeKeyDataErr)
+	if dataErr != nil {
+		return dataErr
+	}
+	//Set Identity Folder to Read-Only
+	err := os.Chmod(ic.CertPath, 440)
+	return err
 }
 
 // SaveBackup saves the certificate of the config with a timestamped filename

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -123,8 +123,8 @@ func TestConfig_SaveIdentity(t *testing.T) {
 
 		// TODO (windows): ignoring for windows due to different default permissions
 		if runtime.GOOS != "windows" {
-			assert.Equal(t, os.FileMode(0644), certInfo.Mode())
-			assert.Equal(t, os.FileMode(0600), keyInfo.Mode())
+			assert.Equal(t, os.FileMode(0444), certInfo.Mode())
+			assert.Equal(t, os.FileMode(0400), keyInfo.Mode())
 		}
 	}
 

--- a/pkg/identity/utils.go
+++ b/pkg/identity/utils.go
@@ -92,7 +92,7 @@ func decodePEM(PEMBytes []byte) ([][]byte, error) {
 
 // writeChainData writes data to path ensuring permissions are appropriate for a cert
 func writeChainData(path string, data []byte) error {
-	err := writeFile(path, 0744, 0644, data)
+	err := writeFile(path, 0444, 0444, data)
 	if err != nil {
 		return errs.New("unable to write certificate to \"%s\": %v", path, err)
 	}
@@ -101,7 +101,7 @@ func writeChainData(path string, data []byte) error {
 
 // writeKeyData writes data to path ensuring permissions are appropriate for a cert
 func writeKeyData(path string, data []byte) error {
-	err := writeFile(path, 0700, 0600, data)
+	err := writeFile(path, 0400, 0400, data)
 	if err != nil {
 		return errs.New("unable to write key to \"%s\": %v", path, err)
 	}

--- a/scripts/test-certificate-signing.sh
+++ b/scripts/test-certificate-signing.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -o errexit
+set -ueo pipefail
 
 trap "echo ERROR: exiting due to error; exit" ERR
 trap "exit" INT TERM


### PR DESCRIPTION
To protect the identity against overwriting or deletion, set it to read only after successful signing from the CA