### PR TITLE
Move SplitConnstr to a nicer place

### DIFF
--- a/internal/dbutil/split.go
+++ b/internal/dbutil/split.go
@@ -1,0 +1,22 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package dbutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SplitConnstr returns the driver and DSN portions of a URL
+func SplitConnstr(s string) (string, string, error) {
+	// consider https://github.com/xo/dburl if this ends up lacking
+	parts := strings.SplitN(s, "://", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Could not parse DB URL %s", s)
+	}
+	if parts[0] == "postgres" {
+		parts[1] = s // postgres wants full URLS for its DSN
+	}
+	return parts[0], parts[1], nil
+}

--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -11,13 +11,13 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
+	"storj.io/storj/internal/dbutil"
 	"storj.io/storj/pkg/identity"
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/peertls"
 	"storj.io/storj/pkg/peertls/tlsopts"
 	"storj.io/storj/pkg/server"
 	"storj.io/storj/pkg/transport"
-	"storj.io/storj/pkg/utils"
 	"storj.io/storj/storage/boltdb"
 	"storj.io/storj/storage/redis"
 )
@@ -53,7 +53,7 @@ func (c CertClientConfig) Sign(ctx context.Context, ident *identity.FullIdentity
 // NewAuthDB creates or opens the authorization database specified by the config
 func (c CertServerConfig) NewAuthDB() (*AuthorizationDB, error) {
 	// TODO: refactor db selection logic?
-	driver, source, err := utils.SplitDBURL(c.AuthorizationDBURL)
+	driver, source, err := dbutil.SplitConnstr(c.AuthorizationDBURL)
 	if err != nil {
 		return nil, peertls.ErrRevocationDB.Wrap(err)
 	}

--- a/pkg/identity/revocations.go
+++ b/pkg/identity/revocations.go
@@ -8,8 +8,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 
+	"storj.io/storj/internal/dbutil"
 	"storj.io/storj/pkg/peertls"
-	"storj.io/storj/pkg/utils"
 	"storj.io/storj/storage"
 	"storj.io/storj/storage/boltdb"
 	"storj.io/storj/storage/redis"
@@ -109,7 +109,7 @@ func (r RevocationDB) Close() error {
 
 // NewRevDB returns a new revocation database given the URL
 func NewRevDB(revocationDBURL string) (*RevocationDB, error) {
-	driver, source, err := utils.SplitDBURL(revocationDBURL)
+	driver, source, err := dbutil.SplitConnstr(revocationDBURL)
 	if err != nil {
 		return nil, peertls.ErrRevocationDB.Wrap(err)
 	}

--- a/pkg/pointerdb/config.go
+++ b/pkg/pointerdb/config.go
@@ -4,8 +4,8 @@
 package pointerdb
 
 import (
+	"storj.io/storj/internal/dbutil"
 	"storj.io/storj/internal/memory"
-	"storj.io/storj/pkg/utils"
 	"storj.io/storj/storage"
 	"storj.io/storj/storage/boltdb"
 	"storj.io/storj/storage/postgreskv"
@@ -28,7 +28,7 @@ type Config struct {
 
 // NewStore returns database for storing pointer data
 func NewStore(dbURLString string) (db storage.KeyValueStore, err error) {
-	driver, source, err := utils.SplitDBURL(dbURLString)
+	driver, source, err := dbutil.SplitConnstr(dbURLString)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,38 +4,10 @@
 package utils
 
 import (
-	"bytes"
-	"encoding/gob"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/zeebo/errs"
 )
-
-// GetBytes transforms an empty interface type into a byte slice
-func GetBytes(key interface{}) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := gob.NewEncoder(&buf)
-	err := enc.Encode(key)
-	if err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
-
-// SplitDBURL returns the driver and DSN portions of a URL
-func SplitDBURL(s string) (string, string, error) {
-	// consider https://github.com/xo/dburl if this ends up lacking
-	parts := strings.SplitN(s, "://", 2)
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Could not parse DB URL %s", s)
-	}
-	if parts[0] == "postgres" {
-		parts[1] = s // postgres wants full URLS for its DSN
-	}
-	return parts[0], parts[1], nil
-}
 
 // CombineErrors combines multiple errors to a single error
 func CombineErrors(errs ...error) error {

--- a/satellite/satellitedb/database.go
+++ b/satellite/satellitedb/database.go
@@ -6,6 +6,7 @@ package satellitedb
 import (
 	"github.com/zeebo/errs"
 
+	"storj.io/storj/internal/dbutil"
 	"storj.io/storj/internal/dbutil/pgutil"
 	"storj.io/storj/internal/migrate"
 	"storj.io/storj/pkg/accounting"
@@ -15,7 +16,6 @@ import (
 	"storj.io/storj/pkg/datarepair/queue"
 	"storj.io/storj/pkg/overlay"
 	"storj.io/storj/pkg/statdb"
-	"storj.io/storj/pkg/utils"
 	"storj.io/storj/satellite"
 	"storj.io/storj/satellite/console"
 	dbx "storj.io/storj/satellite/satellitedb/dbx"
@@ -36,7 +36,7 @@ type DB struct {
 
 // New creates instance of database (supports: postgres, sqlite3)
 func New(databaseURL string) (satellite.DB, error) {
-	driver, source, err := utils.SplitDBURL(databaseURL)
+	driver, source, err := dbutil.SplitConnstr(databaseURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Also rename to `SplitConnstr` since it's actually not a valid URL and it's usually reffered as `connstr`.