### PR TITLE
Adding Travis CI build status icon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](http://godoc.org/github.com/storj/storj)
 [![Coverage Status](https://coveralls.io/repos/github/storj/storj/badge.svg?branch=master)](https://coveralls.io/github/storj/storj?branch=master)
 ![Alpha](https://img.shields.io/badge/version-alpha-green.svg)
+[![Build Status](https://travis-ci.com/storj/storj.svg?branch=master)](https://travis-ci.com/storj/storj)
 
 <img src="https://github.com/storj/storj/raw/master/resources/logo.png" width="100">
 


### PR DESCRIPTION
This PR adds the Travis CI build icon for the `master` branch so that it is easy to see if the master branch is currently passing.

This makes it easy to identify when we shouldn't pile on a failing branch if it's currently under fixing.

You can test the README change with the new icon [here](https://github.com/storj/storj/tree/add-build-status).

Thanks for submitting a PR!

![](https://media.giphy.com/media/14nakW0jC4HA6k/giphy.gif)

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
