### PR TITLE
kad.FindNear fix

### DIFF
--- a/pkg/dht/dht.go
+++ b/pkg/dht/dht.go
@@ -5,36 +5,18 @@ package dht
 
 import (
 	"context"
-	"time"
 
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/storj"
-	"storj.io/storj/storage"
 )
 
 // DHT is the interface for the DHT in the Storj network
 type DHT interface {
 	FindNear(ctx context.Context, start storj.NodeID, limit int, restrictions ...pb.Restriction) ([]*pb.Node, error)
-	GetRoutingTable() RoutingTable
 	Bootstrap(ctx context.Context) error
 	Ping(ctx context.Context, node pb.Node) (pb.Node, error)
 	FindNode(ctx context.Context, ID storj.NodeID) (pb.Node, error)
 	Seen() []*pb.Node
-}
-
-// RoutingTable contains information on nodes we have locally
-type RoutingTable interface {
-	// local params
-	Local() pb.Node
-	K() int
-	CacheSize() int
-	GetBucketIds() (storage.Keys, error)
-	FindNear(id storj.NodeID, limit int) ([]*pb.Node, error)
-	ConnectionSuccess(node *pb.Node) error
-	ConnectionFailed(node *pb.Node) error
-	// these are for refreshing
-	SetBucketTimestamp(id []byte, now time.Time) error
-	GetBucketTimestamp(id []byte) (time.Time, error)
 }
 
 // Bucket is a set of methods to act on kademlia k buckets

--- a/pkg/kademlia/dialer_test.go
+++ b/pkg/kademlia/dialer_test.go
@@ -22,7 +22,7 @@ func TestDialer(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 3,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		expectedKademliaEntries := 1 + len(planet.Satellites) + len(planet.StorageNodes)
+		expectedKademliaEntries := len(planet.Satellites) + len(planet.StorageNodes)
 
 		// TODO: also use satellites
 		peers := planet.StorageNodes

--- a/pkg/kademlia/inspector.go
+++ b/pkg/kademlia/inspector.go
@@ -40,8 +40,7 @@ func (srv *Inspector) CountNodes(ctx context.Context, req *pb.CountNodesRequest)
 
 // GetBuckets returns all kademlia buckets for current kademlia instance
 func (srv *Inspector) GetBuckets(ctx context.Context, req *pb.GetBucketsRequest) (*pb.GetBucketsResponse, error) {
-	rt := srv.dht.GetRoutingTable()
-	b, err := rt.GetBucketIds()
+	b, err := srv.dht.GetBucketIds()
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +71,7 @@ func (srv *Inspector) FindNear(ctx context.Context, req *pb.FindNearRequest) (*p
 
 // PingNode sends a PING RPC to the provided node ID in the Kad network.
 func (srv *Inspector) PingNode(ctx context.Context, req *pb.PingNodeRequest) (*pb.PingNodeResponse, error) {
-	rt := srv.dht.GetRoutingTable()
-	self := rt.Local()
+	self := srv.dht.Local()
 
 	_, err := srv.dht.Ping(ctx, pb.Node{
 		Id:   req.Id,

--- a/pkg/kademlia/routing.go
+++ b/pkg/kademlia/routing.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"
 
@@ -148,28 +149,32 @@ func (rt *RoutingTable) GetBucketIds() (storage.Keys, error) {
 
 // FindNear returns the node corresponding to the provided nodeID
 // returns all Nodes closest via XOR to the provided nodeID up to the provided limit
-// always returns limit + self
-func (rt *RoutingTable) FindNear(id storj.NodeID, limit int) (nodes []*pb.Node, err error) {
-	// if id is not in the routing table
-	nodeIDsKeys, err := rt.nodeBucketDB.List(nil, 0)
-	if err != nil {
-		return nodes, RoutingErr.New("could not get node ids %s", err)
-	}
-	nodeIDs, err := storj.NodeIDsFromBytes(nodeIDsKeys.ByteSlices())
-	if err != nil {
-		return nodes, RoutingErr.Wrap(err)
-	}
-	sortByXOR(nodeIDs, id)
-	if len(nodeIDs) >= limit {
-		nodeIDs = nodeIDs[:limit]
-	}
-
-	nodes, err = rt.getNodesFromIDsBytes(nodeIDs)
-	if err != nil {
-		return nodes, RoutingErr.New("could not get nodes %s", err)
-	}
-
-	return nodes, nil
+func (rt *RoutingTable) FindNear(target storj.NodeID, limit int, restrictions ...pb.Restriction) ([]*pb.Node, error) {
+	closestNodes := make([]*pb.Node, 0, limit+1)
+	err := rt.iterate(storj.NodeID{}, 0, func(newID storj.NodeID, protoNode []byte) error {
+		newPos := len(closestNodes)
+		for ; newPos > 0 && compareByXor(closestNodes[newPos-1].Id, newID, target) > 0; newPos-- {
+		}
+		if newPos != limit {
+			newNode := pb.Node{}
+			err := proto.Unmarshal(protoNode, &newNode)
+			if err != nil {
+				return err
+			}
+			if meetsRestrictions(restrictions, newNode) {
+				closestNodes = append(closestNodes, &newNode)
+				if newPos != len(closestNodes) { //reorder
+					copy(closestNodes[newPos+1:], closestNodes[newPos:])
+					closestNodes[newPos] = &newNode
+					if len(closestNodes) > limit {
+						closestNodes = closestNodes[:limit]
+					}
+				}
+			}
+		}
+		return nil
+	})
+	return closestNodes, Error.Wrap(err)
 }
 
 // UpdateSelf updates a node on the routing table
@@ -254,8 +259,32 @@ func (rt *RoutingTable) GetBucketTimestamp(bIDBytes []byte) (time.Time, error) {
 	return time.Unix(0, timestamp).UTC(), nil
 }
 
-func (rt *RoutingTable) iterate(opts storage.IterateOptions, f func(it storage.Iterator) error) error {
-	return rt.nodeBucketDB.Iterate(opts, f)
+func (rt *RoutingTable) iterate(start storj.NodeID, maxLimit int, f func(storj.NodeID, []byte) error) error {
+	if maxLimit < 1 {
+		maxLimit = int(^uint(0) >> 1) //todo: should we use storage.LookupLimit instead?
+	}
+	return rt.nodeBucketDB.Iterate(storage.IterateOptions{First: storage.Key(start.Bytes()), Recurse: true},
+		func(it storage.Iterator) error {
+			var item storage.ListItem
+			for it.Next(&item) {
+				nodeID, err := storj.NodeIDFromBytes(item.Key)
+				if err != nil {
+					return err
+				}
+				if nodeID == rt.self.Id {
+					continue //todo:  revisit if self ID should be in routing table
+				}
+				if nodeID.IsZero() {
+					panic("nil id") //todo:  revisit if self ID should be in routing table
+				}
+				err = f(nodeID, item.Value)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	)
 }
 
 // ConnFailure implements the Transport failure function

--- a/pkg/piecestore/psserver/server.go
+++ b/pkg/piecestore/psserver/server.go
@@ -383,8 +383,6 @@ func (s *Server) getDashboardData(ctx context.Context) (*pb.DashboardStats, erro
 		return &pb.DashboardStats{}, ServerError.Wrap(err)
 	}
 
-	rt := s.kad.GetRoutingTable()
-
 	nodes, err := s.kad.FindNear(ctx, storj.NodeID{}, 10000000)
 	if err != nil {
 		return &pb.DashboardStats{}, ServerError.Wrap(err)
@@ -399,11 +397,11 @@ func (s *Server) getDashboardData(ctx context.Context) (*pb.DashboardStats, erro
 	}
 
 	return &pb.DashboardStats{
-		NodeId:           rt.Local().Id.String(),
+		NodeId:           s.kad.Local().Id.String(),
 		NodeConnections:  int64(len(nodes)),
 		BootstrapAddress: strings.Join(bsNodes[:], ", "),
 		InternalAddress:  "",
-		ExternalAddress:  rt.Local().Address.Address,
+		ExternalAddress:  s.kad.Local().Address.Address,
 		Connection:       true,
 		Uptime:           ptypes.DurationProto(time.Since(s.startTime)),
 		Stats:            statsSummary,


### PR DESCRIPTION
We realized that the Kademlia FindNear() function was
1) not using XOR distance (AKA _totally broken_)
2) largely a duplicate of the RoutingTable FindNear() function

Changes in this PR:
1) upgraded RoutingTable FindNear() to use iterator and restrictions
2) removed unneeded RoutingTable interface
3) made Kademlia wrap methods that were previously accessed via RoutingTable
4) fixed the tests