### PR TITLE
fixes infinite loop in audit TestVerifierHappyPath

### DIFF
--- a/pkg/audit/cursor_test.go
+++ b/pkg/audit/cursor_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"storj.io/storj/internal/testcontext"
@@ -43,14 +42,13 @@ func TestAuditSegment(t *testing.T) {
 		t.Run("NextStripe", func(t *testing.T) {
 			for _, tt := range tests {
 				t.Run(tt.bm, func(t *testing.T) {
-					assert1 := assert.New(t)
 					stripe, err := cursor.NextStripe(ctx)
 					if err != nil {
-						assert1.Error(err)
-						assert1.Nil(stripe)
+						require.Error(t, err)
+						require.Nil(t, stripe)
 					}
 					if stripe != nil {
-						assert1.Nil(err)
+						require.Nil(t, err)
 					}
 				})
 			}

--- a/pkg/audit/newverifier_test.go
+++ b/pkg/audit/newverifier_test.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -23,15 +22,15 @@ func TestVerifierHappyPath(t *testing.T) {
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 
 		err := planet.Satellites[0].Audit.Service.Close()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		uplink := planet.Uplinks[0]
 		testData := make([]byte, 1*memory.MiB)
 		_, err = rand.Read(testData)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = uplink.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		pointerdb := planet.Satellites[0].Metainfo.Service
 		overlay := planet.Satellites[0].Overlay.Service
@@ -56,9 +55,9 @@ func TestVerifierHappyPath(t *testing.T) {
 
 		// stop some storage nodes to ensure audit can deal with it
 		err = planet.StopPeer(planet.StorageNodes[0])
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = planet.StopPeer(planet.StorageNodes[1])
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// remove stopped nodes from overlay cache
 		err = planet.Satellites[0].Overlay.Service.Delete(ctx, planet.StorageNodes[0].ID())
@@ -67,6 +66,6 @@ func TestVerifierHappyPath(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = verifier.Verify(ctx, stripe)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/pkg/audit/newverifier_test.go
+++ b/pkg/audit/newverifier_test.go
@@ -38,14 +38,15 @@ func TestVerifierHappyPath(t *testing.T) {
 		cursor := audit.NewCursor(pointerdb)
 
 		var stripe *audit.Stripe
-		for {
+		maxRetries := 3
+		for i := 0; i < maxRetries; i++ {
 			stripe, err = cursor.NextStripe(ctx)
 			if stripe != nil || err != nil {
 				break
 			}
 		}
 		require.NoError(t, err)
-		require.NotNil(t, stripe)
+		require.NotNil(t, stripe, "unable to get stripe; likely no pointers in pointerdb")
 
 		transport := planet.Satellites[0].Transport
 		orders := planet.Satellites[0].Orders.Service


### PR DESCRIPTION
# why changes
When there are no pointers in the pointerdb, this test caused a memory leak because of an infinite loop.

# what changes
Just makes the NextStripe call 3 times and if it still doesn't have a non-nil stripe, then the test fails. #1616 refactors NextStripe so that a more informative error is returned in the future (i.e. "unable to find pointers after %d attempts").
- Also makes sure that all audit tests use `require` instead of `assert`.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
