### PR TITLE
Reduce Log Messages on Production Settings

### DIFF
--- a/pkg/accounting/tally/tally.go
+++ b/pkg/accounting/tally/tally.go
@@ -163,7 +163,6 @@ func (t *Tally) calculateAtRestData(ctx context.Context) (latestTally time.Time,
 				}
 				pieceSize := segmentSize / int64(minReq)
 				for _, piece := range pieces {
-					t.logger.Debug("found piece on Node ID" + piece.NodeId.String())
 					nodeData[piece.NodeId] += float64(pieceSize)
 				}
 			}

--- a/pkg/accounting/tally/tally.go
+++ b/pkg/accounting/tally/tally.go
@@ -163,7 +163,7 @@ func (t *Tally) calculateAtRestData(ctx context.Context) (latestTally time.Time,
 				}
 				pieceSize := segmentSize / int64(minReq)
 				for _, piece := range pieces {
-					t.logger.Info("found piece on Node ID" + piece.NodeId.String())
+					t.logger.Debug("found piece on Node ID" + piece.NodeId.String())
 					nodeData[piece.NodeId] += float64(pieceSize)
 				}
 			}

--- a/pkg/piecestore/psclient/readerwriter.go
+++ b/pkg/piecestore/psclient/readerwriter.go
@@ -82,7 +82,7 @@ func (s *StreamWriter) Close() error {
 
 	s.storagenodeHash = reply.SignedHash
 
-	zap.S().Debugf("Stream close and recv summary: %v", reply)
+	zap.S().Debugf("Stream close and recv summary: %s, %d", reply.Message, reply.TotalReceived)
 
 	return nil
 }


### PR DESCRIPTION
This log messages produces Gigabytes of log, that arent super necessary right now