### PR TITLE
removes pingbackTimeout

### DIFF
--- a/bootstrap/peer.go
+++ b/bootstrap/peer.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"time"
 
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"
@@ -136,7 +135,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config) (*P
 			return nil, errs.Combine(err, peer.Close())
 		}
 
-		peer.Kademlia.Endpoint = kademlia.NewEndpoint(peer.Log.Named("kademlia:endpoint"), peer.Kademlia.Service, peer.Kademlia.RoutingTable, 60*time.Second)
+		peer.Kademlia.Endpoint = kademlia.NewEndpoint(peer.Log.Named("kademlia:endpoint"), peer.Kademlia.Service, peer.Kademlia.RoutingTable)
 		pb.RegisterNodesServer(peer.Server.GRPC(), peer.Kademlia.Endpoint)
 
 		peer.Kademlia.Inspector = kademlia.NewInspector(peer.Kademlia.Service, peer.Identity)

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -163,7 +163,7 @@ func testNode(ctx *testcontext.Context, name string, t *testing.T, bn []pb.Node)
 	k, err := newKademlia(logger, pb.NodeType_STORAGE, bn, lis.Addr().String(), nil, fid, ctx.Dir(name), defaultAlpha)
 	assert.NoError(t, err)
 
-	s := NewEndpoint(logger, k, k.routingTable, 60*time.Second)
+	s := NewEndpoint(logger, k, k.routingTable)
 	// new ident opts
 
 	serverOptions, err := tlsopts.NewOptions(fid, tlsopts.Config{})

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -12,7 +12,6 @@ import (
 	"net/smtp"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"
@@ -279,7 +278,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config *Config) (*
 			return nil, errs.Combine(err, peer.Close())
 		}
 
-		peer.Kademlia.Endpoint = kademlia.NewEndpoint(peer.Log.Named("kademlia:endpoint"), peer.Kademlia.Service, peer.Kademlia.RoutingTable, 60*time.Second)
+		peer.Kademlia.Endpoint = kademlia.NewEndpoint(peer.Log.Named("kademlia:endpoint"), peer.Kademlia.Service, peer.Kademlia.RoutingTable)
 		pb.RegisterNodesServer(peer.Server.GRPC(), peer.Kademlia.Endpoint)
 
 		peer.Kademlia.Inspector = kademlia.NewInspector(peer.Kademlia.Service, peer.Identity)

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -164,7 +164,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config) (*P
 			return nil, errs.Combine(err, peer.Close())
 		}
 
-		peer.Kademlia.Endpoint = kademlia.NewEndpoint(peer.Log.Named("kademlia:endpoint"), peer.Kademlia.Service, peer.Kademlia.RoutingTable, 60*time.Second)
+		peer.Kademlia.Endpoint = kademlia.NewEndpoint(peer.Log.Named("kademlia:endpoint"), peer.Kademlia.Service, peer.Kademlia.RoutingTable)
 		pb.RegisterNodesServer(peer.Server.GRPC(), peer.Kademlia.Endpoint)
 
 		peer.Kademlia.Inspector = kademlia.NewInspector(peer.Kademlia.Service, peer.Identity)

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -5,7 +5,6 @@ package storagenode
 
 import (
 	"context"
-	"time"
 
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"


### PR DESCRIPTION
## why changes
- this pr #1545 added a consistent timeout across `transport.dialNode` calls, so the specific timeout setting for pingback is no longer necessary.
- tests to ensure that behavior remains the same were included in #1545 as well (specifically `TestSlowDialerHasTimeout` in pkg/kademlia/dialer_test.go and `TestPingTimeout` in pkg/kademlia/kademlia_planet_test.go).

## what changes
- removes `pingbackTimeout` field from `kademlia.Endpoint`
- removes `pingbackTimeout` argument from `kademlia.NewEndpoint`
- removes context.WithTimeout call with `pingbackTimeout` since it will come with a timeout built into the dialer.

## Code Review Checklist
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Could the PR be broken into smaller PRs?
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?