### PR TITLE
uplink setup wizard uses default port, checks errors

### DIFF
--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -71,43 +71,75 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 
 	var override map[string]interface{}
 	if !setupCfg.NonInteractive {
-		fmt.Print("Enter your Satellite address: ")
+		_, err = fmt.Print("Enter your Satellite address: ")
+		if err != nil {
+			return err
+		}
 		var satelliteAddress string
-		fmt.Scanln(&satelliteAddress)
+		_, err = fmt.Scanln(&satelliteAddress)
+		if err != nil {
+			return err
+		}
 
 		// TODO add better validation
 		if satelliteAddress == "" {
 			return errs.New("Satellite address cannot be empty")
 		}
 
-		fmt.Print("Enter your API key: ")
+		satelliteAddress, err = ApplyDefaultHostAndPortToAddr(satelliteAddress, cmd.Flags().Lookup("satellite-addr").Value.String())
+		if err != nil {
+			return err
+		}
+
+		_, err = fmt.Print("Enter your API key: ")
+		if err != nil {
+			return err
+		}
 		var apiKey string
-		fmt.Scanln(&apiKey)
+		_, err = fmt.Scanln(&apiKey)
+		if err != nil {
+			return err
+		}
 
 		if apiKey == "" {
 			return errs.New("API key cannot be empty")
 		}
 
-		fmt.Print("Enter your encryption passphrase: ")
+		_, err = fmt.Print("Enter your encryption passphrase: ")
+		if err != nil {
+			return err
+		}
 		encKey, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return err
 		}
-		fmt.Println()
+		_, err = fmt.Println()
+		if err != nil {
+			return err
+		}
 
-		fmt.Print("Enter your encryption passphrase again: ")
+		_, err = fmt.Print("Enter your encryption passphrase again: ")
+		if err != nil {
+			return err
+		}
 		repeatedEncKey, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return err
 		}
-		fmt.Println()
+		_, err = fmt.Println()
+		if err != nil {
+			return err
+		}
 
 		if !bytes.Equal(encKey, repeatedEncKey) {
 			return errs.New("encryption passphrases doesn't match")
 		}
 
 		if len(encKey) == 0 {
-			fmt.Println("Warning: Encryption passphrase is empty!")
+			_, err = fmt.Println("Warning: Encryption passphrase is empty!")
+			if err != nil {
+				return err
+			}
 		}
 
 		override = map[string]interface{}{
@@ -122,49 +154,58 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 
 // ApplyDefaultHostAndPortToAddrFlag applies the default host and/or port if either is missing in the specified flag name.
 func ApplyDefaultHostAndPortToAddrFlag(cmd *cobra.Command, flagName string) error {
-	defaultHost, defaultPort, err := net.SplitHostPort(cmd.Flags().Lookup(flagName).DefValue)
-	if err != nil {
-		return Error.Wrap(err)
-	}
-
 	flag := cmd.Flags().Lookup(flagName)
 	if flag == nil {
 		// No flag found for us to handle.
 		return nil
 	}
-	address := flag.Value.String()
+
+	address, err := ApplyDefaultHostAndPortToAddr(flag.Value.String(), flag.DefValue)
+	if err != nil {
+		return Error.Wrap(err)
+	}
+
+	if flag.Value.String() == address {
+		// Don't trip the flag set bit
+		return nil
+	}
+
+	return Error.Wrap(flag.Value.Set(address))
+}
+
+// ApplyDefaultHostAndPortToAddr applies the default host and/or port if either is missing in the specified address.
+func ApplyDefaultHostAndPortToAddr(address, defaultAddress string) (string, error) {
+	defaultHost, defaultPort, err := net.SplitHostPort(defaultAddress)
+	if err != nil {
+		return "", Error.Wrap(err)
+	}
 
 	addressParts := strings.Split(address, ":")
 	numberOfParts := len(addressParts)
 
-	if numberOfParts > 1 && len(addressParts[0]) > 0 {
+	if numberOfParts > 1 && len(addressParts[0]) > 0 && len(addressParts[1]) > 0 {
 		// address is host:port so skip applying any defaults.
-		return nil
+		return address, nil
 	}
 
 	// We are missing a host:port part. Figure out which part we are missing.
 	indexOfPortSeparator := strings.Index(address, ":")
 	lengthOfFirstPart := len(addressParts[0])
 
-	if indexOfPortSeparator == -1 {
+	if indexOfPortSeparator < 0 {
 		if lengthOfFirstPart == 0 {
 			// address is blank.
-			address = net.JoinHostPort(defaultHost, defaultPort)
-		} else {
-			// address is host
-			address = net.JoinHostPort(addressParts[0], defaultPort)
+			return defaultAddress, nil
 		}
-	} else if indexOfPortSeparator == 0 {
-		// address is :1234
-		address = net.JoinHostPort(defaultHost, addressParts[1])
-	} else if indexOfPortSeparator > 0 {
-		// address is host:
-		address = net.JoinHostPort(defaultPort, addressParts[0])
+		// address is host
+		return net.JoinHostPort(addressParts[0], defaultPort), nil
 	}
 
-	err = flag.Value.Set(address)
-	if err != nil {
-		return Error.Wrap(err)
+	if indexOfPortSeparator == 0 {
+		// address is :1234
+		return net.JoinHostPort(defaultHost, addressParts[1]), nil
 	}
-	return nil
+
+	// address is host:
+	return net.JoinHostPort(addressParts[0], defaultPort), nil
 }

--- a/cmd/uplink/cmd/setup_test.go
+++ b/cmd/uplink/cmd/setup_test.go
@@ -43,13 +43,13 @@ func TestDefaultPortAppliedToSatelliteAddrWithNoPort(t *testing.T) {
 	defaultValue := "localhost:7777"
 	setupCmd.Flags().String(flagName, defaultValue, "")
 
-	err := setupCmd.Flags().Set(flagName, "localhost")
+	err := setupCmd.Flags().Set(flagName, "ahost")
 	assert.NoError(t, err)
 
 	err = cmd.ApplyDefaultHostAndPortToAddrFlag(setupCmd, flagName)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "localhost:7777", setupCmd.Flags().Lookup("satellite-addr").Value.String(),
+	assert.Equal(t, "ahost:7777", setupCmd.Flags().Lookup("satellite-addr").Value.String(),
 		"satellite-addr should contain default port when no port specified")
 }
 
@@ -64,13 +64,13 @@ func TestNoDefaultPortAppliedToSatelliteAddrWithPort(t *testing.T) {
 	defaultValue := "localhost:7777"
 	setupCmd.Flags().String(flagName, defaultValue, "")
 
-	err := setupCmd.Flags().Set(flagName, "localhost:7778")
+	err := setupCmd.Flags().Set(flagName, "ahost:7778")
 	assert.NoError(t, err)
 
 	err = cmd.ApplyDefaultHostAndPortToAddrFlag(setupCmd, flagName)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "localhost:7778", setupCmd.Flags().Lookup(flagName).Value.String(),
+	assert.Equal(t, "ahost:7778", setupCmd.Flags().Lookup(flagName).Value.String(),
 		"satellite-addr should contain default port when no port specified")
 }
 
@@ -92,5 +92,26 @@ func TestDefaultHostAppliedToSatelliteAddrWithNoHost(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "localhost:7778", setupCmd.Flags().Lookup("satellite-addr").Value.String(),
+		"satellite-addr should contain default port when no port specified")
+}
+
+func TestDefaultPortAppliedToSatelliteAddrWithPortColonButNoPort(t *testing.T) {
+	setupCmd := &cobra.Command{
+		Use:         "setup",
+		Short:       "Create an uplink config file",
+		RunE:        nil,
+		Annotations: map[string]string{"type": "setup"},
+	}
+	flagName := "satellite-addr"
+	defaultValue := "localhost:7777"
+	setupCmd.Flags().String(flagName, defaultValue, "")
+
+	err := setupCmd.Flags().Set(flagName, "ahost:")
+	assert.NoError(t, err)
+
+	err = cmd.ApplyDefaultHostAndPortToAddrFlag(setupCmd, flagName)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "ahost:7777", setupCmd.Flags().Lookup("satellite-addr").Value.String(),
 		"satellite-addr should contain default port when no port specified")
 }


### PR DESCRIPTION
We had a neat uplink setup wizard PR and a default satellite addr PR. this PR combines them so the wizard gets the default address functionality. also checks errors because I couldn't help myself

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
