### PR TITLE
Restrict slash in bucket name

### DIFF
--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -458,6 +458,9 @@ func (endpoint *Endpoint) validateBucket(bucket []byte) error {
 	if len(bucket) == 0 {
 		return errs.New("bucket not specified")
 	}
+	if bytes.ContainsAny(bucket, "/") {
+		return errs.New("bucket should not contain slash")
+	}
 	return nil
 }
 

--- a/storagenode/inspector/inspector_test.go
+++ b/storagenode/inspector/inspector_test.go
@@ -46,7 +46,7 @@ func TestInspectorStats(t *testing.T) {
 	_, err = rand.Read(expectedData)
 	require.NoError(t, err)
 
-	err = planet.Uplinks[0].Upload(ctx, planet.Satellites[0], "test/bucket", "test/path", expectedData)
+	err = planet.Uplinks[0].Upload(ctx, planet.Satellites[0], "testbucket", "test/path", expectedData)
 	require.NoError(t, err)
 
 	for _, storageNode := range planet.StorageNodes {
@@ -93,7 +93,7 @@ func TestInspectorDashboard(t *testing.T) {
 	_, err = rand.Read(expectedData)
 	require.NoError(t, err)
 
-	err = planet.Uplinks[0].Upload(ctx, planet.Satellites[0], "test/bucket", "test/path", expectedData)
+	err = planet.Uplinks[0].Upload(ctx, planet.Satellites[0], "testbucket", "test/path", expectedData)
 	require.NoError(t, err)
 
 	for _, storageNode := range planet.StorageNodes {

--- a/storagenode/monitor/monitor_test.go
+++ b/storagenode/monitor/monitor_test.go
@@ -41,7 +41,7 @@ func TestMonitor(t *testing.T) {
 	_, err = rand.Read(expectedData)
 	require.NoError(t, err)
 
-	err = planet.Uplinks[0].Upload(ctx, planet.Satellites[0], "test/bucket", "test/path", expectedData)
+	err = planet.Uplinks[0].Upload(ctx, planet.Satellites[0], "testbucket", "test/path", expectedData)
 	require.NoError(t, err)
 
 	nodeAssertions := 0

--- a/storagenode/piecestore/endpoint_test.go
+++ b/storagenode/piecestore/endpoint_test.go
@@ -33,7 +33,7 @@ func TestUploadAndPartialDownload(t *testing.T) {
 	_, err = rand.Read(expectedData)
 	require.NoError(t, err)
 
-	err = planet.Uplinks[0].Upload(ctx, planet.Satellites[0], "test/bucket", "test/path", expectedData)
+	err = planet.Uplinks[0].Upload(ctx, planet.Satellites[0], "testbucket", "test/path", expectedData)
 	assert.NoError(t, err)
 
 	var totalDownload int64
@@ -49,7 +49,7 @@ func TestUploadAndPartialDownload(t *testing.T) {
 		}
 		totalDownload += piecestore.DefaultConfig.InitialStep
 
-		download, err := planet.Uplinks[0].DownloadStream(ctx, planet.Satellites[0], "test/bucket", "test/path")
+		download, err := planet.Uplinks[0].DownloadStream(ctx, planet.Satellites[0], "testbucket", "test/path")
 		require.NoError(t, err)
 
 		pos, err := download.Seek(tt.offset, io.SeekStart)
@@ -73,9 +73,9 @@ func TestUploadAndPartialDownload(t *testing.T) {
 		totalBandwidthUsage.Add(usage)
 	}
 
-	err = planet.Uplinks[0].Delete(ctx, planet.Satellites[0], "test/bucket", "test/path")
+	err = planet.Uplinks[0].Delete(ctx, planet.Satellites[0], "testbucket", "test/path")
 	require.NoError(t, err)
-	_, err = planet.Uplinks[0].Download(ctx, planet.Satellites[0], "test/bucket", "test/path")
+	_, err = planet.Uplinks[0].Download(ctx, planet.Satellites[0], "testbucket", "test/path")
 	require.Error(t, err)
 
 	// check rough limits for the upload and download


### PR DESCRIPTION
Restricts `/` in `metainfo` endpoint bucket name 