### PR TITLE
internal/version: do version check much earlier in process initialization

### DIFF
--- a/bootstrap/peer.go
+++ b/bootstrap/peer.go
@@ -114,11 +114,6 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config, ver
 			config.ExternalAddress = peer.Addr()
 		}
 
-		pbVersion, err := versionService.Info.Proto()
-		if err != nil {
-			return nil, errs.Combine(err, peer.Close())
-		}
-
 		self := pb.Node{
 			Id:   peer.ID(),
 			Type: pb.NodeType_BOOTSTRAP,
@@ -129,7 +124,6 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config, ver
 			Metadata: &pb.NodeMetadata{
 				Wallet: config.Operator.Wallet,
 			},
-			Version: pbVersion,
 		}
 
 		kdb, ndb := peer.DB.RoutingTable()

--- a/bootstrap/peer.go
+++ b/bootstrap/peer.go
@@ -84,22 +84,12 @@ type Peer struct {
 }
 
 // New creates a new Bootstrap Node.
-func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config, versionInfo version.Info) (*Peer, error) {
-	peer := &Peer{
+func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config, versionService *version.Service) (peer *Peer, err error) {
+	peer = &Peer{
 		Log:      log,
 		Identity: full,
 		DB:       db,
-	}
-
-	var err error
-
-	{
-		test := version.Info{}
-		if test != versionInfo {
-			peer.Log.Sugar().Debugf("Binary Version: %s with CommitHash %s, built at %s as Release %v",
-				versionInfo.Version.String(), versionInfo.CommitHash, versionInfo.Timestamp.String(), versionInfo.Release)
-			peer.Version = version.NewService(config.Version, versionInfo, "Bootstrap")
-		}
+		Version:  versionService,
 	}
 
 	{ // setup listener and server
@@ -124,6 +114,11 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config, ver
 			config.ExternalAddress = peer.Addr()
 		}
 
+		pbVersion, err := versionService.Info.Proto()
+		if err != nil {
+			return nil, errs.Combine(err, peer.Close())
+		}
+
 		self := pb.Node{
 			Id:   peer.ID(),
 			Type: pb.NodeType_BOOTSTRAP,
@@ -134,6 +129,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config, ver
 			Metadata: &pb.NodeMetadata{
 				Wallet: config.Operator.Wallet,
 			},
+			Version: pbVersion,
 		}
 
 		kdb, ndb := peer.DB.RoutingTable()
@@ -189,10 +185,7 @@ func (peer *Peer) Run(ctx context.Context) error {
 	group, ctx := errgroup.WithContext(ctx)
 
 	group.Go(func() error {
-		if peer.Version != nil {
-			return ignoreCancel(peer.Version.Run(ctx))
-		}
-		return nil
+		return ignoreCancel(peer.Version.Run(ctx))
 	})
 	group.Go(func() error {
 		return ignoreCancel(peer.Kademlia.Service.Bootstrap(ctx))

--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -75,7 +75,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	versionService, err := version.NewService(ctx, log, runCfg.Version, version.Build, "Bootstrap")
+	versionService, err := version.NewServiceWithVersionCheck(ctx, log, runCfg.Version, version.Build, "Bootstrap")
 	if err != nil {
 		return err
 	}

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -115,7 +115,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 		zap.S().Fatal(err)
 	}
 
-	versionService, err := version.NewService(ctx, log, runCfg.Config.Version, version.Build, "Satellite")
+	versionService, err := version.NewServiceWithVersionCheck(ctx, log, runCfg.Config.Version, version.Build, "Satellite")
 	if err != nil {
 		return err
 	}

--- a/cmd/storagenode/main.go
+++ b/cmd/storagenode/main.go
@@ -129,7 +129,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	versionService, err := version.NewService(ctx, log, runCfg.Config.Version, version.Build, "Storagenode")
+	versionService, err := version.NewServiceWithVersionCheck(ctx, log, runCfg.Config.Version, version.Build, "Storagenode")
 	if err != nil {
 		return err
 	}

--- a/internal/testplanet/planet.go
+++ b/internal/testplanet/planet.go
@@ -489,10 +489,7 @@ func (planet *Planet) newSatellites(count int) ([]*satellite.Peer, error) {
 		config.Console.StaticDir = filepath.Join(storjRoot, "web/satellite")
 		config.Mail.TemplatePath = filepath.Join(storjRoot, "web/satellite/static/emails")
 
-		versionService, err := version.NewService(context.TODO(), log, config.Version, planet.NewVersionInfo(), "Satellite")
-		if err != nil {
-			return xs, err
-		}
+		versionService := version.NewService(log, config.Version, planet.NewVersionInfo(), "Satellite")
 
 		peer, err := satellite.New(log, identity, db, &config, versionService)
 		if err != nil {
@@ -593,10 +590,7 @@ func (planet *Planet) newStorageNodes(count int, whitelistedSatelliteIDs []strin
 			planet.config.Reconfigure.StorageNode(i, &config)
 		}
 
-		versionService, err := version.NewService(context.TODO(), log, config.Version, planet.NewVersionInfo(), "Storagenode")
-		if err != nil {
-			return xs, err
-		}
+		versionService := version.NewService(log, config.Version, planet.NewVersionInfo(), "Storagenode")
 
 		peer, err := storagenode.New(log, identity, db, config, versionService)
 		if err != nil {
@@ -676,10 +670,7 @@ func (planet *Planet) newBootstrap() (peer *bootstrap.Peer, err error) {
 		planet.config.Reconfigure.Bootstrap(0, &config)
 	}
 
-	versionService, err := version.NewService(context.TODO(), log, config.Version, planet.NewVersionInfo(), "Bootstrap")
-	if err != nil {
-		return nil, err
-	}
+	versionService := version.NewService(log, config.Version, planet.NewVersionInfo(), "Bootstrap")
 
 	peer, err = bootstrap.New(log, identity, db, config, versionService)
 	if err != nil {

--- a/internal/testplanet/planet.go
+++ b/internal/testplanet/planet.go
@@ -489,9 +489,12 @@ func (planet *Planet) newSatellites(count int) ([]*satellite.Peer, error) {
 		config.Console.StaticDir = filepath.Join(storjRoot, "web/satellite")
 		config.Mail.TemplatePath = filepath.Join(storjRoot, "web/satellite/static/emails")
 
-		verInfo := planet.NewVersionInfo()
+		versionService, err := version.NewService(context.TODO(), log, config.Version, planet.NewVersionInfo(), "Satellite")
+		if err != nil {
+			return xs, err
+		}
 
-		peer, err := satellite.New(log, identity, db, &config, verInfo)
+		peer, err := satellite.New(log, identity, db, &config, versionService)
 		if err != nil {
 			return xs, err
 		}
@@ -590,9 +593,12 @@ func (planet *Planet) newStorageNodes(count int, whitelistedSatelliteIDs []strin
 			planet.config.Reconfigure.StorageNode(i, &config)
 		}
 
-		verInfo := planet.NewVersionInfo()
+		versionService, err := version.NewService(context.TODO(), log, config.Version, planet.NewVersionInfo(), "Storagenode")
+		if err != nil {
+			return xs, err
+		}
 
-		peer, err := storagenode.New(log, identity, db, config, verInfo)
+		peer, err := storagenode.New(log, identity, db, config, versionService)
 		if err != nil {
 			return xs, err
 		}
@@ -670,10 +676,12 @@ func (planet *Planet) newBootstrap() (peer *bootstrap.Peer, err error) {
 		planet.config.Reconfigure.Bootstrap(0, &config)
 	}
 
-	var verInfo version.Info
-	verInfo = planet.NewVersionInfo()
+	versionService, err := version.NewService(context.TODO(), log, config.Version, planet.NewVersionInfo(), "Bootstrap")
+	if err != nil {
+		return nil, err
+	}
 
-	peer, err = bootstrap.New(log, identity, db, config, verInfo)
+	peer, err = bootstrap.New(log, identity, db, config, versionService)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/version/service.go
+++ b/internal/version/service.go
@@ -39,7 +39,7 @@ type Service struct {
 	allowed bool
 }
 
-// NewService creates a Version Check Client with default configuration, or returns (nil, nil) if version checking is disabled
+// NewService creates a Version Check Client with provided configuration and runs one check, returning an error if the version is out of date.
 func NewService(ctx context.Context, log *zap.Logger, config Config, info Info, service string) (*Service, error) {
 	log.Sugar().Debugf("Binary Version: %s with CommitHash %s, built at %s as Release %v",
 		info.Version.String(), info.CommitHash, info.Timestamp.String(), info.Release)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -110,6 +110,9 @@ func (v Info) Marshal() (data []byte, err error) {
 	return
 }
 
+// Proto converts an Info struct to a pb.NodeVersion
+// TODO: shouldn't we just use pb.NodeVersion everywhere? gogoproto will let
+// us make it match Info.
 func (v Info) Proto() (*pb.NodeVersion, error) {
 	pbts, err := ptypes.TimestampProto(v.Timestamp)
 	if err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -12,10 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	monkit "gopkg.in/spacemonkeygo/monkit.v2"
-
-	"storj.io/storj/pkg/pb"
 )
 
 var (
@@ -108,22 +105,6 @@ func New(data []byte) (v Info, err error) {
 func (v Info) Marshal() (data []byte, err error) {
 	data, err = json.Marshal(v)
 	return
-}
-
-// Proto converts an Info struct to a pb.NodeVersion
-// TODO: shouldn't we just use pb.NodeVersion everywhere? gogoproto will let
-// us make it match Info.
-func (v Info) Proto() (*pb.NodeVersion, error) {
-	pbts, err := ptypes.TimestampProto(v.Timestamp)
-	if err != nil {
-		return nil, err
-	}
-	return &pb.NodeVersion{
-		Version:    v.Version.String(),
-		CommitHash: v.CommitHash,
-		Timestamp:  pbts,
-		Release:    v.Release,
-	}, nil
 }
 
 // containsVersion compares the allowed version array against the passed version

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -12,7 +12,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
 	monkit "gopkg.in/spacemonkeygo/monkit.v2"
+
+	"storj.io/storj/pkg/pb"
 )
 
 var (
@@ -105,6 +108,19 @@ func New(data []byte) (v Info, err error) {
 func (v Info) Marshal() (data []byte, err error) {
 	data, err = json.Marshal(v)
 	return
+}
+
+func (v Info) Proto() (*pb.NodeVersion, error) {
+	pbts, err := ptypes.TimestampProto(v.Timestamp)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.NodeVersion{
+		Version:    v.Version.String(),
+		CommitHash: v.CommitHash,
+		Timestamp:  pbts,
+		Release:    v.Release,
+	}, nil
 }
 
 // containsVersion compares the allowed version array against the passed version

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -243,11 +243,6 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config *Config, ve
 			config.ExternalAddress = peer.Addr()
 		}
 
-		pbVersion, err := versionService.Info.Proto()
-		if err != nil {
-			return nil, errs.Combine(err, peer.Close())
-		}
-
 		self := pb.Node{
 			Id:   peer.ID(),
 			Type: pb.NodeType_SATELLITE,
@@ -257,7 +252,6 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config *Config, ve
 			Metadata: &pb.NodeMetadata{
 				Wallet: config.Operator.Wallet,
 			},
-			Version: pbVersion,
 		}
 
 		{ // setup routing table

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -138,11 +138,6 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config, ver
 			config.ExternalAddress = peer.Addr()
 		}
 
-		pbVersion, err := versionService.Info.Proto()
-		if err != nil {
-			return nil, errs.Combine(err, peer.Close())
-		}
-
 		self := pb.Node{
 			Id:   peer.ID(),
 			Type: pb.NodeType_STORAGE,
@@ -153,7 +148,6 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config, ver
 			Metadata: &pb.NodeMetadata{
 				Wallet: config.Operator.Wallet,
 			},
-			Version: pbVersion,
 		}
 
 		kdb, ndb := peer.DB.RoutingTable()


### PR DESCRIPTION
The combination of the version service with the peer services is becoming very messy. One of the primary goals of the version service is to prevent a binary from starting if it is out of date, but as it currently stands, the version check does not start until lots of other services start in parallel. This is going to be a huge foot gun and is very racy.

This change makes the version check be one of the very first things release-build processes do (and only release-build processes) before starting anything else.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
