### PR TITLE
adds test for correct download with non-critical amount of nodes offline

### DIFF
--- a/internal/testplanet/uplink_test.go
+++ b/internal/testplanet/uplink_test.go
@@ -106,6 +106,9 @@ func TestDownloadWithSomeNodesOffline(t *testing.T) {
 			if nodesToKill[node.ID()] {
 				err = planet.StopPeer(node)
 				assert.NoError(t, err)
+
+				err = satellite.Overlay.Service.Delete(ctx, node.ID())
+				assert.NoError(t, err)
 			}
 		}
 

--- a/internal/testplanet/uplink_test.go
+++ b/internal/testplanet/uplink_test.go
@@ -13,6 +13,9 @@ import (
 	"storj.io/storj/internal/memory"
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testplanet"
+	"storj.io/storj/pkg/pb"
+	"storj.io/storj/pkg/storj"
+	"storj.io/storj/uplink"
 )
 
 func TestUploadDownload(t *testing.T) {
@@ -36,4 +39,79 @@ func TestUploadDownload(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedData, data)
+}
+
+func TestDownloadWithSomeNodesOffline(t *testing.T) {
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1, StorageNodeCount: 10, UplinkCount: 1,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		// first, upload some remote data
+		ul := planet.Uplinks[0]
+		satellite := planet.Satellites[0]
+
+		satellite.Repair.Checker.Loop.Stop()
+
+		testData := make([]byte, 1*memory.MiB)
+		_, err := rand.Read(testData)
+		assert.NoError(t, err)
+
+		err = ul.UploadWithConfig(ctx, satellite, &uplink.RSConfig{
+			MinThreshold:     2,
+			RepairThreshold:  3,
+			SuccessThreshold: 4,
+			MaxThreshold:     5,
+		}, "testbucket", "test/path", testData)
+		require.NoError(t, err)
+
+		// get a remote segment from pointerdb
+		pdb := satellite.Metainfo.Service
+		listResponse, _, err := pdb.List("", "", "", true, 0, 0)
+		require.NoError(t, err)
+
+		var path string
+		var pointer *pb.Pointer
+		for _, v := range listResponse {
+			path = v.GetPath()
+			pointer, err = pdb.Get(path)
+			assert.NoError(t, err)
+			if pointer.GetType() == pb.Pointer_REMOTE {
+				break
+			}
+		}
+
+		// calculate how many storagenodes to kill
+		numStorageNodes := len(planet.StorageNodes)
+		redundancy := pointer.GetRemote().GetRedundancy()
+		remotePieces := pointer.GetRemote().GetRemotePieces()
+		minReq := redundancy.GetMinReq()
+		numPieces := len(remotePieces)
+		toKill := numPieces - int(minReq)
+
+		// we should have enough storage nodes to repair on
+		assert.True(t, (numStorageNodes-toKill) >= numPieces)
+
+		// kill nodes and track lost pieces
+		var lostPieces []int32
+		nodesToKill := make(map[storj.NodeID]bool)
+		nodesToKeepAlive := make(map[storj.NodeID]bool)
+		for i, piece := range remotePieces {
+			if i >= toKill {
+				nodesToKeepAlive[piece.NodeId] = true
+				continue
+			}
+			nodesToKill[piece.NodeId] = true
+			lostPieces = append(lostPieces, piece.GetPieceNum())
+		}
+		for _, node := range planet.StorageNodes {
+			if nodesToKill[node.ID()] {
+				err = planet.StopPeer(node)
+				assert.NoError(t, err)
+			}
+		}
+
+		// we should be able to download data without any of the original nodes
+		newData, err := ul.Download(ctx, satellite, "testbucket", "test/path")
+		assert.NoError(t, err)
+		assert.Equal(t, newData, testData)
+	})
 }

--- a/internal/testplanet/uplink_test.go
+++ b/internal/testplanet/uplink_test.go
@@ -52,7 +52,7 @@ func TestDownloadWithSomeNodesOffline(t *testing.T) {
 
 		testData := make([]byte, 1*memory.MiB)
 		_, err := rand.Read(testData)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = ul.UploadWithConfig(ctx, satellite, &uplink.RSConfig{
 			MinThreshold:     2,
@@ -72,7 +72,7 @@ func TestDownloadWithSomeNodesOffline(t *testing.T) {
 		for _, v := range listResponse {
 			path = v.GetPath()
 			pointer, err = pdb.Get(path)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			if pointer.GetType() == pb.Pointer_REMOTE {
 				break
 			}
@@ -96,16 +96,16 @@ func TestDownloadWithSomeNodesOffline(t *testing.T) {
 		for _, node := range planet.StorageNodes {
 			if nodesToKill[node.ID()] {
 				err = planet.StopPeer(node)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				err = satellite.Overlay.Service.Delete(ctx, node.ID())
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		}
 
 		// we should be able to download data without any of the original nodes
 		newData, err := ul.Download(ctx, satellite, "testbucket", "test/path")
-		assert.NoError(t, err)
-		assert.Equal(t, newData, testData)
+		require.NoError(t, err)
+		require.Equal(t, testData, newData)
 	})
 }

--- a/pkg/overlay/cache.go
+++ b/pkg/overlay/cache.go
@@ -24,7 +24,7 @@ const (
 var ErrEmptyNode = errs.New("empty node ID")
 
 // ErrNodeNotFound is returned if a node does not exist in database
-var ErrNodeNotFound = errs.New("Node not found")
+var ErrNodeNotFound = errs.Class("Node not found")
 
 // ErrBucketNotFound is returned if a bucket is unable to be found in the routing table
 var ErrBucketNotFound = errs.New("Bucket not found")

--- a/pkg/overlay/cache_test.go
+++ b/pkg/overlay/cache_test.go
@@ -71,7 +71,7 @@ func testCache(ctx context.Context, t *testing.T, store overlay.DB) {
 
 		invalid2, err := cache.Get(ctx, missingID)
 		assert.Error(t, err)
-		assert.True(t, err == overlay.ErrNodeNotFound)
+		assert.Contains(t, err.Error(), overlay.ErrNodeNotFound.Error())
 		assert.Nil(t, invalid2)
 
 		// TODO: add erroring database test
@@ -130,7 +130,7 @@ func testCache(ctx context.Context, t *testing.T, store overlay.DB) {
 		deleted, err := cache.Get(ctx, valid1ID)
 		assert.Error(t, err)
 		assert.Nil(t, deleted)
-		assert.True(t, err == overlay.ErrNodeNotFound)
+		assert.Contains(t, err.Error(), overlay.ErrNodeNotFound.Error())
 
 		// Test idempotent delete / non existent key delete
 		err = cache.Delete(ctx, valid1ID)

--- a/pkg/overlay/cache_test.go
+++ b/pkg/overlay/cache_test.go
@@ -71,7 +71,7 @@ func testCache(ctx context.Context, t *testing.T, store overlay.DB) {
 
 		invalid2, err := cache.Get(ctx, missingID)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), overlay.ErrNodeNotFound.Error())
+		assert.True(t, overlay.ErrNodeNotFound.Has(err))
 		assert.Nil(t, invalid2)
 
 		// TODO: add erroring database test
@@ -130,7 +130,7 @@ func testCache(ctx context.Context, t *testing.T, store overlay.DB) {
 		deleted, err := cache.Get(ctx, valid1ID)
 		assert.Error(t, err)
 		assert.Nil(t, deleted)
-		assert.Contains(t, err.Error(), overlay.ErrNodeNotFound.Error())
+		assert.True(t, overlay.ErrNodeNotFound.Has(err))
 
 		// Test idempotent delete / non existent key delete
 		err = cache.Delete(ctx, valid1ID)

--- a/pkg/storage/segments/repairer_test.go
+++ b/pkg/storage/segments/repairer_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestSegmentStoreRepair(t *testing.T) {
+	t.Skip("flaky")
+
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 10, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
@@ -36,10 +38,10 @@ func TestSegmentStoreRepair(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = ul.UploadWithConfig(ctx, satellite, &uplink.RSConfig{
-			MinThreshold:     2,
-			RepairThreshold:  3,
-			SuccessThreshold: 4,
-			MaxThreshold:     5,
+			MinThreshold:     1,
+			RepairThreshold:  2,
+			SuccessThreshold: 3,
+			MaxThreshold:     4,
 		}, "testbucket", "test/path", testData)
 		require.NoError(t, err)
 
@@ -85,9 +87,6 @@ func TestSegmentStoreRepair(t *testing.T) {
 			if nodesToKill[node.ID()] {
 				err = planet.StopPeer(node)
 				assert.NoError(t, err)
-
-				err = satellite.Overlay.Service.Delete(ctx, node.ID())
-				assert.NoError(t, err)
 			}
 		}
 
@@ -105,9 +104,6 @@ func TestSegmentStoreRepair(t *testing.T) {
 		for _, node := range planet.StorageNodes {
 			if nodesToKeepAlive[node.ID()] {
 				err = planet.StopPeer(node)
-				assert.NoError(t, err)
-
-				err = satellite.Overlay.Service.Delete(ctx, node.ID())
 				assert.NoError(t, err)
 			}
 		}

--- a/pkg/storage/segments/repairer_test.go
+++ b/pkg/storage/segments/repairer_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestSegmentStoreRepair(t *testing.T) {
-	t.Skip("flaky")
-
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 10, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
@@ -38,10 +36,10 @@ func TestSegmentStoreRepair(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = ul.UploadWithConfig(ctx, satellite, &uplink.RSConfig{
-			MinThreshold:     1,
-			RepairThreshold:  2,
-			SuccessThreshold: 3,
-			MaxThreshold:     4,
+			MinThreshold:     2,
+			RepairThreshold:  3,
+			SuccessThreshold: 4,
+			MaxThreshold:     5,
 		}, "testbucket", "test/path", testData)
 		require.NoError(t, err)
 
@@ -87,6 +85,9 @@ func TestSegmentStoreRepair(t *testing.T) {
 			if nodesToKill[node.ID()] {
 				err = planet.StopPeer(node)
 				assert.NoError(t, err)
+
+				err = satellite.Overlay.Service.Delete(ctx, node.ID())
+				assert.NoError(t, err)
 			}
 		}
 
@@ -104,6 +105,9 @@ func TestSegmentStoreRepair(t *testing.T) {
 		for _, node := range planet.StorageNodes {
 			if nodesToKeepAlive[node.ID()] {
 				err = planet.StopPeer(node)
+				assert.NoError(t, err)
+
+				err = satellite.Overlay.Service.Delete(ctx, node.ID())
 				assert.NoError(t, err)
 			}
 		}

--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -326,7 +326,7 @@ func (endpoint *Endpoint) createOrderLimitsForSegment(ctx context.Context, point
 
 		node, err := endpoint.cache.Get(ctx, piece.NodeId)
 		if err != nil {
-			endpoint.log.Error("error getting node from overlay cache")
+			endpoint.log.Error("error getting node from overlay cache", zap.Error(err))
 			combinedErrs = errs.Combine(combinedErrs, err)
 			continue
 		}

--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -342,7 +342,7 @@ func (endpoint *Endpoint) createOrderLimitsForSegment(ctx context.Context, point
 	}
 
 	if len(limits) < redundancy.RequiredCount() {
-		err = Error.New("not enough nodes available. Available: %d, Required: %d", len(limits), redundancy.RequiredCount())
+		err = Error.New("not enough nodes available: got %d, required %d", len(limits), redundancy.RequiredCount())
 		return nil, errs.Combine(combinedErrs, err)
 	}
 

--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -116,7 +116,7 @@ func (cache *overlaycache) Get(ctx context.Context, id storj.NodeID) (*pb.Node, 
 		dbx.OverlayCacheNode_NodeId(id.Bytes()),
 	)
 	if err == sql.ErrNoRows {
-		return nil, overlay.ErrNodeNotFound
+		return nil, errs.Combine(overlay.ErrNodeNotFound, errs.New("couldn't find nodeID: %s", id.String()))
 	}
 	if err != nil {
 		return nil, err

--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -116,7 +116,7 @@ func (cache *overlaycache) Get(ctx context.Context, id storj.NodeID) (*pb.Node, 
 		dbx.OverlayCacheNode_NodeId(id.Bytes()),
 	)
 	if err == sql.ErrNoRows {
-		return nil, errs.Combine(overlay.ErrNodeNotFound, errs.New("couldn't find nodeID: %s", id.String()))
+		return nil, overlay.ErrNodeNotFound.New("couldn't find nodeID: %s", id.String())
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## why changes
The repairer test is flakily passing and failing, so we decided to create `TestDownloadWithSomeNodesOnline` as a "sanity check" type test to preface the repair test.
We found that there was a bug in satellite/metainfo/metainfo.go where the whole download would fail, even if the required number of pieces were still online. This fail was happening because the overlaycache.Get call returned an error, which wasn't properly handled. 

## what changes
- Adds error handling to ensure that the download would only fail if less than the minimum required number of nodes were online.
- Adds `TestDownloadWithSomeNodesOffline` to internal/testplanet/uplink_test.go, which uploads some data, stops some nodes, then downloads to make sure data is the same.

## Code Review Checklist
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?


Thanks for submitting a PR!

![](https://media.giphy.com/media/14nakW0jC4HA6k/giphy.gif)
