### PR TITLE
Use go 1.12.1 for compiling in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.11.x
+go: 1.12.x
 
 go_import_path: "storj.io/storj"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.12.x
+go: 1.12.1
 
 go_import_path: "storj.io/storj"
 


### PR DESCRIPTION
go 1.12.2 and go 1.11.7 seem to be having issues with compilation so use the previous version