### PR TITLE
web ui: change default graphql endpoint

### DIFF
--- a/web/satellite/src/utils/apolloManager.ts
+++ b/web/satellite/src/utils/apolloManager.ts
@@ -9,7 +9,7 @@ import { getToken } from '@/utils/tokenManager';
 
 // Satellite url
 const satelliteUrl = new HttpLink({
-    uri: 'http://localhost:10100/api/graphql/v0',
+    uri: '/api/graphql/v0',
 
 });
 


### PR DESCRIPTION
this default graphql endpoint works whenever the satellite is hosting the npm built assets.