### PR TITLE
Ensure ECClient upload timer is stopped when no more status is expected

### DIFF
--- a/pkg/storage/ec/client.go
+++ b/pkg/storage/ec/client.go
@@ -134,7 +134,9 @@ func (ec *ecClient) Put(ctx context.Context, nodes []*pb.Node, rs eestream.Redun
 
 	// Ensure timer is stopped in the case of repair threshold is reached, but
 	// not the success threshold due to errors instead of slowness.
-	timer.Stop()
+	if timer != nil {
+		timer.Stop()
+	}
 
 	/* clean up the partially uploaded segment's pieces */
 	defer func() {

--- a/pkg/storage/ec/client.go
+++ b/pkg/storage/ec/client.go
@@ -119,8 +119,10 @@ func (ec *ecClient) Put(ctx context.Context, nodes []*pb.Node, rs eestream.Redun
 					rs.RepairThreshold(), elapsed.Seconds(), more.Seconds(), rs.OptimalThreshold())
 
 				timer = time.AfterFunc(more, func() {
-					zap.S().Infof("Timer expired. Successfully uploaded to %d nodes. Canceling the long tail...", atomic.LoadInt32(&successfulCount))
-					cancel()
+					if ctx.Err() != context.Canceled {
+						zap.S().Infof("Timer expired. Successfully uploaded to %d nodes. Canceling the long tail...", atomic.LoadInt32(&successfulCount))
+						cancel()
+					}
 				})
 			case rs.OptimalThreshold():
 				zap.S().Infof("Success threshold (%d nodes) reached. Canceling the long tail...", rs.OptimalThreshold())
@@ -129,6 +131,10 @@ func (ec *ecClient) Put(ctx context.Context, nodes []*pb.Node, rs eestream.Redun
 			}
 		}
 	}
+
+	// Ensure timer is stopped in the case of repair threshold is reached, but
+	// not the success threshold due to errors instead of slowness.
+	timer.Stop()
 
 	/* clean up the partially uploaded segment's pieces */
 	defer func() {


### PR DESCRIPTION
This PR ensures that the upload timer of ECClient is always stopped after no more status is expected from uploaded pieces. It also ensures that the "Timer expired" message will be logged only if the context is not already cancelled.

This is to avoid confusing logs where a "Timer expired" message is logged significantly later and mixes with similar messages logged from the upload of the next file segments.