### PR TITLE
encrypted private grpc

### DIFF
--- a/cmd/inspector/main.go
+++ b/cmd/inspector/main.go
@@ -33,16 +33,16 @@ var (
 	IdentityPath = flag.String("identity-path", "", "path to the identity certificate for use on the network")
 
 	// ErrInspectorDial throws when there are errors dialing the inspector server
-	ErrInspectorDial = errs.Class("error dialing inspector server:")
+	ErrInspectorDial = errs.Class("error dialing inspector server")
 
 	// ErrRequest is for gRPC request errors after dialing
-	ErrRequest = errs.Class("error processing request:")
+	ErrRequest = errs.Class("error processing request")
 
 	// ErrIdentity is for errors during identity creation for this CLI
-	ErrIdentity = errs.Class("error creating identity:")
+	ErrIdentity = errs.Class("error creating identity")
 
 	// ErrArgs throws when there are errors with CLI args
-	ErrArgs = errs.Class("error with CLI args:")
+	ErrArgs = errs.Class("error with CLI args")
 
 	// Commander CLI
 	rootCmd = &cobra.Command{

--- a/cmd/inspector/main.go
+++ b/cmd/inspector/main.go
@@ -134,7 +134,7 @@ func NewInspector(address, path string) (*Inspector, error) {
 		return nil, ErrIdentity.Wrap(err)
 	}
 
-	conn, err := transport.DialAddressInsecure(ctx, address)
+	conn, err := transport.DialAddressEncrypted(ctx, address)
 	if err != nil {
 		return &Inspector{}, ErrInspectorDial.Wrap(err)
 	}

--- a/cmd/storagenode/dashboard.go
+++ b/cmd/storagenode/dashboard.go
@@ -34,7 +34,7 @@ func (dash *dashboardClient) dashboard(ctx context.Context) (*pb.DashboardRespon
 }
 
 func newDashboardClient(ctx context.Context, address string) (*dashboardClient, error) {
-	conn, err := transport.DialAddressInsecure(ctx, address)
+	conn, err := transport.DialAddressEncrypted(ctx, address)
 	if err != nil {
 		return &dashboardClient{}, err
 	}
@@ -164,7 +164,7 @@ type inspector struct {
 }
 
 func newInspectorClient(ctx context.Context, bootstrapAddress string) (*inspector, error) {
-	conn, err := transport.DialAddressInsecure(ctx, bootstrapAddress)
+	conn, err := transport.DialAddressEncrypted(ctx, bootstrapAddress)
 	if err != nil {
 		return &inspector{}, err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -68,7 +68,9 @@ func New(opts *tlsopts.Options, publicAddr, privateAddr string, interceptor grpc
 	}
 	private := private{
 		listener: privateListener,
-		grpc:     grpc.NewServer(),
+		grpc: grpc.NewServer(
+			opts.ServerNoClientAuthOption(),
+		),
 	}
 
 	return &Server{

--- a/pkg/transport/insecure.go
+++ b/pkg/transport/insecure.go
@@ -5,19 +5,23 @@ package transport
 
 import (
 	"context"
+	"crypto/tls"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
-// DialAddressInsecure returns an insecure grpc connection without tls to a node.
+// DialAddressEncrypted returns a grpc connection with encryption to a node; no client auth/cert is used.
 //
 // Use this method for communication with localhost. For example, with the inspector or debugging services.
 // Otherwise in most cases DialNode should be used for communicating with nodes since it is secure.
-func DialAddressInsecure(ctx context.Context, address string, opts ...grpc.DialOption) (conn *grpc.ClientConn, err error) {
+func DialAddressEncrypted(ctx context.Context, address string, opts ...grpc.DialOption) (conn *grpc.ClientConn, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	options := append([]grpc.DialOption{
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			InsecureSkipVerify: true,
+		})),
 		grpc.WithBlock(),
 		grpc.FailOnNonTempDialError(true),
 	}, opts...)


### PR DESCRIPTION
Is there any specific reason not to do this?

This would add encryption to the private GRPC server. This is different from how we use TLS on the public server in that it performs no "peer certificate verification" and doesn't require a client certificate. It just uses the existing server identity's certificate on the server side.