### PR TITLE
cmd/identity: set default CONFDIR

### DIFF
--- a/cmd/identity/main.go
+++ b/cmd/identity/main.go
@@ -59,15 +59,15 @@ var (
 
 	identityDir, configDir string
 	defaultIdentityDir     = fpath.ApplicationDir("storj", "identity")
-	defaultConfigDir       = fpath.ApplicationDir("storj")
+	defaultConfigDir       = fpath.ApplicationDir("storj", "identity")
 )
 
 func init() {
 	rootCmd.AddCommand(newServiceCmd)
 	rootCmd.AddCommand(authorizeCmd)
 
-	cfgstruct.Bind(newServiceCmd.Flags(), &config, cfgstruct.IdentityDir(defaultIdentityDir))
-	cfgstruct.Bind(authorizeCmd.Flags(), &config, cfgstruct.IdentityDir(defaultIdentityDir))
+	cfgstruct.Bind(newServiceCmd.Flags(), &config, cfgstruct.ConfDir(defaultConfigDir), cfgstruct.IdentityDir(defaultIdentityDir))
+	cfgstruct.Bind(authorizeCmd.Flags(), &config, cfgstruct.ConfDir(defaultConfigDir), cfgstruct.IdentityDir(defaultIdentityDir))
 }
 
 func main() {


### PR DESCRIPTION
this bandaid-fixes the identity tool issues (revocation db defaults to /revocations.db due to the missing CONFDIR)

current identity authorize commands on macs are failing because they can't open the revocation db for the tls settings