### PR TITLE
creating a metainfo endpoint in repair and audit?

### DIFF
--- a/pkg/audit/service.go
+++ b/pkg/audit/service.go
@@ -16,6 +16,7 @@ import (
 	"storj.io/storj/pkg/pointerdb"
 	"storj.io/storj/pkg/statdb"
 	"storj.io/storj/pkg/transport"
+	"storj.io/storj/satellite/orders"
 )
 
 // Config contains configurable values for audit service
@@ -39,11 +40,11 @@ type Service struct {
 // NewService instantiates a Service with access to a Cursor and Verifier
 func NewService(log *zap.Logger, config Config, sdb statdb.DB, pointerdb *pointerdb.Service,
 	allocation *pointerdb.AllocationSigner, transport transport.Client, overlay *overlay.Cache,
-	identity *identity.FullIdentity) (service *Service, err error) {
+	identity *identity.FullIdentity, orders orders.DB) (service *Service, err error) {
 	return &Service{
 		log: log,
 
-		Cursor:   NewCursor(pointerdb, allocation, overlay, identity),
+		Cursor:   NewCursor(log.Named("audit:cursor"), pointerdb, allocation, overlay, identity, orders),
 		Verifier: NewVerifier(log.Named("audit:verifier"), transport, overlay, identity, config.MinBytesPerSecond),
 		Reporter: NewReporter(sdb, config.MaxRetriesStatDB),
 


### PR DESCRIPTION
Slightly extends on #1591 - gets started trying to create a metainfo.Endpoint in the repair and audit services so that remote orders can be saved.
Seems like the main hurdles for going this route would be:
- getting access to a project ID given a pointer
- getting the bucket given a pointer

Made it a separate PR from Stefan's in case it made his changes unclear.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
