### PR TITLE
adds log for share download time in audit service

### DIFF
--- a/pkg/audit/verifier.go
+++ b/pkg/audit/verifier.go
@@ -166,6 +166,11 @@ func (d *defaultDownloader) getShare(ctx context.Context, limit *pb.AddressedOrd
 
 	bandwidthMsgSize := shareSize
 
+	start := time.Now()
+	defer func() {
+		d.log.Debug("share download", zap.Stringer("time", time.Since(start)))
+	}()
+
 	// determines number of seconds allotted for receiving data from a storage node
 	timedCtx := ctx
 	if d.minBytesPerSecond > 0 {

--- a/pkg/audit/verifier.go
+++ b/pkg/audit/verifier.go
@@ -168,7 +168,7 @@ func (d *defaultDownloader) getShare(ctx context.Context, limit *pb.AddressedOrd
 
 	start := time.Now()
 	defer func() {
-		d.log.Debug("share download", zap.Stringer("time", time.Since(start)))
+		d.log.Debug("getShare start", zap.Stringer("time", time.Since(start)))
 	}()
 
 	// determines number of seconds allotted for receiving data from a storage node
@@ -179,7 +179,8 @@ func (d *defaultDownloader) getShare(ctx context.Context, limit *pb.AddressedOrd
 			maxTransferTime = 5 * time.Second
 		}
 		var cancel func()
-		timedCtx, cancel = context.WithTimeout(ctx, maxTransferTime)
+		d.log.Debug("new max transfer time", zap.Stringer("time", maxTransferTime*10))
+		timedCtx, cancel = context.WithTimeout(ctx, maxTransferTime*10)
 		defer cancel()
 	}
 
@@ -207,6 +208,11 @@ func (d *defaultDownloader) getShare(ctx context.Context, limit *pb.AddressedOrd
 	}()
 
 	offset := int64(shareSize) * stripeIndex
+
+	downloadStart := time.Now()
+	defer func() {
+		d.log.Debug("share download start", zap.Stringer("time", time.Since(downloadStart)))
+	}()
 
 	downloader, err := ps.Download(timedCtx, limit.GetLimit(), offset, int64(shareSize))
 	if err != nil {

--- a/pkg/audit/verifier.go
+++ b/pkg/audit/verifier.go
@@ -164,12 +164,12 @@ func (d *defaultDownloader) DownloadShares(ctx context.Context, limits []*pb.Add
 func (d *defaultDownloader) getShare(ctx context.Context, limit *pb.AddressedOrderLimit, stripeIndex int64, shareSize int32, pieceNum int) (share Share, err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	bandwidthMsgSize := shareSize
-
 	start := time.Now()
 	defer func() {
-		d.log.Debug("getShare start", zap.Stringer("time", time.Since(start)))
+		d.log.Debug("enter getShare func", zap.Stringer("time", time.Since(start)))
 	}()
+
+	bandwidthMsgSize := shareSize
 
 	// determines number of seconds allotted for receiving data from a storage node
 	timedCtx := ctx


### PR DESCRIPTION
Why:
- In the audit service, we don't know how long the download actually takes to start, or if we're definitely allotting enough time for the download to happen.

What:
- This adds logging to see when the getShare function is entered, when the actual share download starts, and what the maxTransferTime is.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
