### PR TITLE
Decreases refresh time per bucket in Kademlia

### DIFF
--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -205,13 +205,13 @@ func TestRefresh(t *testing.T) {
 	err := rt.SetBucketTimestamp(bID[:], now.Add(-2*time.Hour))
 	assert.NoError(t, err)
 	//refresh should  call FindNode, updating the time
-	err = k.refresh(ctx)
+	err = k.refresh(ctx, time.Minute)
 	assert.NoError(t, err)
 	ts1, err := rt.GetBucketTimestamp(bID[:])
 	assert.NoError(t, err)
 	assert.True(t, now.Add(-5*time.Minute).Before(ts1))
 	//refresh should not call FindNode, leaving the previous time
-	err = k.refresh(ctx)
+	err = k.refresh(ctx, time.Minute)
 	assert.NoError(t, err)
 	ts2, err := rt.GetBucketTimestamp(bID[:])
 	assert.NoError(t, err)


### PR DESCRIPTION
Decreases the refresh interval and minimum time threshold to start a refresh in Kademlia. 

This is the first in a series of improvements to make Kademlia bootstrapping more efficient.