### PR TITLE
Make tracked branch feature work with multi-arch manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,43 +220,16 @@ deploy: ## Update Kubernetes deployments in staging (jenkins)
 push-images: ## Push Docker images to Docker Hub (jenkins)
 	# images have to be pushed before a manifest can be created
 	# satellite
-	docker push storjlabs/satellite:${TAG}${CUSTOMTAG}-amd64
-	docker push storjlabs/satellite:${TAG}${CUSTOMTAG}-arm32v6
-	docker manifest create storjlabs/satellite:${TAG}${CUSTOMTAG} storjlabs/satellite:${TAG}${CUSTOMTAG}-amd64 storjlabs/satellite:${TAG}${CUSTOMTAG}-arm32v6
-	docker manifest annotate storjlabs/satellite:${TAG}${CUSTOMTAG} storjlabs/satellite:${TAG}${CUSTOMTAG}-amd64 --os linux --arch amd64
-	docker manifest annotate storjlabs/satellite:${TAG}${CUSTOMTAG} storjlabs/satellite:${TAG}${CUSTOMTAG}-arm32v6 --os linux --arch arm --variant arm32v6
-	docker manifest push storjlabs/satellite:${TAG}${CUSTOMTAG}
-	# storagenode
-	docker push storjlabs/storagenode:${TAG}${CUSTOMTAG}-amd64
-	docker push storjlabs/storagenode:${TAG}${CUSTOMTAG}-arm32v6
-	docker manifest create storjlabs/storagenode:${TAG}${CUSTOMTAG} storjlabs/storagenode:${TAG}${CUSTOMTAG}-amd64 storjlabs/storagenode:${TAG}${CUSTOMTAG}-arm32v6
-	docker manifest annotate storjlabs/storagenode:${TAG}${CUSTOMTAG} storjlabs/storagenode:${TAG}${CUSTOMTAG}-amd64 --os linux --arch amd64
-	docker manifest annotate storjlabs/storagenode:${TAG}${CUSTOMTAG} storjlabs/storagenode:${TAG}${CUSTOMTAG}-arm32v6 --os linux --arch arm --variant arm32v6
-	docker manifest push storjlabs/storagenode:${TAG}${CUSTOMTAG}
-	# uplink
-	docker push storjlabs/uplink:${TAG}${CUSTOMTAG}-amd64
-	docker push storjlabs/uplink:${TAG}${CUSTOMTAG}-arm32v6
-	docker manifest create storjlabs/uplink:${TAG}${CUSTOMTAG} storjlabs/uplink:${TAG}${CUSTOMTAG}-amd64 storjlabs/uplink:${TAG}${CUSTOMTAG}-arm32v6
-	docker manifest annotate storjlabs/uplink:${TAG}${CUSTOMTAG} storjlabs/uplink:${TAG}${CUSTOMTAG}-amd64 --os linux --arch amd64
-	docker manifest annotate storjlabs/uplink:${TAG}${CUSTOMTAG} storjlabs/uplink:${TAG}${CUSTOMTAG}-arm32v6 --os linux --arch arm --variant arm32v6
-	docker manifest push storjlabs/uplink:${TAG}${CUSTOMTAG}
-	# gateway
-	docker push storjlabs/gateway:${TAG}${CUSTOMTAG}-amd64
-	docker push storjlabs/gateway:${TAG}${CUSTOMTAG}-arm32v6
-	docker manifest create storjlabs/gateway:${TAG}${CUSTOMTAG} storjlabs/gateway:${TAG}${CUSTOMTAG}-amd64 storjlabs/gateway:${TAG}${CUSTOMTAG}-arm32v6
-	docker manifest annotate storjlabs/gateway:${TAG}${CUSTOMTAG} storjlabs/gateway:${TAG}${CUSTOMTAG}-amd64 --os linux --arch amd64
-	docker manifest annotate storjlabs/gateway:${TAG}${CUSTOMTAG} storjlabs/gateway:${TAG}${CUSTOMTAG}-arm32v6 --os linux --arch arm --variant arm32v6
-	docker manifest push storjlabs/gateway:${TAG}${CUSTOMTAG}
-ifeq (${TRACKED_BRANCH},true)
-	docker tag storjlabs/satellite:${TAG}${CUSTOMTAG} storjlabs/satellite:${LATEST_TAG}
-	docker push storjlabs/satellite:${LATEST_TAG}
-	docker tag storjlabs/storagenode:${TAG}${CUSTOMTAG} storjlabs/storagenode:${LATEST_TAG}
-	docker push storjlabs/storagenode:${LATEST_TAG}
-	docker tag storjlabs/uplink:${TAG}${CUSTOMTAG} storjlabs/uplink:${LATEST_TAG}
-	docker push storjlabs/uplink:${LATEST_TAG}
-	docker tag storjlabs/gateway:${TAG}${CUSTOMTAG} storjlabs/gateway:${LATEST_TAG}
-	docker push storjlabs/gateway:${LATEST_TAG}
-endif
+	for c in satellite storagenode uplink gateway; do \
+		docker push storjlabs/satellite:${TAG}${CUSTOMTAG}-amd64 \
+		&& docker push storjlabs/satellite:${TAG}${CUSTOMTAG}-arm32v6 \
+		&& for t in ${TAG}${CUSTOMTAG} ${LATEST_TAG}; do \
+			docker manifest create storjlabs/$$c:$$t storjlabs/$$c:$$t-amd64 storjlabs/$$c:$$t-arm32v6 \
+			&& docker manifest annotate storjlabs/$$c:$$t storjlabs/$$c:$$t-amd64 --os linux --arch amd64 \
+			&& docker manifest annotate storjlabs/$$c:$$t storjlabs/$$c:$$t-arm32v6 --os linux --arch arm --variant arm32v6 \
+			&& docker manifest push --purge storjlabs/$$c:$$t \
+		; done \
+	; done
 
 .PHONY: binaries-upload
 binaries-upload: ## Upload binaries to Google Storage (jenkins)
@@ -273,19 +246,11 @@ binaries-clean: ## Remove all local release binaries (jenkins)
 	rm -rf release
 
 .PHONY: clean-images
-ifeq (${TRACKED_BRANCH},true)
-clean-images: ## Remove Docker images from local engine
-	-docker rmi storjlabs/gateway:${TAG}${CUSTOMTAG} storjlabs/gateway:${LATEST_TAG}
-	-docker rmi storjlabs/satellite:${TAG}${CUSTOMTAG} storjlabs/satellite:${LATEST_TAG}
-	-docker rmi storjlabs/storagenode:${TAG}${CUSTOMTAG} storjlabs/storagenode:${LATEST_TAG}
-	-docker rmi storjlabs/uplink:${TAG}${CUSTOMTAG} storjlabs/uplink:${LATEST_TAG}
-else
 clean-images:
 	-docker rmi storjlabs/gateway:${TAG}${CUSTOMTAG}
 	-docker rmi storjlabs/satellite:${TAG}${CUSTOMTAG}
 	-docker rmi storjlabs/storagenode:${TAG}${CUSTOMTAG}
 	-docker rmi storjlabs/uplink:${TAG}${CUSTOMTAG}
-endif
 
 .PHONY: test-docker-clean
 test-docker-clean: ## Clean up Docker environment used in test-docker target


### PR DESCRIPTION
This should make the `push-images` target complete successfully and push binaries to GCS again.