### PR TITLE
fix some email list parsing in certificates tool

### DIFF
--- a/cmd/certificates/auth.go
+++ b/cmd/certificates/auth.go
@@ -82,7 +82,6 @@ func parseEmailsList(fileName, delimiter string) (emails []string, err error) {
 	if err != nil {
 		return nil, errs.Wrap(err)
 	}
-	defer file.Close()
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -91,7 +90,7 @@ func parseEmailsList(fileName, delimiter string) (emails []string, err error) {
 		}
 		emails = append(emails, line)
 	}
-	return emails, nil
+	return emails, file.Close()
 }
 
 func cmdCreateAuth(cmd *cobra.Command, args []string) error {

--- a/cmd/certificates/auth.go
+++ b/cmd/certificates/auth.go
@@ -4,10 +4,10 @@
 package main
 
 import (
+	"bufio"
 	"encoding/csv"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -77,6 +77,23 @@ func init() {
 	cfgstruct.Bind(authExportCmd.Flags(), &authExportCfg, cfgstruct.ConfDir(defaultConfDir))
 }
 
+func parseEmailsList(fileName, delimiter string) (emails []string, err error) {
+	file, err := os.Open(fileName)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		emails = append(emails, line)
+	}
+	return emails, nil
+}
+
 func cmdCreateAuth(cmd *cobra.Command, args []string) error {
 	count, err := strconv.Atoi(args[0])
 	if err != nil {
@@ -94,11 +111,10 @@ func cmdCreateAuth(cmd *cobra.Command, args []string) error {
 		}
 		emails = args[1:]
 	} else {
-		list, err := ioutil.ReadFile(authCreateCfg.EmailsPath)
+		emails, err = parseEmailsList(authCreateCfg.EmailsPath, authCreateCfg.Delimiter)
 		if err != nil {
 			return errs.Wrap(err)
 		}
-		emails = strings.Split(string(list), authCreateCfg.Delimiter)
 	}
 
 	var incErrs utils.ErrorGroup
@@ -122,7 +138,7 @@ func cmdInfoAuth(cmd *cobra.Command, args []string) error {
 			return errs.New("Either use `--emails-path` or positional args, not both.")
 		}
 		emails = args
-	} else if len(args) == 0 || authExportCfg.All {
+	} else if len(args) == 0 || authInfoCfg.All {
 		emails, err = authDB.UserIDs()
 		if err != nil {
 			return err
@@ -130,11 +146,10 @@ func cmdInfoAuth(cmd *cobra.Command, args []string) error {
 	} else if _, err := os.Stat(authInfoCfg.EmailsPath); err != nil {
 		return errs.New("Emails path error: %s", err)
 	} else {
-		list, err := ioutil.ReadFile(authInfoCfg.EmailsPath)
+		emails, err = parseEmailsList(authInfoCfg.EmailsPath, authInfoCfg.Delimiter)
 		if err != nil {
 			return errs.Wrap(err)
 		}
-		emails = strings.Split(string(list), authInfoCfg.Delimiter)
 	}
 
 	var emailErrs, printErrs utils.ErrorGroup
@@ -225,11 +240,10 @@ func cmdExportAuth(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
-		list, err := ioutil.ReadFile(authExportCfg.EmailsPath)
+		emails, err = parseEmailsList(authExportCfg.EmailsPath, authExportCfg.Delimiter)
 		if err != nil {
 			return errs.Wrap(err)
 		}
-		emails = strings.Split(string(list), authExportCfg.Delimiter)
 	}
 
 	var (


### PR DESCRIPTION
this avoids getting an "userID cannot be empty" error when using an
emails list that has a newline at the end.