### PR TITLE
libuplink: remove encryption key from project opening

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -240,17 +240,20 @@ func (flags GatewayFlags) NewGateway(ctx context.Context, ident *identity.FullId
 		return nil, err
 	}
 
-	encKey := new(storj.Key)
+	var encKey storj.Key
 	copy(encKey[:], flags.Enc.Key)
 
-	project, err := uplink.OpenProject(ctx, flags.Client.SatelliteAddr, encKey, apiKey)
+	var opts libuplink.ProjectOptions
+	opts.Volatile.EncryptionKey = encKey
+
+	project, err := uplink.OpenProject(ctx, flags.Client.SatelliteAddr, apiKey, &opts)
 	if err != nil {
 		return nil, err
 	}
 
 	return miniogw.NewStorjGateway(
 		project,
-		encKey,
+		&encKey,
 		storj.Cipher(flags.Enc.PathType).ToCipherSuite(),
 		flags.GetEncryptionScheme().ToEncryptionParameters(),
 		flags.GetRedundancyScheme(),

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -240,8 +240,8 @@ func (flags GatewayFlags) NewGateway(ctx context.Context, ident *identity.FullId
 		return nil, err
 	}
 
-	var encKey storj.Key
-	copy(encKey[:], flags.Enc.Key)
+	encKey := new(storj.Key)
+	copy((*encKey)[:], flags.Enc.Key)
 
 	var opts libuplink.ProjectOptions
 	opts.Volatile.EncryptionKey = encKey
@@ -253,7 +253,7 @@ func (flags GatewayFlags) NewGateway(ctx context.Context, ident *identity.FullId
 
 	return miniogw.NewStorjGateway(
 		project,
-		&encKey,
+		encKey,
 		storj.Cipher(flags.Enc.PathType).ToCipherSuite(),
 		flags.GetEncryptionScheme().ToEncryptionParameters(),
 		flags.GetRedundancyScheme(),

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -241,7 +241,7 @@ func (flags GatewayFlags) NewGateway(ctx context.Context, ident *identity.FullId
 	}
 
 	encKey := new(storj.Key)
-	copy((*encKey)[:], flags.Enc.Key)
+	copy(encKey[:], flags.Enc.Key)
 
 	var opts libuplink.ProjectOptions
 	opts.Volatile.EncryptionKey = encKey

--- a/lib/uplink/bucket_attrs_test.go
+++ b/lib/uplink/bucket_attrs_test.go
@@ -57,7 +57,7 @@ func testPlanetWithLibUplink(t *testing.T, cfg testConfig, encKey *storj.Key,
 	}
 	defer ctx.Check(uplink.Close)
 	var projectOptions ProjectOptions
-	projectOptions.Volatile.EncryptionKey = *encKey
+	projectOptions.Volatile.EncryptionKey = encKey
 	proj, err := uplink.OpenProject(ctx, satellite.Addr(), apiKey, &projectOptions)
 	if err != nil {
 		t.Fatalf("could not open project from libuplink under testplanet: %v", err)

--- a/lib/uplink/bucket_attrs_test.go
+++ b/lib/uplink/bucket_attrs_test.go
@@ -56,7 +56,9 @@ func testPlanetWithLibUplink(t *testing.T, cfg testConfig, encKey *storj.Key,
 		t.Fatalf("could not create new Uplink object: %v", err)
 	}
 	defer ctx.Check(uplink.Close)
-	proj, err := uplink.OpenProject(ctx, satellite.Addr(), encKey, apiKey)
+	var projectOptions ProjectOptions
+	projectOptions.Volatile.EncryptionKey = *encKey
+	proj, err := uplink.OpenProject(ctx, satellite.Addr(), apiKey, &projectOptions)
 	if err != nil {
 		t.Fatalf("could not open project from libuplink under testplanet: %v", err)
 	}

--- a/pkg/miniogw/gateway_test.go
+++ b/pkg/miniogw/gateway_test.go
@@ -729,7 +729,7 @@ func initEnv(ctx context.Context, planet *testplanet.Planet) (minio.ObjectLayer,
 	}
 
 	var projectOptions libuplink.ProjectOptions
-	projectOptions.Volatile.EncryptionKey = *encKey
+	projectOptions.Volatile.EncryptionKey = encKey
 	proj, err := uplink.OpenProject(ctx, planet.Satellites[0].Addr(), parsedAPIKey, &projectOptions)
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/miniogw/gateway_test.go
+++ b/pkg/miniogw/gateway_test.go
@@ -728,7 +728,9 @@ func initEnv(ctx context.Context, planet *testplanet.Planet) (minio.ObjectLayer,
 		return nil, nil, nil, err
 	}
 
-	proj, err := uplink.OpenProject(ctx, planet.Satellites[0].Addr(), encKey, parsedAPIKey)
+	var projectOptions libuplink.ProjectOptions
+	projectOptions.Volatile.EncryptionKey = *encKey
+	proj, err := uplink.OpenProject(ctx, planet.Satellites[0].Addr(), parsedAPIKey, &projectOptions)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/miniogw/integration_test.go
+++ b/pkg/miniogw/integration_test.go
@@ -194,7 +194,9 @@ func runGateway(ctx context.Context, gwCfg config, uplinkCfg uplink.Config, log 
 	encKey := new(storj.Key)
 	copy(encKey[:], uplinkCfg.Enc.Key)
 
-	project, err := uplink.OpenProject(ctx, uplinkCfg.Client.SatelliteAddr, encKey, apiKey)
+	var projectOptions libuplink.ProjectOptions
+	projectOptions.Volatile.EncryptionKey = *encKey
+	project, err := uplink.OpenProject(ctx, uplinkCfg.Client.SatelliteAddr, apiKey, &projectOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/miniogw/integration_test.go
+++ b/pkg/miniogw/integration_test.go
@@ -195,7 +195,7 @@ func runGateway(ctx context.Context, gwCfg config, uplinkCfg uplink.Config, log 
 	copy(encKey[:], uplinkCfg.Enc.Key)
 
 	var projectOptions libuplink.ProjectOptions
-	projectOptions.Volatile.EncryptionKey = *encKey
+	projectOptions.Volatile.EncryptionKey = encKey
 	project, err := uplink.OpenProject(ctx, uplinkCfg.Client.SatelliteAddr, apiKey, &projectOptions)
 	if err != nil {
 		return err


### PR DESCRIPTION
What: This change moves project-level bucket metadata encryption information to the volatile section, because it is unlikely to remain in future releases

Why: Ultimately, the web user interface will allow bucket management (creation, removal, etc), but not object management as that requires an encryption key for sure and we don't want to have users give the satellite their encryption keys.

At a high level, a (*Project) type should map to all of the things you can do inside the web user interface within a project, which by necessity cannot have an encryption key. So, we really don't want an encryption key in the non-volatile section of this library.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
