### PR TITLE
adds exponential backoff restart for storage node service calls

### DIFF
--- a/internal/testplanet/planet.go
+++ b/internal/testplanet/planet.go
@@ -585,6 +585,10 @@ func (planet *Planet) newStorageNodes(count int, whitelistedSatelliteIDs []strin
 				},
 			},
 			Version: planet.NewVersionConfig(),
+			Retry: storagenode.RetryConfig{
+				BaseWait: 1 * time.Second,
+				MaxWait:  30 * time.Second,
+			},
 		}
 		if planet.config.Reconfigure.StorageNode != nil {
 			planet.config.Reconfigure.StorageNode(i, &config)

--- a/internal/testplanet/retry_service_test.go
+++ b/internal/testplanet/retry_service_test.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information
+
+package testplanet_test
+
+import (
+	"testing"
+
+	"storj.io/storj/bootstrap"
+	"storj.io/storj/internal/testcontext"
+	"storj.io/storj/internal/testplanet"
+)
+
+func TestStorageNodeServiceRetry(t *testing.T) {
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
+		Reconfigure: testplanet.Reconfigure{
+			Bootstrap: func(index int, config *bootstrap.Config) {
+				config.Kademlia.BootstrapAddr = ":9990"
+			},
+		},
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+
+		// have all storage nodes start up (without a bootstrap node)
+		// confirm that storagenodes can't find anybody
+		// after they've all started, start the bootstrap node,
+		// then wait for the back off time, then make sure nodes find out about everybody.
+
+	})
+}

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -295,24 +295,31 @@ func (peer *Peer) Run(ctx context.Context) error {
 	return group.Wait()
 }
 
-func (peer *Peer) exponentialBackoffBootstrap(ctx context.Context, waitInterval, maxWait time.Duration, attempts int, combined error) error {
-	if waitInterval*2 > maxWait {
-		return errs.Combine(combined, Error.New("unable to bootstrap to network after %d attempts", attempts))
-	}
-	if attempts == 1 {
-		time.Sleep(waitInterval)
-	}
-	if attempts > 1 {
-		waitInterval = waitInterval * 2
-		time.Sleep(waitInterval)
-	}
+func exponentialBackoff(ctx context.Context, waitInterval, maxWait time.Duration, toExec func(context.Context) error) error {
 
-	err := peer.Kademlia.Service.Bootstrap(ctx)
+	var errList errs.Group
+	err := toExec(ctx)
 	if err != nil {
-		errs.Combine(combined, err)
-		attempts++
-		peer.exponentialBackoffBootstrap(ctx, waitInterval, maxWait, attempts, combined)
+		errList.Add(err)
 	}
+	// if waitInterval*2 > maxWait {
+	// 	return errs.Combine(combined, Error.New("unable to bootstrap to network after %d attempts", attempts))
+	// }
+	// if attempts == 1 {
+	// 	time.Sleep(waitInterval)
+	// }
+	// if attempts > 1 {
+	// 	waitInterval = waitInterval * 2
+	// 	time.Sleep(waitInterval)
+	// }
+
+	// err := peer.Kademlia.Service.Bootstrap(ctx)
+	// if err != nil {
+	// 	errs.Combine(combined, err)
+	// 	attempts++
+	// 	peer.exponentialBackoffBootstrap(ctx, waitInterval, maxWait, attempts, combined)
+	// }
+	// return nil
 	return nil
 }
 

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -272,16 +272,16 @@ func (peer *Peer) Run(ctx context.Context) error {
 		return ignoreCancel(peer.Kademlia.Service.Bootstrap(ctx))
 	})
 	group.Go(func() error {
-		return peer.backoffRestart(ctx, baseWaitInterval, maxWaitDuration, "kademlia", peer.Kademlia.Service.Run)
+		return backoffRestart(ctx, baseWaitInterval, maxWaitDuration, "kademlia", peer.Kademlia.Service.Run)
 	})
 	group.Go(func() error {
-		return peer.backoffRestart(ctx, baseWaitInterval, maxWaitDuration, "agreements.sender", peer.Agreements.Sender.Run)
+		return backoffRestart(ctx, baseWaitInterval, maxWaitDuration, "agreements.sender", peer.Agreements.Sender.Run)
 	})
 	group.Go(func() error {
-		return peer.backoffRestart(ctx, baseWaitInterval, maxWaitDuration, "storage2.sender", peer.Storage2.Sender.Run)
+		return backoffRestart(ctx, baseWaitInterval, maxWaitDuration, "storage2.sender", peer.Storage2.Sender.Run)
 	})
 	group.Go(func() error {
-		return peer.backoffRestart(ctx, baseWaitInterval, maxWaitDuration, "storage2.monitor", peer.Storage2.Monitor.Run)
+		return backoffRestart(ctx, baseWaitInterval, maxWaitDuration, "storage2.monitor", peer.Storage2.Monitor.Run)
 	})
 	group.Go(func() error {
 		// TODO: move the message into Server instead
@@ -289,38 +289,28 @@ func (peer *Peer) Run(ctx context.Context) error {
 		peer.Log.Sugar().Infof("Node %s started", peer.Identity.ID)
 		peer.Log.Sugar().Infof("Public server started on %s", peer.Addr())
 		peer.Log.Sugar().Infof("Private server started on %s", peer.PrivateAddr())
-		return peer.backoffRestart(ctx, baseWaitInterval, maxWaitDuration, "peer.server", peer.Server.Run)
+		return backoffRestart(ctx, baseWaitInterval, maxWaitDuration, "peer.Server", peer.Server.Run)
 	})
 
 	return group.Wait()
 }
 
-func (peer *Peer) backoffRestart(ctx context.Context, waitInterval, maxWait time.Duration, name string, service func(context.Context) error) error {
+func backoffRestart(ctx context.Context, waitInterval, maxWait time.Duration, name string, service func(context.Context) error) error {
 	var errList errs.Group
 
 	for i := 0; waitInterval < maxWait; i++ {
-		err := func() (err error) {
-			defer func() {
-				rec := recover()
-				if rec != nil {
-					errList.Add(errs.New("caught panic in service %s: %+v", name, rec))
-				}
-			}()
-			return ignoreCancel(service(ctx))
-		}()
-		peer.Log.Sugar().Errorf("Service %s failure: %+v", name, err)
-		if i == 0 {
-			time.Sleep(waitInterval)
-		}
-		if waitInterval*2 > maxWait {
-			errList.Add(Error.New("unable start %s after final wait time of %d", name, waitInterval))
-			return errList.Err()
-		}
 		if i > 0 {
-			waitInterval = waitInterval * 2
 			time.Sleep(waitInterval)
+			waitInterval = waitInterval * 2
 		}
+		err := ignoreCancel(service(ctx))
+		if err != nil {
+			errList.Add(err)
+			continue
+		}
+		return nil
 	}
+
 	errList.Add(Error.New("unable to start %s after final wait time of %d", name, waitInterval))
 	return errList.Err()
 }

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -311,7 +311,7 @@ func backoffRestart(ctx context.Context, waitInterval, maxWait time.Duration, na
 		return nil
 	}
 
-	errList.Add(Error.New("unable to start %s after final wait time of %d", name, waitInterval))
+	errList.Add(Error.New("unable to start %s after final wait time of %ds", name, waitInterval/time.Second))
 	return errList.Err()
 }
 


### PR DESCRIPTION
## why changes
- Occasionally an authentication handshake failed/connection reset by peer error appears and the storage nodes exit, but they should keep attempting to connect, at least a few times, with exponential back off.

## what changes
- Adds `backoffRestart` function in storagenode/peer.go which now wraps all of the storage node peer's service calls.
- On all attempts to run the function after the first, there will be a wait (time.Sleep call) before the next call. Every iteration, the wait interval will multiply by 2, until it exceeds the `maxWait` time, which has been set in the file as a const of 30 seconds. It could be configured though.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
