### PR TITLE
no longer includes totalUsedSpaceOld when calculating storagenode used space

### DIFF
--- a/storagenode/inspector/inspector.go
+++ b/storagenode/inspector/inspector.go
@@ -61,11 +61,6 @@ func (inspector *Endpoint) retrieveStats(ctx context.Context) (*pb.StatSummaryRe
 	if err != nil {
 		return nil, err
 	}
-	totalUsedSpaceOld, err := inspector.psdbDB.SumTTLSizes()
-	if err != nil {
-		return nil, err
-	}
-	totalUsedSpace += totalUsedSpaceOld
 
 	// Bandwidth Usage
 	usage, err := inspector.usageDB.Summary(ctx, getBeginningOfMonth(), time.Now())


### PR DESCRIPTION
Why:
- storagenode dashboard displayed old disk space for now obsolete pieces (they were deleted during migration)

What:
- We're no longer summing old used space with the new used space. The storagenode dashboard will now only show new used space.


## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
