### PR TITLE
convert times to UTC before entering as utimestamp

### DIFF
--- a/pkg/accounting/projectusage_test.go
+++ b/pkg/accounting/projectusage_test.go
@@ -111,7 +111,7 @@ func TestProjectUsageBandwidth(t *testing.T) {
 
 				// Setup: create a BucketBandwidthRollup record to test exceeding bandwidth project limit
 				if tt.expectedResource == "bandwidth" {
-					now := time.Now()
+					now := time.Now().UTC()
 					err := setUpBucketBandwidthAllocations(ctx, projectID, orderDB, now)
 					require.NoError(t, err)
 				}

--- a/pkg/accounting/rollup/rollup.go
+++ b/pkg/accounting/rollup/rollup.go
@@ -136,7 +136,7 @@ func (r *Service) RollupStorage(ctx context.Context, lastRollup time.Time, rollu
 // RollupBW aggregates the bandwidth rollups, modifies rollupStats map
 func (r *Service) RollupBW(ctx context.Context, lastRollup time.Time, rollupStats accounting.RollupStats) error {
 	var latestTally time.Time
-	bws, err := r.db.GetStoragenodeBandwidthSince(ctx, lastRollup)
+	bws, err := r.db.GetStoragenodeBandwidthSince(ctx, lastRollup.UTC())
 	if err != nil {
 		return Error.Wrap(err)
 	}

--- a/pkg/accounting/tally/tally.go
+++ b/pkg/accounting/tally/tally.go
@@ -194,7 +194,7 @@ func (t *Service) CalculateAtRestData(ctx context.Context) (latestTally time.Tim
 	if latestTally.IsZero() {
 		numHours = 1.0 //todo: something more considered?
 	}
-	latestTally = time.Now()
+	latestTally = time.Now().UTC()
 	for k := range nodeData {
 		nodeData[k] *= numHours //calculate byte hours
 	}

--- a/satellite/orders/endpoint.go
+++ b/satellite/orders/endpoint.go
@@ -185,7 +185,7 @@ func (endpoint *Endpoint) Settlement(stream pb.Orders_SettlementServer) (err err
 			}
 			continue
 		}
-		now := time.Now()
+		now := time.Now().UTC()
 		intervalStart := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), 0, 0, 0, now.Location())
 
 		if err := endpoint.DB.UpdateBucketBandwidthSettle(ctx, bucketID, orderLimit.Action, order.Amount, intervalStart); err != nil {

--- a/satellite/orders/orders_test.go
+++ b/satellite/orders/orders_test.go
@@ -110,7 +110,7 @@ func TestUploadDownloadBandwidth(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 6, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		hourBeforeTest := time.Now().Add(-time.Hour)
+		hourBeforeTest := time.Now().UTC().Add(-time.Hour)
 
 		for _, storageNode := range planet.StorageNodes {
 			storageNode.Storage2.Sender.Loop.Pause()
@@ -150,12 +150,12 @@ func TestUploadDownloadBandwidth(t *testing.T) {
 		ordersDB := planet.Satellites[0].DB.Orders()
 		bucketID := storj.JoinPaths(projects[0].ID.String(), "testbucket")
 
-		bucketBandwidth, err := ordersDB.GetBucketBandwidth(ctx, []byte(bucketID), hourBeforeTest, time.Now())
+		bucketBandwidth, err := ordersDB.GetBucketBandwidth(ctx, []byte(bucketID), hourBeforeTest, time.Now().UTC())
 		require.NoError(t, err)
 		require.Equal(t, expectedBucketBandwidth, bucketBandwidth)
 
 		for _, storageNode := range planet.StorageNodes {
-			nodeBandwidth, err := ordersDB.GetStorageNodeBandwidth(ctx, storageNode.ID(), hourBeforeTest, time.Now())
+			nodeBandwidth, err := ordersDB.GetStorageNodeBandwidth(ctx, storageNode.ID(), hourBeforeTest, time.Now().UTC())
 			require.NoError(t, err)
 			require.Equal(t, expectedStorageBandwidth[storageNode.ID()], nodeBandwidth)
 		}

--- a/satellite/orders/service.go
+++ b/satellite/orders/service.go
@@ -77,7 +77,7 @@ func (service *Service) updateBandwidth(ctx context.Context, bucketID []byte, ad
 			action = orderLimit.Action
 		}
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	intervalStart := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), 0, 0, 0, now.Location())
 
 	if err := service.orders.UpdateBucketBandwidthAllocation(ctx, bucketID, action, bucketAllocation, intervalStart); err != nil {
@@ -97,7 +97,7 @@ func (service *Service) CreateGetOrderLimits(ctx context.Context, uplink *identi
 	expiration := pointer.ExpirationDate
 
 	// convert orderExpiration from duration to timestamp
-	orderExpirationTime := time.Now().Add(service.orderExpiration)
+	orderExpirationTime := time.Now().UTC().Add(service.orderExpiration)
 	orderExpiration, err := ptypes.TimestampProto(orderExpirationTime)
 	if err != nil {
 		return nil, Error.Wrap(err)
@@ -181,7 +181,7 @@ func (service *Service) CreateGetOrderLimits(ctx context.Context, uplink *identi
 // CreatePutOrderLimits creates the order limits for uploading pieces to nodes.
 func (service *Service) CreatePutOrderLimits(ctx context.Context, uplink *identity.PeerIdentity, bucketID []byte, nodes []*pb.Node, expiration *timestamp.Timestamp, maxPieceSize int64) (_ storj.PieceID, _ []*pb.AddressedOrderLimit, err error) {
 	// convert orderExpiration from duration to timestamp
-	orderExpirationTime := time.Now().Add(service.orderExpiration)
+	orderExpirationTime := time.Now().UTC().Add(service.orderExpiration)
 	orderExpiration, err := ptypes.TimestampProto(orderExpirationTime)
 	if err != nil {
 		return storj.PieceID{}, nil, Error.Wrap(err)
@@ -241,7 +241,7 @@ func (service *Service) CreateDeleteOrderLimits(ctx context.Context, uplink *ide
 	expiration := pointer.ExpirationDate
 
 	// convert orderExpiration from duration to timestamp
-	orderExpirationTime := time.Now().Add(service.orderExpiration)
+	orderExpirationTime := time.Now().UTC().Add(service.orderExpiration)
 	orderExpiration, err := ptypes.TimestampProto(orderExpirationTime)
 	if err != nil {
 		return nil, Error.Wrap(err)
@@ -320,7 +320,7 @@ func (service *Service) CreateAuditOrderLimits(ctx context.Context, auditor *ide
 	expiration := pointer.ExpirationDate
 
 	// convert orderExpiration from duration to timestamp
-	orderExpirationTime := time.Now().Add(service.orderExpiration)
+	orderExpirationTime := time.Now().UTC().Add(service.orderExpiration)
 	orderExpiration, err := ptypes.TimestampProto(orderExpirationTime)
 	if err != nil {
 		return nil, Error.Wrap(err)
@@ -403,7 +403,7 @@ func (service *Service) CreateGetRepairOrderLimits(ctx context.Context, repairer
 	expiration := pointer.ExpirationDate
 
 	// convert orderExpiration from duration to timestamp
-	orderExpirationTime := time.Now().Add(service.orderExpiration)
+	orderExpirationTime := time.Now().UTC().Add(service.orderExpiration)
 	orderExpiration, err := ptypes.TimestampProto(orderExpirationTime)
 	if err != nil {
 		return nil, Error.Wrap(err)
@@ -486,7 +486,7 @@ func (service *Service) CreatePutRepairOrderLimits(ctx context.Context, repairer
 	expiration := pointer.ExpirationDate
 
 	// convert orderExpiration from duration to timestamp
-	orderExpirationTime := time.Now().Add(service.orderExpiration)
+	orderExpirationTime := time.Now().UTC().Add(service.orderExpiration)
 	orderExpiration, err := ptypes.TimestampProto(orderExpirationTime)
 	if err != nil {
 		return nil, Error.Wrap(err)
@@ -548,7 +548,7 @@ func (service *Service) CreatePutRepairOrderLimits(ctx context.Context, repairer
 
 // UpdateGetInlineOrder updates amount of inline GET bandwidth for given bucket
 func (service *Service) UpdateGetInlineOrder(ctx context.Context, bucketID []byte, amount int64) (err error) {
-	now := time.Now()
+	now := time.Now().UTC()
 	intervalStart := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), 0, 0, 0, now.Location())
 
 	return service.orders.UpdateBucketBandwidthInline(ctx, bucketID, pb.PieceAction_GET, amount, intervalStart)
@@ -556,7 +556,7 @@ func (service *Service) UpdateGetInlineOrder(ctx context.Context, bucketID []byt
 
 // UpdatePutInlineOrder updates amount of inline PUT bandwidth for given bucket
 func (service *Service) UpdatePutInlineOrder(ctx context.Context, bucketID []byte, amount int64) (err error) {
-	now := time.Now()
+	now := time.Now().UTC()
 	intervalStart := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), 0, 0, 0, now.Location())
 
 	return service.orders.UpdateBucketBandwidthInline(ctx, bucketID, pb.PieceAction_PUT, amount, intervalStart)

--- a/satellite/satellitedb/orders_test.go
+++ b/satellite/satellitedb/orders_test.go
@@ -24,7 +24,7 @@ func TestSerialNumbers(t *testing.T) {
 		ordersDB := db.Orders()
 
 		expectedBucket := []byte("bucketID")
-		err := ordersDB.CreateSerialInfo(ctx, storj.SerialNumber{1}, expectedBucket, time.Now())
+		err := ordersDB.CreateSerialInfo(ctx, storj.SerialNumber{1}, expectedBucket, time.Now().UTC())
 		require.NoError(t, err)
 
 		bucketID, err := ordersDB.UseSerialNumber(ctx, storj.SerialNumber{1}, storj.NodeID{1})


### PR DESCRIPTION
This PR addresses the places where we do not convert time to UTC before entering it as a utimestamp in the DB

according to dbx documentation 

> utimestamp (timestamp with no timezone. expected to be in UTC)

![](https://media.giphy.com/media/14nakW0jC4HA6k/giphy.gif)

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
