### PR TITLE
some certificates cmd cleanup:

### DIFF
--- a/cmd/certificates/claims.go
+++ b/cmd/certificates/claims.go
@@ -44,7 +44,7 @@ var (
 )
 
 func cmdExportClaims(cmd *cobra.Command, args []string) (err error) {
-	authDB, err := claimsExportCfg.NewAuthDB()
+	authDB, err := claimsExportCfg.Signer.NewAuthDB()
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func cmdExportClaims(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	if len(toPrint) == 0 {
-		fmt.Printf("no claims in database: %s\n", claimsExportCfg.AuthorizationDBURL)
+		fmt.Printf("no claims in database: %s\n", claimsExportCfg.Signer.AuthorizationDBURL)
 		return nil
 	}
 
@@ -85,7 +85,7 @@ func cmdExportClaims(cmd *cobra.Command, args []string) (err error) {
 }
 
 func cmdDeleteClaim(cmd *cobra.Command, args []string) (err error) {
-	authDB, err := claimsDeleteCfg.NewAuthDB()
+	authDB, err := claimsDeleteCfg.Signer.NewAuthDB()
 	if err != nil {
 		return err
 	}

--- a/cmd/certificates/claims.go
+++ b/cmd/certificates/claims.go
@@ -35,7 +35,7 @@ var (
 
 	claimsExportCfg struct {
 		Signer certificates.CertServerConfig
-		Raw bool `default:"false" help:"if true, the raw data structures will be printed"`
+		Raw    bool `default:"false" help:"if true, the raw data structures will be printed"`
 	}
 
 	claimsDeleteCfg struct {

--- a/cmd/certificates/claims.go
+++ b/cmd/certificates/claims.go
@@ -12,7 +12,6 @@ import (
 	"github.com/zeebo/errs"
 
 	"storj.io/storj/pkg/certificates"
-	"storj.io/storj/pkg/cfgstruct"
 )
 
 var (
@@ -35,21 +34,14 @@ var (
 	}
 
 	claimsExportCfg struct {
-		certificates.CertServerConfig
+		Signer certificates.CertServerConfig
 		Raw bool `default:"false" help:"if true, the raw data structures will be printed"`
 	}
 
-	claimsDeleteCfg certificates.CertServerConfig
+	claimsDeleteCfg struct {
+		Signer certificates.CertServerConfig
+	}
 )
-
-func init() {
-	rootCmd.AddCommand(claimsCmd)
-	claimsCmd.AddCommand(claimsExportCmd)
-	claimsCmd.AddCommand(claimDeleteCmd)
-
-	cfgstruct.Bind(claimsExportCmd.Flags(), &claimsExportCfg, cfgstruct.ConfDir(defaultConfDir))
-	cfgstruct.Bind(claimDeleteCmd.Flags(), &claimsDeleteCfg, cfgstruct.ConfDir(defaultConfDir))
-}
 
 func cmdExportClaims(cmd *cobra.Command, args []string) (err error) {
 	authDB, err := claimsExportCfg.NewAuthDB()

--- a/cmd/certificates/main.go
+++ b/cmd/certificates/main.go
@@ -86,6 +86,10 @@ func main() {
 	rootCmd.AddCommand(setupCmd)
 	rootCmd.AddCommand(signCmd)
 	rootCmd.AddCommand(verifyCmd)
+	rootCmd.AddCommand(claimsCmd)
+
+	claimsCmd.AddCommand(claimsExportCmd)
+	claimsCmd.AddCommand(claimDeleteCmd)
 
 	authCmd.AddCommand(authCreateCmd)
 	authCmd.AddCommand(authInfoCmd)
@@ -98,6 +102,8 @@ func main() {
 	cfgstruct.BindSetup(setupCmd.Flags(), &config, cfgstruct.ConfDir(defaultConfDir), cfgstruct.IdentityDir(defaultIdentityDir))
 	cfgstruct.Bind(signCmd.Flags(), &signCfg, cfgstruct.ConfDir(defaultConfDir), cfgstruct.IdentityDir(defaultIdentityDir))
 	cfgstruct.Bind(verifyCmd.Flags(), &verifyCfg, cfgstruct.ConfDir(defaultConfDir), cfgstruct.IdentityDir(defaultIdentityDir))
+	cfgstruct.Bind(claimsExportCmd.Flags(), &claimsExportCfg, cfgstruct.ConfDir(defaultConfDir))
+	cfgstruct.Bind(claimDeleteCmd.Flags(), &claimsDeleteCfg, cfgstruct.ConfDir(defaultConfDir))
 
 	process.Exec(rootCmd)
 }

--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -30,7 +30,7 @@ type CertClientConfig struct {
 
 // CertServerConfig is a config struct for use with a certificate signing service server
 type CertServerConfig struct {
-	Overwrite          bool   `default:"false" help:"if true, overwrites config AND authorization db is truncated"`
+	Overwrite          bool   `default:"false" help:"if true, overwrites config AND authorization db is truncated" setup:"true"`
 	AuthorizationDBURL string `default:"bolt://$CONFDIR/authorizations.db" help:"url to the certificate signing authorization database"`
 	MinDifficulty      uint   `default:"30" help:"minimum difficulty of the requester's identity required to claim an authorization"`
 	CA                 identity.FullCAConfig

--- a/pkg/identity/certificate_authority.go
+++ b/pkg/identity/certificate_authority.go
@@ -53,7 +53,7 @@ type CASetupConfig struct {
 	KeyPath        string `help:"path to the private key for this identity" default:"$IDENTITYDIR/ca.key"`
 	Difficulty     uint64 `help:"minimum difficulty for identity generation" default:"30"`
 	Timeout        string `help:"timeout for CA generation; golang duration string (0 no timeout)" default:"5m"`
-	Overwrite      bool   `help:"if true, existing CA certs AND keys will overwritten" default:"false"`
+	Overwrite      bool   `help:"if true, existing CA certs AND keys will overwritten" default:"false" setup:"true"`
 	Concurrency    uint   `help:"number of concurrent workers for certificate authority generation" default:"4"`
 }
 

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -58,7 +58,7 @@ type FullIdentity struct {
 type SetupConfig struct {
 	CertPath  string `help:"path to the certificate chain for this identity" default:"$IDENTITYDIR/identity.cert"`
 	KeyPath   string `help:"path to the private key for this identity" default:"$IDENTITYDIR/identity.key"`
-	Overwrite bool   `help:"if true, existing identity certs AND keys will overwritten for" default:"false"`
+	Overwrite bool   `help:"if true, existing identity certs AND keys will overwritten for" default:"false" setup:"true"`
 	Version   string `help:"semantic version of identity storage format" default:"0"`
 }
 


### PR DESCRIPTION
+ make claims flags consistent with other certificates sub-commands flags
+ move claim commands registration/binding into main
+ prevent overwrite fields on CA/Identity setup-configs from being
written to config.yaml
+ prevent overwtite flag on certificates config from being read from
config.yaml