### PR TITLE
tlsconfig refactor / cleanup

### DIFF
--- a/pkg/peertls/tlsopts/options.go
+++ b/pkg/peertls/tlsopts/options.go
@@ -23,11 +23,11 @@ var (
 
 // Options holds config, identity, and peer verification function data for use with tls.
 type Options struct {
-	Config   Config
-	Ident    *identity.FullIdentity
-	RevDB    *identity.RevocationDB
-	PCVFuncs []peertls.PeerCertVerificationFunc
-	Cert     *tls.Certificate
+	Config            Config
+	Ident             *identity.FullIdentity
+	RevDB             *identity.RevocationDB
+	VerificationFuncs []peertls.PeerCertVerificationFunc
+	Cert              *tls.Certificate
 }
 
 // NewOptions is a constructor for `tls options` given an identity and config
@@ -86,7 +86,7 @@ func (opts *Options) configure(c Config) (err error) {
 		}
 	}
 
-	opts.PCVFuncs = pcvs
+	opts.VerificationFuncs = pcvs
 
 	opts.Cert, err = peertls.TLSCert(opts.Ident.ChainRaw(), opts.Ident.Leaf, opts.Ident.Key)
 	return err

--- a/pkg/peertls/tlsopts/options_test.go
+++ b/pkg/peertls/tlsopts/options_test.go
@@ -102,6 +102,6 @@ func TestNewOptions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, reflect.DeepEqual(fi, opts.Ident))
 		assert.Equal(t, c.config, opts.Config)
-		assert.Len(t, opts.PCVFuncs, c.pcvFuncsLen)
+		assert.Len(t, opts.VerificationFuncs, c.pcvFuncsLen)
 	}
 }


### PR DESCRIPTION
+ Rename `options.PCVFuncs` to `options.VerificationFuncs`
+ Separate `ClientTLSConfig` from `ServerTLSConfig` and disambiguate
+ Factor out common stuff