### PR TITLE
Improve bwagreement tests

### DIFF
--- a/pkg/accounting/tally/tally_test.go
+++ b/pkg/accounting/tally/tally_test.go
@@ -16,7 +16,7 @@ import (
 	"storj.io/storj/internal/teststorj"
 	"storj.io/storj/pkg/accounting/tally"
 	"storj.io/storj/pkg/bwagreement"
-	"storj.io/storj/pkg/bwagreement/test"
+	"storj.io/storj/pkg/bwagreement/bwagreementtest"
 	"storj.io/storj/pkg/identity"
 	"storj.io/storj/pkg/overlay/mocks"
 	"storj.io/storj/pkg/pb"
@@ -79,9 +79,9 @@ func TestQueryWithBw(t *testing.T) {
 
 func makeBWA(ctx context.Context, t *testing.T, bwDb bwagreement.DB, serialNum string, fiC *identity.FullIdentity, action pb.PayerBandwidthAllocation_Action) {
 	//generate an agreement with the key
-	pba, err := test.GeneratePayerBandwidthAllocation(action, fiC, fiC, time.Hour)
+	pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(action, fiC, fiC, time.Hour)
 	assert.NoError(t, err)
-	rba, err := test.GenerateRenterBandwidthAllocation(pba, teststorj.NodeIDFromString("StorageNodeID"), fiC, 666)
+	rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, teststorj.NodeIDFromString("StorageNodeID"), fiC, 666)
 	assert.NoError(t, err)
 	//save to db
 	err = bwDb.CreateAgreement(ctx, serialNum, bwagreement.Agreement{Signature: rba.GetSignature(), Agreement: rba.GetData()})

--- a/pkg/accounting/tally/tally_test.go
+++ b/pkg/accounting/tally/tally_test.go
@@ -16,7 +16,7 @@ import (
 	"storj.io/storj/internal/teststorj"
 	"storj.io/storj/pkg/accounting/tally"
 	"storj.io/storj/pkg/bwagreement"
-	"storj.io/storj/pkg/bwagreement/bwagreementtest"
+	"storj.io/storj/pkg/bwagreement/testbwagreement"
 	"storj.io/storj/pkg/identity"
 	"storj.io/storj/pkg/overlay/mocks"
 	"storj.io/storj/pkg/pb"
@@ -79,9 +79,9 @@ func TestQueryWithBw(t *testing.T) {
 
 func makeBWA(ctx context.Context, t *testing.T, bwDb bwagreement.DB, serialNum string, fiC *identity.FullIdentity, action pb.PayerBandwidthAllocation_Action) {
 	//generate an agreement with the key
-	pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(action, fiC, fiC, time.Hour)
+	pba, err := testbwagreement.GeneratePayerBandwidthAllocation(action, fiC, fiC, time.Hour)
 	assert.NoError(t, err)
-	rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, teststorj.NodeIDFromString("StorageNodeID"), fiC, 666)
+	rba, err := testbwagreement.GenerateRenterBandwidthAllocation(pba, teststorj.NodeIDFromString("StorageNodeID"), fiC, 666)
 	assert.NoError(t, err)
 	//save to db
 	err = bwDb.CreateAgreement(ctx, serialNum, bwagreement.Agreement{Signature: rba.GetSignature(), Agreement: rba.GetData()})

--- a/pkg/bwagreement/bwagreementtest/common.go
+++ b/pkg/bwagreement/bwagreementtest/common.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-package test
+package bwagreementtest
 
 import (
 	"crypto/ecdsa"

--- a/pkg/bwagreement/server_test.go
+++ b/pkg/bwagreement/server_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-package test
+package bwagreement_test
 
 import (
 	"context"
@@ -23,6 +23,7 @@ import (
 	"storj.io/storj/internal/testidentity"
 	"storj.io/storj/pkg/auth"
 	"storj.io/storj/pkg/bwagreement"
+	"storj.io/storj/pkg/bwagreement/bwagreementtest"
 	"storj.io/storj/pkg/identity"
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/storj"
@@ -65,15 +66,15 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 	satellite := bwagreement.NewServer(bwdb, zap.NewNop(), satID.ID)
 
 	{ // TestSameSerialNumberBandwidthAgreements
-		pbaFile1, err := GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
+		pbaFile1, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
 		assert.NoError(t, err)
 
 		ctxSN1, storageNode1 := getPeerContext(ctx, t)
-		rbaNode1, err := GenerateRenterBandwidthAllocation(pbaFile1, storageNode1, upID, 666)
+		rbaNode1, err := bwagreementtest.GenerateRenterBandwidthAllocation(pbaFile1, storageNode1, upID, 666)
 		assert.NoError(t, err)
 
 		ctxSN2, storageNode2 := getPeerContext(ctx, t)
-		rbaNode2, err := GenerateRenterBandwidthAllocation(pbaFile1, storageNode2, upID, 666)
+		rbaNode2, err := bwagreementtest.GenerateRenterBandwidthAllocation(pbaFile1, storageNode2, upID, 666)
 		assert.NoError(t, err)
 
 		/* More than one storage node can submit bwagreements with the same serial number.
@@ -93,10 +94,10 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 		/* Storage node can submit a second bwagreement with a different sequence value.
 		   Uplink downloads another file. New PayerBandwidthAllocation with a new sequence. */
 		{
-			pbaFile2, err := GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
+			pbaFile2, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
 			assert.NoError(t, err)
 
-			rbaNode1, err := GenerateRenterBandwidthAllocation(pbaFile2, storageNode1, upID, 666)
+			rbaNode1, err := bwagreementtest.GenerateRenterBandwidthAllocation(pbaFile2, storageNode1, upID, 666)
 			assert.NoError(t, err)
 
 			reply, err := satellite.BandwidthAgreements(ctxSN1, rbaNode1)
@@ -106,7 +107,7 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 
 		/* Storage nodes can't submit a second bwagreement with the same sequence. */
 		{
-			rbaNode1, err := GenerateRenterBandwidthAllocation(pbaFile1, storageNode1, upID, 666)
+			rbaNode1, err := bwagreementtest.GenerateRenterBandwidthAllocation(pbaFile1, storageNode1, upID, 666)
 			assert.NoError(t, err)
 
 			reply, err := satellite.BandwidthAgreements(ctxSN1, rbaNode1)
@@ -125,12 +126,12 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 	}
 
 	{ // TestExpiredBandwidthAgreements
-		{ // storage nodes can submit a bwagreement that will expire in one second
-			pba, err := GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Second)
+		{ // storage nodes can submit a bwagreement that will expire in 30 seconds
+			pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, 30*time.Second)
 			assert.NoError(t, err)
 
 			ctxSN1, storageNode1 := getPeerContext(ctx, t)
-			rba, err := GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
+			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
 			assert.NoError(t, err)
 
 			reply, err := satellite.BandwidthAgreements(ctxSN1, rba)
@@ -139,11 +140,11 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 		}
 
 		{ // storage nodes can't submit a bwagreement that expires right now
-			pba, err := GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, 0*time.Second)
+			pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, 0*time.Second)
 			assert.NoError(t, err)
 
 			ctxSN1, storageNode1 := getPeerContext(ctx, t)
-			rba, err := GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
+			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
 			assert.NoError(t, err)
 
 			reply, err := satellite.BandwidthAgreements(ctxSN1, rba)
@@ -152,11 +153,11 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 		}
 
 		{ // storage nodes can't submit a bwagreement that expires yesterday
-			pba, err := GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, -23*time.Hour-55*time.Second)
+			pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, -23*time.Hour-55*time.Second)
 			assert.NoError(t, err)
 
 			ctxSN1, storageNode1 := getPeerContext(ctx, t)
-			rba, err := GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
+			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
 			assert.NoError(t, err)
 
 			reply, err := satellite.BandwidthAgreements(ctxSN1, rba)
@@ -166,13 +167,13 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 	}
 
 	{ // TestManipulatedBandwidthAgreements
-		pba, err := GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
+		pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
 		if !assert.NoError(t, err) {
 			t.Fatal(err)
 		}
 
 		ctxSN1, storageNode1 := getPeerContext(ctx, t)
-		rba, err := GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
+		rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
 		assert.NoError(t, err)
 
 		// Unmarschal Renter and Payer bwagreements
@@ -354,11 +355,11 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 	{ //TestInvalidBandwidthAgreements
 		ctxSN1, storageNode1 := getPeerContext(ctx, t)
 		ctxSN2, storageNode2 := getPeerContext(ctx, t)
-		pba, err := GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
+		pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
 		assert.NoError(t, err)
 
 		{ // Storage node sends an corrupted signuature to force a satellite crash
-			rba, err := GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
+			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
 			assert.NoError(t, err)
 
 			rba.Signature = []byte("invalid")
@@ -369,7 +370,7 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 		}
 
 		{ // Storage node sends an corrupted uplink Certs to force a crash
-			rba, err := GenerateRenterBandwidthAllocation(pba, storageNode2, upID, 666)
+			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, storageNode2, upID, 666)
 			assert.NoError(t, err)
 
 			rbaData := &pb.RenterBandwidthAllocation_Data{}

--- a/pkg/bwagreement/server_test.go
+++ b/pkg/bwagreement/server_test.go
@@ -23,7 +23,7 @@ import (
 	"storj.io/storj/internal/testidentity"
 	"storj.io/storj/pkg/auth"
 	"storj.io/storj/pkg/bwagreement"
-	"storj.io/storj/pkg/bwagreement/bwagreementtest"
+	"storj.io/storj/pkg/bwagreement/testbwagreement"
 	"storj.io/storj/pkg/identity"
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/storj"
@@ -66,15 +66,15 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 	satellite := bwagreement.NewServer(bwdb, zap.NewNop(), satID.ID)
 
 	{ // TestSameSerialNumberBandwidthAgreements
-		pbaFile1, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
+		pbaFile1, err := testbwagreement.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
 		assert.NoError(t, err)
 
 		ctxSN1, storageNode1 := getPeerContext(ctx, t)
-		rbaNode1, err := bwagreementtest.GenerateRenterBandwidthAllocation(pbaFile1, storageNode1, upID, 666)
+		rbaNode1, err := testbwagreement.GenerateRenterBandwidthAllocation(pbaFile1, storageNode1, upID, 666)
 		assert.NoError(t, err)
 
 		ctxSN2, storageNode2 := getPeerContext(ctx, t)
-		rbaNode2, err := bwagreementtest.GenerateRenterBandwidthAllocation(pbaFile1, storageNode2, upID, 666)
+		rbaNode2, err := testbwagreement.GenerateRenterBandwidthAllocation(pbaFile1, storageNode2, upID, 666)
 		assert.NoError(t, err)
 
 		/* More than one storage node can submit bwagreements with the same serial number.
@@ -94,10 +94,10 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 		/* Storage node can submit a second bwagreement with a different sequence value.
 		   Uplink downloads another file. New PayerBandwidthAllocation with a new sequence. */
 		{
-			pbaFile2, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
+			pbaFile2, err := testbwagreement.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
 			assert.NoError(t, err)
 
-			rbaNode1, err := bwagreementtest.GenerateRenterBandwidthAllocation(pbaFile2, storageNode1, upID, 666)
+			rbaNode1, err := testbwagreement.GenerateRenterBandwidthAllocation(pbaFile2, storageNode1, upID, 666)
 			assert.NoError(t, err)
 
 			reply, err := satellite.BandwidthAgreements(ctxSN1, rbaNode1)
@@ -107,7 +107,7 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 
 		/* Storage nodes can't submit a second bwagreement with the same sequence. */
 		{
-			rbaNode1, err := bwagreementtest.GenerateRenterBandwidthAllocation(pbaFile1, storageNode1, upID, 666)
+			rbaNode1, err := testbwagreement.GenerateRenterBandwidthAllocation(pbaFile1, storageNode1, upID, 666)
 			assert.NoError(t, err)
 
 			reply, err := satellite.BandwidthAgreements(ctxSN1, rbaNode1)
@@ -127,11 +127,11 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 
 	{ // TestExpiredBandwidthAgreements
 		{ // storage nodes can submit a bwagreement that will expire in 30 seconds
-			pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, 30*time.Second)
+			pba, err := testbwagreement.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, 30*time.Second)
 			assert.NoError(t, err)
 
 			ctxSN1, storageNode1 := getPeerContext(ctx, t)
-			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
+			rba, err := testbwagreement.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
 			assert.NoError(t, err)
 
 			reply, err := satellite.BandwidthAgreements(ctxSN1, rba)
@@ -140,11 +140,11 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 		}
 
 		{ // storage nodes can't submit a bwagreement that expires right now
-			pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, 0*time.Second)
+			pba, err := testbwagreement.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, 0*time.Second)
 			assert.NoError(t, err)
 
 			ctxSN1, storageNode1 := getPeerContext(ctx, t)
-			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
+			rba, err := testbwagreement.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
 			assert.NoError(t, err)
 
 			reply, err := satellite.BandwidthAgreements(ctxSN1, rba)
@@ -153,11 +153,11 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 		}
 
 		{ // storage nodes can't submit a bwagreement that expires yesterday
-			pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, -23*time.Hour-55*time.Second)
+			pba, err := testbwagreement.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, -23*time.Hour-55*time.Second)
 			assert.NoError(t, err)
 
 			ctxSN1, storageNode1 := getPeerContext(ctx, t)
-			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
+			rba, err := testbwagreement.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
 			assert.NoError(t, err)
 
 			reply, err := satellite.BandwidthAgreements(ctxSN1, rba)
@@ -167,13 +167,13 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 	}
 
 	{ // TestManipulatedBandwidthAgreements
-		pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
+		pba, err := testbwagreement.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
 		if !assert.NoError(t, err) {
 			t.Fatal(err)
 		}
 
 		ctxSN1, storageNode1 := getPeerContext(ctx, t)
-		rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
+		rba, err := testbwagreement.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
 		assert.NoError(t, err)
 
 		// Unmarschal Renter and Payer bwagreements
@@ -355,11 +355,11 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 	{ //TestInvalidBandwidthAgreements
 		ctxSN1, storageNode1 := getPeerContext(ctx, t)
 		ctxSN2, storageNode2 := getPeerContext(ctx, t)
-		pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
+		pba, err := testbwagreement.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, satID, upID, time.Hour)
 		assert.NoError(t, err)
 
 		{ // Storage node sends an corrupted signuature to force a satellite crash
-			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
+			rba, err := testbwagreement.GenerateRenterBandwidthAllocation(pba, storageNode1, upID, 666)
 			assert.NoError(t, err)
 
 			rba.Signature = []byte("invalid")
@@ -370,7 +370,7 @@ func testDatabase(ctx context.Context, t *testing.T, bwdb bwagreement.DB) {
 		}
 
 		{ // Storage node sends an corrupted uplink Certs to force a crash
-			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, storageNode2, upID, 666)
+			rba, err := testbwagreement.GenerateRenterBandwidthAllocation(pba, storageNode2, upID, 666)
 			assert.NoError(t, err)
 
 			rbaData := &pb.RenterBandwidthAllocation_Data{}

--- a/pkg/bwagreement/testbwagreement/common.go
+++ b/pkg/bwagreement/testbwagreement/common.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-package bwagreementtest
+package testbwagreement
 
 import (
 	"crypto/ecdsa"

--- a/pkg/piecestore/psserver/server_test.go
+++ b/pkg/piecestore/psserver/server_test.go
@@ -26,7 +26,7 @@ import (
 
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testidentity"
-	"storj.io/storj/pkg/bwagreement/test"
+	"storj.io/storj/pkg/bwagreement/bwagreementtest"
 	"storj.io/storj/pkg/identity"
 	"storj.io/storj/pkg/pb"
 	pstore "storj.io/storj/pkg/piecestore"
@@ -233,7 +233,7 @@ func TestRetrieve(t *testing.T) {
 			err = stream.Send(&pb.PieceRetrieval{PieceData: &pb.PieceRetrieval_PieceData{Id: tt.id, PieceSize: tt.reqSize, Offset: tt.offset}})
 			assert.NoError(err)
 
-			pba, err := test.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, snID, upID, time.Hour)
+			pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, snID, upID, time.Hour)
 			assert.NoError(err)
 
 			totalAllocated := int64(0)
@@ -244,7 +244,7 @@ func TestRetrieve(t *testing.T) {
 				// Send bandwidth bandwidthAllocation
 				totalAllocated += tt.allocSize
 
-				rba, err := test.GenerateRenterBandwidthAllocation(pba, snID.ID, upID, totalAllocated)
+				rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, snID.ID, upID, totalAllocated)
 				assert.NoError(err)
 
 				err = stream.Send(
@@ -342,9 +342,9 @@ func TestStore(t *testing.T) {
 			err = stream.Send(&pb.PieceStore{PieceData: &pb.PieceStore_PieceData{Id: tt.id, ExpirationUnixSec: tt.ttl}})
 			assert.NoError(err)
 			// Send Bandwidth Allocation Data
-			pba, err := test.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_PUT, snID, upID, time.Hour)
+			pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_PUT, snID, upID, time.Hour)
 			assert.NoError(err)
-			rba, err := test.GenerateRenterBandwidthAllocation(pba, snID.ID, upID, tt.totalReceived)
+			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, snID.ID, upID, tt.totalReceived)
 			assert.NoError(err)
 			msg := &pb.PieceStore{
 				PieceData:           &pb.PieceStore_PieceData{Content: tt.content},
@@ -464,9 +464,9 @@ func TestPbaValidation(t *testing.T) {
 			assert.NoError(err)
 			// Send Bandwidth Allocation Data
 			content := []byte("content")
-			pba, err := test.GeneratePayerBandwidthAllocation(tt.action, satID1, upID, time.Hour)
+			pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(tt.action, satID1, upID, time.Hour)
 			assert.NoError(err)
-			rba, err := test.GenerateRenterBandwidthAllocation(pba, snID.ID, upID, int64(len(content)))
+			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, snID.ID, upID, int64(len(content)))
 			assert.NoError(err)
 			msg := &pb.PieceStore{
 				PieceData:           &pb.PieceStore_PieceData{Content: content},

--- a/pkg/piecestore/psserver/server_test.go
+++ b/pkg/piecestore/psserver/server_test.go
@@ -26,7 +26,7 @@ import (
 
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testidentity"
-	"storj.io/storj/pkg/bwagreement/bwagreementtest"
+	"storj.io/storj/pkg/bwagreement/testbwagreement"
 	"storj.io/storj/pkg/identity"
 	"storj.io/storj/pkg/pb"
 	pstore "storj.io/storj/pkg/piecestore"
@@ -233,7 +233,7 @@ func TestRetrieve(t *testing.T) {
 			err = stream.Send(&pb.PieceRetrieval{PieceData: &pb.PieceRetrieval_PieceData{Id: tt.id, PieceSize: tt.reqSize, Offset: tt.offset}})
 			assert.NoError(err)
 
-			pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, snID, upID, time.Hour)
+			pba, err := testbwagreement.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_GET, snID, upID, time.Hour)
 			assert.NoError(err)
 
 			totalAllocated := int64(0)
@@ -244,7 +244,7 @@ func TestRetrieve(t *testing.T) {
 				// Send bandwidth bandwidthAllocation
 				totalAllocated += tt.allocSize
 
-				rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, snID.ID, upID, totalAllocated)
+				rba, err := testbwagreement.GenerateRenterBandwidthAllocation(pba, snID.ID, upID, totalAllocated)
 				assert.NoError(err)
 
 				err = stream.Send(
@@ -342,9 +342,9 @@ func TestStore(t *testing.T) {
 			err = stream.Send(&pb.PieceStore{PieceData: &pb.PieceStore_PieceData{Id: tt.id, ExpirationUnixSec: tt.ttl}})
 			assert.NoError(err)
 			// Send Bandwidth Allocation Data
-			pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_PUT, snID, upID, time.Hour)
+			pba, err := testbwagreement.GeneratePayerBandwidthAllocation(pb.PayerBandwidthAllocation_PUT, snID, upID, time.Hour)
 			assert.NoError(err)
-			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, snID.ID, upID, tt.totalReceived)
+			rba, err := testbwagreement.GenerateRenterBandwidthAllocation(pba, snID.ID, upID, tt.totalReceived)
 			assert.NoError(err)
 			msg := &pb.PieceStore{
 				PieceData:           &pb.PieceStore_PieceData{Content: tt.content},
@@ -464,9 +464,9 @@ func TestPbaValidation(t *testing.T) {
 			assert.NoError(err)
 			// Send Bandwidth Allocation Data
 			content := []byte("content")
-			pba, err := bwagreementtest.GeneratePayerBandwidthAllocation(tt.action, satID1, upID, time.Hour)
+			pba, err := testbwagreement.GeneratePayerBandwidthAllocation(tt.action, satID1, upID, time.Hour)
 			assert.NoError(err)
-			rba, err := bwagreementtest.GenerateRenterBandwidthAllocation(pba, snID.ID, upID, int64(len(content)))
+			rba, err := testbwagreement.GenerateRenterBandwidthAllocation(pba, snID.ID, upID, int64(len(content)))
 			assert.NoError(err)
 			msg := &pb.PieceStore{
 				PieceData:           &pb.PieceStore_PieceData{Content: content},


### PR DESCRIPTION
Don't use 1 sec expiration as it's likely to expire during tests.