### PR TITLE
prevents audit's cursor.NextStripe from returning nil, nil

### DIFF
--- a/pkg/audit/cursor.go
+++ b/pkg/audit/cursor.go
@@ -60,6 +60,14 @@ func (cursor *Cursor) NextStripe(ctx context.Context) (stripe *Stripe, err error
 		if err != nil {
 			return nil, err
 		}
+
+		// keep track of last path listed
+		if !more {
+			cursor.lastPath = ""
+		} else {
+			cursor.lastPath = pointerItems[len(pointerItems)-1].Path
+		}
+
 		if len(pointerItems) == 0 {
 			attempts++
 		} else {
@@ -93,13 +101,6 @@ func (cursor *Cursor) getRandomValidPointer(pointerItems []*pb.ListResponse_Item
 		pointerItem, err := getRandomPointer(pointerItems)
 		if err != nil {
 			return nil, err
-		}
-
-		// keep track of last path listed
-		if !more {
-			cursor.lastPath = ""
-		} else {
-			cursor.lastPath = pointerItems[len(pointerItems)-1].Path
 		}
 
 		pointer, err = cursor.pointerdb.Get(pointerItem.Path)


### PR DESCRIPTION
# why changes
Previously, there were 3 cases where the audit cursor's NextStripe function could return a nil (instead of a stripe) as well as a nil error. This meant that NextStripe would have to be called multiple times in some cases to acquire a valid stripe to audit.

# what changes
Adds new `getRandomValidPointer` function the pkg/audit/cursor.go to ensure that a valid stripe is found, or an error is returned after a configured number of retries.
The retry values still need to be added as a config.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
