### PR TITLE
Separate identity from server config

### DIFF
--- a/bootstrap/peer.go
+++ b/bootstrap/peer.go
@@ -34,6 +34,8 @@ type DB interface {
 
 // Config is all the configuration parameters for a Bootstrap Node
 type Config struct {
+	Identity identity.Config
+
 	Server   server.Config
 	Kademlia kademlia.Config
 }

--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -79,7 +79,7 @@ func init() {
 func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	log := zap.L()
 
-	identity, err := runCfg.Server.Identity.Load()
+	identity, err := runCfg.Identity.Load()
 	if err != nil {
 		zap.S().Fatal(err)
 	}
@@ -90,7 +90,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	ctx := process.Ctx(cmd)
-	if err := process.InitMetricsWithCertPath(ctx, nil, runCfg.Server.Identity.CertPath); err != nil {
+	if err := process.InitMetricsWithCertPath(ctx, nil, runCfg.Identity.CertPath); err != nil {
 		zap.S().Errorf("Failed to initialize telemetry batcher: %+v", err)
 	}
 

--- a/cmd/certificates/main.go
+++ b/cmd/certificates/main.go
@@ -34,9 +34,12 @@ var (
 
 	config struct {
 		batchCfg
-		CA         identity.CASetupConfig
-		Identity   identity.SetupConfig
-		Server     server.Config
+		CA       identity.CASetupConfig
+		Identity identity.SetupConfig
+		Server   struct { // workaround server.Config change
+			Identity identity.Config
+			server.Config
+		}
 		Signer     certificates.CertServerConfig
 		All        bool   `help:"print the all authorizations for auth info/export subcommands" default:"false"`
 		Out        string `help:"output file path for auth export subcommand; if \"-\", will use STDOUT" default:"-"`
@@ -74,7 +77,12 @@ func init() {
 func cmdRun(cmd *cobra.Command, args []string) error {
 	ctx := process.Ctx(cmd)
 
-	return config.Server.Run(ctx, nil, config.Signer)
+	identity, err := config.Server.Identity.Load()
+	if err != nil {
+		zap.S().Fatal(err)
+	}
+
+	return config.Server.Run(ctx, identity, nil, config.Signer)
 }
 
 func main() {

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -111,13 +111,13 @@ func init() {
 func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	log := zap.L()
 
-	identity, err := runCfg.Server.Identity.Load()
+	identity, err := runCfg.Identity.Load()
 	if err != nil {
 		zap.S().Fatal(err)
 	}
 
 	ctx := process.Ctx(cmd)
-	if err := process.InitMetricsWithCertPath(ctx, nil, runCfg.Server.Identity.CertPath); err != nil {
+	if err := process.InitMetricsWithCertPath(ctx, nil, runCfg.Identity.CertPath); err != nil {
 		zap.S().Errorf("Failed to initialize telemetry batcher: %+v", err)
 	}
 

--- a/cmd/storagenode/main.go
+++ b/cmd/storagenode/main.go
@@ -132,7 +132,7 @@ func init() {
 func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	log := zap.L()
 
-	identity, err := runCfg.Server.Identity.Load()
+	identity, err := runCfg.Identity.Load()
 	if err != nil {
 		zap.S().Fatal(err)
 	}
@@ -143,7 +143,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	ctx := process.Ctx(cmd)
-	if err := process.InitMetricsWithCertPath(ctx, nil, runCfg.Server.Identity.CertPath); err != nil {
+	if err := process.InitMetricsWithCertPath(ctx, nil, runCfg.Identity.CertPath); err != nil {
 		zap.S().Error("Failed to initialize telemetry batcher: ", err)
 	}
 
@@ -332,7 +332,7 @@ func cmdDiag(cmd *cobra.Command, args []string) (err error) {
 func dashCmd(cmd *cobra.Command, args []string) (err error) {
 	ctx := context.Background()
 
-	ident, err := runCfg.Server.Identity.Load()
+	ident, err := runCfg.Identity.Load()
 	if err != nil {
 		zap.S().Fatal(err)
 	} else {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -22,19 +22,11 @@ type Config struct {
 	UsePeerCAWhitelist  bool   `help:"if true, uses peer ca whitelist checking" default:"false"`
 	Address             string `user:"true" help:"address to listen on" default:":7777"`
 	Extensions          peertls.TLSExtConfig
-
-	Identity identity.Config // TODO: separate identity
 }
 
 // Run will run the given responsibilities with the configured identity.
-func (sc Config) Run(ctx context.Context,
-	interceptor grpc.UnaryServerInterceptor, services ...Service) (err error) {
+func (sc Config) Run(ctx context.Context, identity *identity.FullIdentity, interceptor grpc.UnaryServerInterceptor, services ...Service) (err error) {
 	defer mon.Task()(&ctx)(&err)
-
-	ident, err := sc.Identity.Load()
-	if err != nil {
-		return err
-	}
 
 	lis, err := net.Listen("tcp", sc.Address)
 	if err != nil {
@@ -42,7 +34,7 @@ func (sc Config) Run(ctx context.Context,
 	}
 	defer func() { _ = lis.Close() }()
 
-	opts, err := NewOptions(ident, sc)
+	opts, err := NewOptions(identity, sc)
 	if err != nil {
 		return err
 	}

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -40,6 +40,8 @@ type DB interface {
 
 // Config is all the configuration parameters for a Storage Node
 type Config struct {
+	Identity identity.Config
+
 	Server   server.Config
 	Kademlia kademlia.Config
 	Storage  psserver.Config


### PR DESCRIPTION
This separates Identity flags from Server. If we have multiple servers per peer, then it doesn't make sense to have identity multiple times.

Note this changes flags:
```
 --server.identity.key-path
 --server.identity.cert-path
```

Into:
```
 --identity.key-path
 --identity.cert-path
```

With the exception of certificates server.