### PR TITLE
SHA256Hash() and TBSBytes() needn't return error

### DIFF
--- a/cmd/identity/main.go
+++ b/cmd/identity/main.go
@@ -195,10 +195,7 @@ func cmdAuthorize(cmd *cobra.Command, args []string) error {
 }
 
 func printExtensions(cert []byte, exts []pkix.Extension) error {
-	hash, err := pkcrypto.SHA256Hash(cert)
-	if err != nil {
-		return err
-	}
+	hash := pkcrypto.SHA256Hash(cert)
 	b64Hash, err := json.Marshal(hash)
 	if err != nil {
 		return err

--- a/pkg/peertls/extensions.go
+++ b/pkg/peertls/extensions.go
@@ -131,10 +131,7 @@ func ParseExtensions(c TLSExtConfig, opts ParseExtOptions) (handlers ExtensionHa
 func NewRevocationExt(key crypto.PrivateKey, revokedCert *x509.Certificate) (pkix.Extension, error) {
 	nowUnix := time.Now().Unix()
 
-	hash, err := pkcrypto.SHA256Hash(revokedCert.Raw)
-	if err != nil {
-		return pkix.Extension{}, err
-	}
+	hash := pkcrypto.SHA256Hash(revokedCert.Raw)
 	rev := Revocation{
 		Timestamp: nowUnix,
 		CertHash:  make([]byte, len(hash)),
@@ -240,11 +237,7 @@ func (r Revocation) Verify(signingCert *x509.Certificate) error {
 		return pkcrypto.ErrUnsupportedKey.New("%T", signingCert.PublicKey)
 	}
 
-	data, err := r.TBSBytes()
-	if err != nil {
-		return err
-	}
-
+	data := r.TBSBytes()
 	if err := pkcrypto.VerifySignature(r.Signature, data, pubKey); err != nil {
 		return err
 	}
@@ -253,11 +246,12 @@ func (r Revocation) Verify(signingCert *x509.Certificate) error {
 
 // TBSBytes (ToBeSigned) returns the hash of the revoked certificate hash and
 // the timestamp (i.e. hash(hash(cert bytes) + timestamp)).
-func (r *Revocation) TBSBytes() ([]byte, error) {
-	toHash := new(bytes.Buffer)
+func (r *Revocation) TBSBytes() []byte {
+	var toHash bytes.Buffer
 	_, err := toHash.Write(r.CertHash)
 	if err != nil {
-		return nil, ErrExtension.Wrap(err)
+		// bytes.Buffer#Write() is documented as never returning an error
+		panic(err)
 	}
 
 	// NB: append timestamp to revoked cert bytes
@@ -268,15 +262,12 @@ func (r *Revocation) TBSBytes() ([]byte, error) {
 
 // Sign generates a signature using the passed key and attaches it to the revocation.
 func (r *Revocation) Sign(key crypto.PrivateKey) error {
-	data, err := r.TBSBytes()
+	data := r.TBSBytes()
+	sig, err := pkcrypto.SignHashOf(key, data)
 	if err != nil {
 		return err
 	}
-
-	r.Signature, err = pkcrypto.SignHashOf(key, data)
-	if err != nil {
-		return err
-	}
+	r.Signature = sig
 	return nil
 }
 

--- a/pkg/peertls/peertls_test.go
+++ b/pkg/peertls/peertls_test.go
@@ -253,8 +253,7 @@ func TestRevocation_Sign(t *testing.T) {
 	assert.NoError(t, err)
 	leafCert, caKey := chain[0], keys[0]
 
-	leafHash, err := pkcrypto.SHA256Hash(leafCert.Raw)
-	assert.NoError(t, err)
+	leafHash := pkcrypto.SHA256Hash(leafCert.Raw)
 
 	rev := peertls.Revocation{
 		Timestamp: time.Now().Unix(),
@@ -271,8 +270,7 @@ func TestRevocation_Verify(t *testing.T) {
 	assert.NoError(t, err)
 	leafCert, caCert, caKey := chain[0], chain[1], keys[0]
 
-	leafHash, err := pkcrypto.SHA256Hash(leafCert.Raw)
-	assert.NoError(t, err)
+	leafHash := pkcrypto.SHA256Hash(leafCert.Raw)
 
 	rev := peertls.Revocation{
 		Timestamp: time.Now().Unix(),
@@ -292,8 +290,7 @@ func TestRevocation_Marshal(t *testing.T) {
 	assert.NoError(t, err)
 	leafCert, caKey := chain[0], keys[0]
 
-	leafHash, err := pkcrypto.SHA256Hash(leafCert.Raw)
-	assert.NoError(t, err)
+	leafHash := pkcrypto.SHA256Hash(leafCert.Raw)
 
 	rev := peertls.Revocation{
 		Timestamp: time.Now().Unix(),
@@ -320,8 +317,7 @@ func TestRevocation_Unmarshal(t *testing.T) {
 	assert.NoError(t, err)
 	leafCert, caKey := chain[0], keys[0]
 
-	leafHash, err := pkcrypto.SHA256Hash(leafCert.Raw)
-	assert.NoError(t, err)
+	leafHash := pkcrypto.SHA256Hash(leafCert.Raw)
 
 	rev := peertls.Revocation{
 		Timestamp: time.Now().Unix(),

--- a/pkg/pkcrypto/encoding.go
+++ b/pkg/pkcrypto/encoding.go
@@ -14,7 +14,7 @@ import (
 	"github.com/zeebo/errs"
 )
 
-// WriteKey writes the private key to the writer, PEM-encoded.
+// WriteKey writes the private key, PEM-encoded.
 func WriteKey(w io.Writer, key crypto.PrivateKey) error {
 	var (
 		kb  []byte
@@ -37,7 +37,7 @@ func WriteKey(w io.Writer, key crypto.PrivateKey) error {
 	return nil
 }
 
-// KeyBytes returns bytes of the private key to the writer, PEM-encoded.
+// KeyBytes returns bytes of the private key, PEM-encoded.
 func KeyBytes(key crypto.PrivateKey) ([]byte, error) {
 	var data bytes.Buffer
 	err := WriteKey(&data, key)

--- a/pkg/pkcrypto/hashing.go
+++ b/pkg/pkcrypto/hashing.go
@@ -4,15 +4,11 @@
 package pkcrypto
 
 import (
-	"crypto"
+	"crypto/sha256"
 )
 
 // SHA256Hash calculates the SHA256 hash of the input data
 func SHA256Hash(data []byte) []byte {
-	hash := crypto.SHA256.New()
-	if _, err := hash.Write(data); err != nil {
-		// hash.Write() is documented as never returning an error
-		panic(err)
-	}
-	return hash.Sum(nil)
+	sum := sha256.Sum256(data)
+	return sum[:]
 }

--- a/pkg/pkcrypto/hashing.go
+++ b/pkg/pkcrypto/hashing.go
@@ -8,10 +8,11 @@ import (
 )
 
 // SHA256Hash calculates the SHA256 hash of the input data
-func SHA256Hash(data []byte) ([]byte, error) {
+func SHA256Hash(data []byte) []byte {
 	hash := crypto.SHA256.New()
 	if _, err := hash.Write(data); err != nil {
-		return nil, err
+		// hash.Write() is documented as never returning an error
+		panic(err)
 	}
-	return hash.Sum(nil), nil
+	return hash.Sum(nil)
 }

--- a/pkg/pkcrypto/signing.go
+++ b/pkg/pkcrypto/signing.go
@@ -36,12 +36,7 @@ func VerifySignature(signedData []byte, data []byte, pubKey crypto.PublicKey) er
 	if _, err := asn1.Unmarshal(signedData, signature); err != nil {
 		return ErrVerifySignature.New("unable to unmarshal ecdsa signature: %v", err)
 	}
-
-	digest, err := SHA256Hash(data)
-	if err != nil {
-		return ErrVerifySignature.Wrap(err)
-	}
-
+	digest := SHA256Hash(data)
 	if !ecdsa.Verify(key, digest, signature.R, signature.S) {
 		return ErrVerifySignature.New("signature is not valid")
 	}
@@ -67,10 +62,7 @@ func SignBytes(key crypto.PrivateKey, data []byte) ([]byte, error) {
 // SignHashOf signs a SHA-256 digest of the given data and returns the new
 // signature.
 func SignHashOf(key crypto.PrivateKey, data []byte) ([]byte, error) {
-	hash, err := SHA256Hash(data)
-	if err != nil {
-		return nil, ErrSign.Wrap(err)
-	}
+	hash := SHA256Hash(data)
 	signature, err := SignBytes(key, hash)
 	if err != nil {
 		return nil, ErrSign.Wrap(err)

--- a/pkg/pkcrypto/signing.go
+++ b/pkg/pkcrypto/signing.go
@@ -26,7 +26,7 @@ func GeneratePrivateKey() (*ecdsa.PrivateKey, error) {
 }
 
 // VerifySignature checks the signature against the passed data and public key
-func VerifySignature(signedData []byte, data []byte, pubKey crypto.PublicKey) error {
+func VerifySignature(signedData, data []byte, pubKey crypto.PublicKey) error {
 	key, ok := pubKey.(*ecdsa.PublicKey)
 	if !ok {
 		return ErrUnsupportedKey.New("%T", key)


### PR DESCRIPTION
according to Go docs, the error cases should never happen. change them to panics, just in case, but no need to return error and check it every single time.

NOTE: this change has two commits; the first actually corresponds to #1241. This change is meant to build on top of that one. I don't think Github provides any nice way to do that, so please bear with the awkwardness for now.