### PR TITLE
Rollup tests

### DIFF
--- a/pkg/accounting/db.go
+++ b/pkg/accounting/db.go
@@ -41,9 +41,9 @@ type DB interface {
 	// LastTimestamp records the latest last tallied time.
 	LastTimestamp(ctx context.Context, timestampType string) (time.Time, error)
 	// SaveBWRaw records raw sums of agreement values to the database and updates the LastTimestamp.
-	SaveBWRaw(ctx context.Context, tallyEnd time.Time, bwTotals map[storj.NodeID][]int64) error
+	SaveBWRaw(ctx context.Context, tallyEnd time.Time, created time.Time, bwTotals map[storj.NodeID][]int64) error
 	// SaveAtRestRaw records raw tallies of at-rest-data.
-	SaveAtRestRaw(ctx context.Context, latestTally time.Time, nodeData map[storj.NodeID]float64) error
+	SaveAtRestRaw(ctx context.Context, latestTally time.Time, created time.Time, nodeData map[storj.NodeID]float64) error
 	// GetRaw retrieves all raw tallies
 	GetRaw(ctx context.Context) ([]*Raw, error)
 	// GetRawSince r retrieves all raw tallies sinces

--- a/pkg/accounting/rollup/rollup.go
+++ b/pkg/accounting/rollup/rollup.go
@@ -68,7 +68,6 @@ func (r *Rollup) Query(ctx context.Context) error {
 		r.logger.Info("Rollup found no new tallies")
 		return nil
 	}
-	fmt.Println("tallies:", tallies)
 	//loop through tallies and build Rollup
 	rollupStats := make(accounting.RollupStats)
 	for _, tallyRow := range tallies {

--- a/pkg/accounting/rollup/rollup.go
+++ b/pkg/accounting/rollup/rollup.go
@@ -68,6 +68,7 @@ func (r *Rollup) Query(ctx context.Context) error {
 		r.logger.Info("Rollup found no new tallies")
 		return nil
 	}
+	fmt.Println("tallies:", tallies)
 	//loop through tallies and build Rollup
 	rollupStats := make(accounting.RollupStats)
 	for _, tallyRow := range tallies {

--- a/pkg/accounting/rollup/rollup_test.go
+++ b/pkg/accounting/rollup/rollup_test.go
@@ -105,7 +105,7 @@ func TestQuery(t *testing.T) {
 	}
 }
 
-// contains
+// contains checks for and removes items if found
 func contains(entry storj.NodeID, list []*storj.NodeID) bool {
 	for i, n := range list {
 		if n == nil {

--- a/pkg/accounting/rollup/rollup_test.go
+++ b/pkg/accounting/rollup/rollup_test.go
@@ -34,10 +34,10 @@ func TestQuery(t *testing.T) {
 			nodes:  10,
 		},
 		{
-			days:   3,
-			atRest: float64(5000),
-			bw:     []int64{1000, 2000, 3000, 4000},
-			nodes:  10,
+			days:   5,
+			atRest: float64(20000),
+			bw:     []int64{4000, 8000, 12000, 16000},
+			nodes:  20,
 		},
 	}
 

--- a/pkg/accounting/rollup/rollup_test.go
+++ b/pkg/accounting/rollup/rollup_test.go
@@ -15,87 +15,145 @@ import (
 )
 
 func TestQueryOneDay(t *testing.T) {
-	ctx := testcontext.New(t)
-	defer ctx.Cleanup()
+	tests := []struct {
+		expected int
+		rest     float64
+		bw       []int64
+	}{
+		{
+			expected: 0,
+			rest:     float64(5000),
+			bw:       []int64{1000, 2000, 3000, 4000},
+		},
+	}
 
-	planet, err := testplanet.New(t, 1, 4, 0)
-	assert.NoError(t, err)
-	defer ctx.Check(planet.Shutdown)
+	for _, tt := range tests {
+		ctx := testcontext.New(t)
+		defer ctx.Cleanup()
 
-	planet.Start(ctx)
-	time.Sleep(2 * time.Second)
+		planet, err := testplanet.New(t, 1, 4, 0)
+		assert.NoError(t, err)
+		defer ctx.Check(planet.Shutdown)
 
-	nodeData, bwTotals := createData(planet)
+		planet.Start(ctx)
+		time.Sleep(2 * time.Second)
 
-	now := time.Now().UTC()
-	before := now.Add(time.Hour * -48)
+		nodeData, bwTotals := createData(planet, tt.rest, tt.bw)
 
-	err = planet.Satellites[0].DB.Accounting().SaveAtRestRaw(ctx, before, before, nodeData)
-	assert.NoError(t, err)
+		now := time.Now().UTC()
+		before := now.Add(time.Hour * -24)
 
-	err = planet.Satellites[0].DB.Accounting().SaveBWRaw(ctx, before, before, bwTotals)
-	assert.NoError(t, err)
+		err = planet.Satellites[0].DB.Accounting().SaveAtRestRaw(ctx, before, before, nodeData)
+		assert.NoError(t, err)
 
-	err = planet.Satellites[0].Accounting.Rollup.Query(ctx)
-	assert.NoError(t, err)
+		err = planet.Satellites[0].DB.Accounting().SaveBWRaw(ctx, before, before, bwTotals)
+		assert.NoError(t, err)
 
-	// rollup.Query cuts off the hr/min/sec before saving, we need to do the same when querying
-	now = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	before = time.Date(before.Year(), before.Month(), before.Day(), 0, 0, 0, 0, before.Location())
+		err = planet.Satellites[0].Accounting.Rollup.Query(ctx)
+		assert.NoError(t, err)
 
-	rows, err := planet.Satellites[0].DB.Accounting().QueryPaymentInfo(ctx, before, now)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(rows))
+		// rollup.Query cuts off the hr/min/sec before saving, we need to do the same when querying
+		now = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		before = time.Date(before.Year(), before.Month(), before.Day(), 0, 0, 0, 0, before.Location())
+
+		rows, err := planet.Satellites[0].DB.Accounting().QueryPaymentInfo(ctx, before, now)
+		assert.NoError(t, err)
+		assert.Equal(t, tt.expected, len(rows))
+	}
 }
 
 func TestQueryTwoDays(t *testing.T) {
-	ctx := testcontext.New(t)
-	defer ctx.Cleanup()
+	tests := []struct {
+		expected int
+		rest     float64
+		bw       []int64
+	}{
+		{
+			expected: 4,
+			rest:     float64(5000),
+			bw:       []int64{1000, 2000, 3000, 4000},
+		},
+	}
 
-	planet, err := testplanet.New(t, 1, 4, 0)
-	assert.NoError(t, err)
-	defer ctx.Check(planet.Shutdown)
+	for _, tt := range tests {
+		ctx := testcontext.New(t)
+		defer ctx.Cleanup()
 
-	planet.Start(ctx)
-	time.Sleep(2 * time.Second)
+		planet, err := testplanet.New(t, 1, 4, 0)
+		assert.NoError(t, err)
+		defer ctx.Check(planet.Shutdown)
 
-	nodeData, bwTotals := createData(planet)
+		planet.Start(ctx)
+		time.Sleep(2 * time.Second)
 
-	now := time.Now().UTC()
-	before := now.Add(time.Hour * -48)
+		nodeData, bwTotals := createData(planet, tt.rest, tt.bw)
 
-	err = planet.Satellites[0].DB.Accounting().SaveAtRestRaw(ctx, before, before, nodeData)
-	assert.NoError(t, err)
+		now := time.Now().UTC()
+		before := now.Add(time.Hour * -24)
 
-	err = planet.Satellites[0].DB.Accounting().SaveBWRaw(ctx, before, before, bwTotals)
-	assert.NoError(t, err)
+		// Save data for day 1
+		err = planet.Satellites[0].DB.Accounting().SaveAtRestRaw(ctx, before, before, nodeData)
+		assert.NoError(t, err)
 
-	err = planet.Satellites[0].DB.Accounting().SaveAtRestRaw(ctx, now, now, nodeData)
-	assert.NoError(t, err)
+		err = planet.Satellites[0].DB.Accounting().SaveBWRaw(ctx, before, before, bwTotals)
+		assert.NoError(t, err)
 
-	err = planet.Satellites[0].DB.Accounting().SaveBWRaw(ctx, now, now, bwTotals)
-	assert.NoError(t, err)
+		// Save data for day 2
+		err = planet.Satellites[0].DB.Accounting().SaveAtRestRaw(ctx, now, now, nodeData)
+		assert.NoError(t, err)
 
-	err = planet.Satellites[0].Accounting.Rollup.Query(ctx)
-	assert.NoError(t, err)
+		err = planet.Satellites[0].DB.Accounting().SaveBWRaw(ctx, now, now, bwTotals)
+		assert.NoError(t, err)
 
-	// rollup.Query cuts off the hr/min/sec before saving, we need to do the same when querying
-	now = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	before = time.Date(before.Year(), before.Month(), before.Day(), 0, 0, 0, 0, before.Location())
+		err = planet.Satellites[0].Accounting.Rollup.Query(ctx)
+		assert.NoError(t, err)
 
-	rows, err := planet.Satellites[0].DB.Accounting().QueryPaymentInfo(ctx, before, now)
-	assert.Equal(t, 4, len(rows))
-	assert.NoError(t, err)
+		// rollup.Query cuts off the hr/min/sec before saving, we need to do the same when querying
+		now = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+		before = time.Date(before.Year(), before.Month(), before.Day(), 0, 0, 0, 0, before.Location())
+
+		rows, err := planet.Satellites[0].DB.Accounting().QueryPaymentInfo(ctx, before, now)
+		assert.Equal(t, 4, len(rows))
+		assert.NoError(t, err)
+
+		// verify data is correct
+		var nodeIDs []*storj.NodeID
+		for _, n := range planet.StorageNodes {
+			ptr := n.Identity.ID
+			nodeIDs = append(nodeIDs, &ptr)
+		}
+		for _, r := range rows {
+			assert.Equal(t, tt.bw[0], r.PutTotal)
+			assert.Equal(t, tt.bw[1], r.GetTotal)
+			assert.Equal(t, tt.bw[2], r.GetAuditTotal)
+			assert.Equal(t, tt.bw[3], r.GetRepairTotal)
+			assert.Equal(t, tt.rest, r.AtRestTotal)
+			assert.True(t, contains(r.NodeID, nodeIDs))
+		}
+	}
 }
 
-func createData(planet *testplanet.Planet) (nodeData map[storj.NodeID]float64, bwTotals map[storj.NodeID][]int64) {
+// contains
+func contains(entry storj.NodeID, list []*storj.NodeID) bool {
+	for i, n := range list {
+		if n == nil {
+			continue
+		}
+		if entry == *n {
+			list[i] = nil
+			return true
+		}
+	}
+	return false
+}
+
+func createData(planet *testplanet.Planet, atRest float64, bw []int64) (nodeData map[storj.NodeID]float64, bwTotals map[storj.NodeID][]int64) {
 	nodeData = make(map[storj.NodeID]float64)
 	bwTotals = make(map[storj.NodeID][]int64)
-	totals := []int64{1000, 2000, 3000, 4000, 5000}
 	for _, n := range planet.StorageNodes {
 		id := n.Identity.ID
-		nodeData[id] = float64(6000)
-		bwTotals[id] = totals
+		nodeData[id] = atRest
+		bwTotals[id] = bw
 	}
 	return nodeData, bwTotals
 }

--- a/pkg/accounting/rollup/rollup_test.go
+++ b/pkg/accounting/rollup/rollup_test.go
@@ -14,12 +14,6 @@ import (
 	"storj.io/storj/pkg/storj"
 )
 
-type testFlags struct {
-	days   int
-	atRest float64
-	bw     []int64
-}
-
 func TestQuery(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 10, UplinkCount: 0,
@@ -76,39 +70,6 @@ func TestQuery(t *testing.T) {
 	})
 }
 
-func TestTwoDays(t *testing.T) {
-	testplanet.Run(t, testplanet.Config{
-		SatelliteCount: 1, StorageNodeCount: 10, UplinkCount: 0,
-	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-
-		flags := &testFlags{
-			days:   2,
-			atRest: float64(5000),
-			bw:     []int64{1000, 2000, 3000, 4000},
-		}
-
-		time.Sleep(time.Second * 2)
-
-		saveAndQuery(t, ctx, flags, planet)
-	})
-}
-
-func TestThreeDays(t *testing.T) {
-	testplanet.Run(t, testplanet.Config{
-		SatelliteCount: 1, StorageNodeCount: 10, UplinkCount: 0,
-	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		flags := &testFlags{
-			days:   3,
-			atRest: float64(5000),
-			bw:     []int64{1000, 2000, 3000, 4000},
-		}
-
-		time.Sleep(time.Second * 2)
-
-		saveAndQuery(t, ctx, flags, planet)
-	})
-}
-
 func createData(planet *testplanet.Planet, atRest float64, bw []int64) (nodeData map[storj.NodeID]float64, bwTotals map[storj.NodeID][]int64) {
 	nodeData = make(map[storj.NodeID]float64)
 	bwTotals = make(map[storj.NodeID][]int64)
@@ -118,52 +79,4 @@ func createData(planet *testplanet.Planet, atRest float64, bw []int64) (nodeData
 		bwTotals[id] = bw
 	}
 	return nodeData, bwTotals
-}
-
-func saveAndQuery(t *testing.T, ctx *testcontext.Context, flags *testFlags, planet *testplanet.Planet) {
-	nodeData, bwTotals := createData(planet, flags.atRest, flags.bw)
-
-	// Set timestamp back by the number of days we want to save
-	timestamp := time.Now().UTC().AddDate(0, 0, -1*flags.days)
-	start := timestamp
-
-	// Save data for n days
-	for i := 0; i < flags.days; i++ {
-		err := planet.Satellites[0].DB.Accounting().SaveAtRestRaw(ctx, timestamp, timestamp, nodeData)
-		assert.NoError(t, err)
-
-		err = planet.Satellites[0].DB.Accounting().SaveBWRaw(ctx, timestamp, timestamp, bwTotals)
-		assert.NoError(t, err)
-
-		// Advance time by 24 hours
-		timestamp = timestamp.Add(time.Hour * 24)
-	}
-
-	end := timestamp
-
-	err := planet.Satellites[0].Accounting.Rollup.Query(ctx)
-	assert.NoError(t, err)
-
-	// rollup.Query cuts off the hr/min/sec before saving, we need to do the same when querying
-	start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
-	end = time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, end.Location())
-
-	rows, err := planet.Satellites[0].DB.Accounting().QueryPaymentInfo(ctx, start, end)
-	assert.NoError(t, err)
-	if flags.days <= 1 {
-		assert.Equal(t, 0, len(rows))
-		return
-	}
-	// TODO: once we sum data totals by node ID across rollups, number of rows should be number of nodes
-	assert.Equal(t, (flags.days-1)*len(planet.StorageNodes), len(rows))
-
-	// verify data is correct
-	for _, r := range rows {
-		assert.Equal(t, flags.bw[0], r.PutTotal)
-		assert.Equal(t, flags.bw[1], r.GetTotal)
-		assert.Equal(t, flags.bw[2], r.GetAuditTotal)
-		assert.Equal(t, flags.bw[3], r.GetRepairTotal)
-		assert.Equal(t, flags.atRest, r.AtRestTotal)
-		assert.NotNil(t, nodeData[r.NodeID])
-	}
 }

--- a/pkg/accounting/rollup/rollup_test.go
+++ b/pkg/accounting/rollup/rollup_test.go
@@ -20,19 +20,59 @@ type testFlags struct {
 	bw     []int64
 }
 
-func TestOneDay(t *testing.T) {
+func TestQuery(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 10, UplinkCount: 0,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		flags := &testFlags{
-			days:   1,
-			atRest: float64(5000),
-			bw:     []int64{1000, 2000, 3000, 4000},
-		}
+		days := 5
+		atRest := float64(5000)
+		bw := []int64{1000, 2000, 3000, 4000}
 
 		time.Sleep(time.Second * 2)
 
-		saveAndQuery(t, ctx, flags, planet)
+		nodeData, bwTotals := createData(planet, atRest, bw)
+
+		// Set timestamp back by the number of days we want to save
+		timestamp := time.Now().UTC().AddDate(0, 0, -1*days)
+		start := timestamp
+
+		for i := 1; i <= days; i++ {
+			err := planet.Satellites[0].DB.Accounting().SaveAtRestRaw(ctx, timestamp, timestamp, nodeData)
+			assert.NoError(t, err)
+
+			err = planet.Satellites[0].DB.Accounting().SaveBWRaw(ctx, timestamp, timestamp, bwTotals)
+			assert.NoError(t, err)
+
+			err = planet.Satellites[0].Accounting.Rollup.Query(ctx)
+			assert.NoError(t, err)
+
+			// Advance time by 24 hours
+			timestamp = timestamp.Add(time.Hour * 24)
+			end := timestamp
+
+			// rollup.Query cuts off the hr/min/sec before saving, we need to do the same when querying
+			start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
+			end = time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, end.Location())
+
+			rows, err := planet.Satellites[0].DB.Accounting().QueryPaymentInfo(ctx, start, end)
+			assert.NoError(t, err)
+			if i == 1 {
+				assert.Equal(t, 0, len(rows))
+				return
+			}
+			// TODO: once we sum data totals by node ID across rollups, number of rows should be number of nodes
+			assert.Equal(t, (i-1)*len(planet.StorageNodes), len(rows))
+
+			// verify data is correct
+			for _, r := range rows {
+				assert.Equal(t, bw[0], r.PutTotal)
+				assert.Equal(t, bw[1], r.GetTotal)
+				assert.Equal(t, bw[2], r.GetAuditTotal)
+				assert.Equal(t, bw[3], r.GetRepairTotal)
+				assert.Equal(t, atRest, r.AtRestTotal)
+				assert.NotNil(t, nodeData[r.NodeID])
+			}
+		}
 	})
 }
 

--- a/pkg/accounting/rollup/rollup_test.go
+++ b/pkg/accounting/rollup/rollup_test.go
@@ -31,13 +31,13 @@ func TestQuery(t *testing.T) {
 			days:   2,
 			atRest: float64(10000),
 			bw:     []int64{2000, 4000, 6000, 8000},
-			nodes:  10,
+			nodes:  6,
 		},
 		{
 			days:   5,
 			atRest: float64(20000),
 			bw:     []int64{4000, 8000, 12000, 16000},
-			nodes:  20,
+			nodes:  8,
 		},
 	}
 

--- a/pkg/accounting/rollup/rollup_test.go
+++ b/pkg/accounting/rollup/rollup_test.go
@@ -29,6 +29,9 @@ func TestOneDay(t *testing.T) {
 			atRest: float64(5000),
 			bw:     []int64{1000, 2000, 3000, 4000},
 		}
+
+		time.Sleep(time.Second * 2)
+
 		testQuery(t, ctx, test, planet)
 	})
 }
@@ -37,11 +40,15 @@ func TestTwoDays(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 10, UplinkCount: 0,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+
 		test := &test{
 			days:   2,
 			atRest: float64(5000),
 			bw:     []int64{1000, 2000, 3000, 4000},
 		}
+
+		time.Sleep(time.Second * 2)
+
 		testQuery(t, ctx, test, planet)
 	})
 }
@@ -55,6 +62,9 @@ func TestThreeDays(t *testing.T) {
 			atRest: float64(5000),
 			bw:     []int64{1000, 2000, 3000, 4000},
 		}
+
+		time.Sleep(time.Second * 2)
+
 		testQuery(t, ctx, test, planet)
 	})
 }

--- a/pkg/accounting/tally/tally.go
+++ b/pkg/accounting/tally/tally.go
@@ -72,7 +72,7 @@ func (t *Tally) Tally(ctx context.Context) error {
 	if err != nil {
 		errAtRest = errs.New("Query for data-at-rest failed : %v", err)
 	} else if len(nodeData) > 0 {
-		err = t.SaveAtRestRaw(ctx, latestTally, nodeData)
+		err = t.SaveAtRestRaw(ctx, latestTally, time.Now().UTC(), nodeData)
 		if err != nil {
 			errAtRest = errs.New("Saving data-at-rest failed : %v", err)
 		}
@@ -82,7 +82,7 @@ func (t *Tally) Tally(ctx context.Context) error {
 	if err != nil {
 		errBWA = errs.New("Query for bandwidth failed: %v", err)
 	} else if len(bwTotals) > 0 {
-		err = t.SaveBWRaw(ctx, tallyEnd, bwTotals)
+		err = t.SaveBWRaw(ctx, tallyEnd, time.Now().UTC(), bwTotals)
 		if err != nil {
 			errBWA = errs.New("Saving for bandwidth failed : %v", err)
 		}
@@ -158,8 +158,8 @@ func (t *Tally) calculateAtRestData(ctx context.Context) (latestTally time.Time,
 }
 
 // SaveAtRestRaw records raw tallies of at-rest-data and updates the LastTimestamp
-func (t *Tally) SaveAtRestRaw(ctx context.Context, latestTally time.Time, nodeData map[storj.NodeID]float64) error {
-	return t.accountingDB.SaveAtRestRaw(ctx, latestTally, nodeData)
+func (t *Tally) SaveAtRestRaw(ctx context.Context, latestTally time.Time, created time.Time, nodeData map[storj.NodeID]float64) error {
+	return t.accountingDB.SaveAtRestRaw(ctx, latestTally, created, nodeData)
 }
 
 // QueryBW queries bandwidth allocation database, selecting all new contracts since the last collection run time.
@@ -183,6 +183,6 @@ func (t *Tally) QueryBW(ctx context.Context) (time.Time, map[storj.NodeID][]int6
 }
 
 // SaveBWRaw records granular tallies (sums of bw agreement values) to the database and updates the LastTimestamp
-func (t *Tally) SaveBWRaw(ctx context.Context, tallyEnd time.Time, bwTotals map[storj.NodeID][]int64) error {
-	return t.accountingDB.SaveBWRaw(ctx, tallyEnd, bwTotals)
+func (t *Tally) SaveBWRaw(ctx context.Context, tallyEnd time.Time, created time.Time, bwTotals map[storj.NodeID][]int64) error {
+	return t.accountingDB.SaveBWRaw(ctx, tallyEnd, created, bwTotals)
 }

--- a/pkg/accounting/tally/tally_test.go
+++ b/pkg/accounting/tally/tally_test.go
@@ -45,7 +45,7 @@ func TestQueryWithBw(t *testing.T) {
 				require.Equal(t, int64(1000), total)
 			}
 		}
-		err = tally.SaveBWRaw(ctx, tallyEnd, bwTotals)
+		err = tally.SaveBWRaw(ctx, tallyEnd, time.Now().UTC(), bwTotals)
 		require.NoError(t, err)
 	})
 }

--- a/satellite/satellitedb/accounting.go
+++ b/satellite/satellitedb/accounting.go
@@ -5,7 +5,6 @@ package satellitedb
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/zeebo/errs"
@@ -71,11 +70,10 @@ func (db *accountingDB) SaveBWRaw(ctx context.Context, tallyEnd time.Time, creat
 			total := dbx.AccountingRaw_DataTotal(float64(total))
 			dataType := dbx.AccountingRaw_DataType(actionType)
 			timestamp := dbx.AccountingRaw_CreatedAt(created)
-			b, err := tx.Create_AccountingRaw(ctx, nID, end, total, dataType, timestamp)
+			_, err = tx.Create_AccountingRaw(ctx, nID, end, total, dataType, timestamp)
 			if err != nil {
 				return Error.Wrap(err)
 			}
-			fmt.Println("SaveBWRaw:", b)
 		}
 	}
 	//save this batch's greatest time
@@ -100,18 +98,16 @@ func (db *accountingDB) SaveAtRestRaw(ctx context.Context, latestTally time.Time
 			err = utils.CombineErrors(err, tx.Rollback())
 		}
 	}()
-	fmt.Println("created:", created)
 	for k, v := range nodeData {
 		nID := dbx.AccountingRaw_NodeId(k.Bytes())
 		end := dbx.AccountingRaw_IntervalEndTime(latestTally)
 		total := dbx.AccountingRaw_DataTotal(v)
 		dataType := dbx.AccountingRaw_DataType(accounting.AtRest)
 		timestamp := dbx.AccountingRaw_CreatedAt(created)
-		raw, err := tx.Create_AccountingRaw(ctx, nID, end, total, dataType, timestamp)
+		_, err = tx.Create_AccountingRaw(ctx, nID, end, total, dataType, timestamp)
 		if err != nil {
 			return Error.Wrap(err)
 		}
-		fmt.Println("SaveAtRestRaw:", raw)
 	}
 	update := dbx.AccountingTimestamps_Update_Fields{Value: dbx.AccountingTimestamps_Value(latestTally)}
 	_, err = tx.Update_AccountingTimestamps_By_Name(ctx, dbx.AccountingTimestamps_Name(accounting.LastAtRestTally), update)
@@ -186,11 +182,10 @@ func (db *accountingDB) SaveRollup(ctx context.Context, latestRollup time.Time, 
 			getRepair := dbx.AccountingRollup_GetRepairTotal(ar.GetRepairTotal)
 			putRepair := dbx.AccountingRollup_PutRepairTotal(ar.PutRepairTotal)
 			atRest := dbx.AccountingRollup_AtRestTotal(ar.AtRestTotal)
-			r, err := tx.Create_AccountingRollup(ctx, nID, start, put, get, audit, getRepair, putRepair, atRest)
+			_, err = tx.Create_AccountingRollup(ctx, nID, start, put, get, audit, getRepair, putRepair, atRest)
 			if err != nil {
 				return Error.Wrap(err)
 			}
-			fmt.Println("SaveRollup", r)
 		}
 	}
 	update := dbx.AccountingTimestamps_Update_Fields{Value: dbx.AccountingTimestamps_Value(latestRollup)}

--- a/satellite/satellitedb/dbx/satellitedb.dbx
+++ b/satellite/satellitedb/dbx/satellitedb.dbx
@@ -96,7 +96,7 @@ model accounting_raw (
 	field interval_end_time timestamp
 	field data_total        float64
 	field data_type         int
-	field created_at        timestamp ( autoinsert )
+	field created_at        timestamp
 )
 
 create accounting_raw ( )

--- a/satellite/satellitedb/dbx/satellitedb.dbx.go
+++ b/satellite/satellitedb/dbx/satellitedb.dbx.go
@@ -2537,15 +2537,14 @@ func (obj *postgresImpl) Create_AccountingRaw(ctx context.Context,
 	accounting_raw_node_id AccountingRaw_NodeId_Field,
 	accounting_raw_interval_end_time AccountingRaw_IntervalEndTime_Field,
 	accounting_raw_data_total AccountingRaw_DataTotal_Field,
-	accounting_raw_data_type AccountingRaw_DataType_Field) (
+	accounting_raw_data_type AccountingRaw_DataType_Field,
+	accounting_raw_created_at AccountingRaw_CreatedAt_Field) (
 	accounting_raw *AccountingRaw, err error) {
-
-	__now := obj.db.Hooks.Now().UTC()
 	__node_id_val := accounting_raw_node_id.value()
 	__interval_end_time_val := accounting_raw_interval_end_time.value()
 	__data_total_val := accounting_raw_data_total.value()
 	__data_type_val := accounting_raw_data_type.value()
-	__created_at_val := __now
+	__created_at_val := accounting_raw_created_at.value()
 
 	var __embed_stmt = __sqlbundle_Literal("INSERT INTO accounting_raws ( node_id, interval_end_time, data_total, data_type, created_at ) VALUES ( ?, ?, ?, ?, ? ) RETURNING accounting_raws.id, accounting_raws.node_id, accounting_raws.interval_end_time, accounting_raws.data_total, accounting_raws.data_type, accounting_raws.created_at")
 
@@ -4492,15 +4491,14 @@ func (obj *sqlite3Impl) Create_AccountingRaw(ctx context.Context,
 	accounting_raw_node_id AccountingRaw_NodeId_Field,
 	accounting_raw_interval_end_time AccountingRaw_IntervalEndTime_Field,
 	accounting_raw_data_total AccountingRaw_DataTotal_Field,
-	accounting_raw_data_type AccountingRaw_DataType_Field) (
+	accounting_raw_data_type AccountingRaw_DataType_Field,
+	accounting_raw_created_at AccountingRaw_CreatedAt_Field) (
 	accounting_raw *AccountingRaw, err error) {
-
-	__now := obj.db.Hooks.Now().UTC()
 	__node_id_val := accounting_raw_node_id.value()
 	__interval_end_time_val := accounting_raw_interval_end_time.value()
 	__data_total_val := accounting_raw_data_total.value()
 	__data_type_val := accounting_raw_data_type.value()
-	__created_at_val := __now
+	__created_at_val := accounting_raw_created_at.value()
 
 	var __embed_stmt = __sqlbundle_Literal("INSERT INTO accounting_raws ( node_id, interval_end_time, data_total, data_type, created_at ) VALUES ( ?, ?, ?, ?, ? )")
 
@@ -6786,13 +6784,14 @@ func (rx *Rx) Create_AccountingRaw(ctx context.Context,
 	accounting_raw_node_id AccountingRaw_NodeId_Field,
 	accounting_raw_interval_end_time AccountingRaw_IntervalEndTime_Field,
 	accounting_raw_data_total AccountingRaw_DataTotal_Field,
-	accounting_raw_data_type AccountingRaw_DataType_Field) (
+	accounting_raw_data_type AccountingRaw_DataType_Field,
+	accounting_raw_created_at AccountingRaw_CreatedAt_Field) (
 	accounting_raw *AccountingRaw, err error) {
 	var tx *Tx
 	if tx, err = rx.getTx(ctx); err != nil {
 		return
 	}
-	return tx.Create_AccountingRaw(ctx, accounting_raw_node_id, accounting_raw_interval_end_time, accounting_raw_data_total, accounting_raw_data_type)
+	return tx.Create_AccountingRaw(ctx, accounting_raw_node_id, accounting_raw_interval_end_time, accounting_raw_data_total, accounting_raw_data_type, accounting_raw_created_at)
 
 }
 
@@ -7359,7 +7358,8 @@ type Methods interface {
 		accounting_raw_node_id AccountingRaw_NodeId_Field,
 		accounting_raw_interval_end_time AccountingRaw_IntervalEndTime_Field,
 		accounting_raw_data_total AccountingRaw_DataTotal_Field,
-		accounting_raw_data_type AccountingRaw_DataType_Field) (
+		accounting_raw_data_type AccountingRaw_DataType_Field,
+		accounting_raw_created_at AccountingRaw_CreatedAt_Field) (
 		accounting_raw *AccountingRaw, err error)
 
 	Create_AccountingRollup(ctx context.Context,

--- a/satellite/satellitedb/locked.go
+++ b/satellite/satellitedb/locked.go
@@ -77,17 +77,17 @@ func (m *lockedAccounting) QueryPaymentInfo(ctx context.Context, start time.Time
 }
 
 // SaveAtRestRaw records raw tallies of at-rest-data.
-func (m *lockedAccounting) SaveAtRestRaw(ctx context.Context, latestTally time.Time, nodeData map[storj.NodeID]float64) error {
+func (m *lockedAccounting) SaveAtRestRaw(ctx context.Context, latestTally time.Time, created time.Time, nodeData map[storj.NodeID]float64) error {
 	m.Lock()
 	defer m.Unlock()
-	return m.db.SaveAtRestRaw(ctx, latestTally, nodeData)
+	return m.db.SaveAtRestRaw(ctx, latestTally, created, nodeData)
 }
 
 // SaveBWRaw records raw sums of agreement values to the database and updates the LastTimestamp.
-func (m *lockedAccounting) SaveBWRaw(ctx context.Context, tallyEnd time.Time, bwTotals map[storj.NodeID][]int64) error {
+func (m *lockedAccounting) SaveBWRaw(ctx context.Context, tallyEnd time.Time, created time.Time, bwTotals map[storj.NodeID][]int64) error {
 	m.Lock()
 	defer m.Unlock()
-	return m.db.SaveBWRaw(ctx, tallyEnd, bwTotals)
+	return m.db.SaveBWRaw(ctx, tallyEnd, created, bwTotals)
 }
 
 // SaveRollup records raw tallies of at rest data to the database


### PR DESCRIPTION
For generating payment reports, we query the accounting rollup table. We want to make sure that this service functions as expected. Once we refactor QueryPaymentInfo to sum data totals across rollups, we'll need to change what we expect the length of rows to be on line 89