### PR TITLE
Fix RSConfig calculation in testplanet.Uplink.GetConfig

### DIFF
--- a/internal/testplanet/uplink.go
+++ b/internal/testplanet/uplink.go
@@ -298,10 +298,10 @@ func (uplink *Uplink) GetConfig(satellite *satellite.Peer) uplink.Config {
 	config.Client.SatelliteAddr = satellite.Addr()
 	config.Client.APIKey = uplink.APIKey[satellite.ID()]
 
-	config.RS.MinThreshold = 1 * uplink.StorageNodeCount / 5
-	config.RS.RepairThreshold = 2 * uplink.StorageNodeCount / 5
-	config.RS.SuccessThreshold = 3 * uplink.StorageNodeCount / 5
-	config.RS.MaxThreshold = 4 * uplink.StorageNodeCount / 5
+	config.RS.MinThreshold = atLeastOne(1 * uplink.StorageNodeCount / 5)
+	config.RS.RepairThreshold = atLeastOne(2 * uplink.StorageNodeCount / 5)
+	config.RS.SuccessThreshold = atLeastOne(3 * uplink.StorageNodeCount / 5)
+	config.RS.MaxThreshold = atLeastOne(4 * uplink.StorageNodeCount / 5)
 
 	config.TLS.UsePeerCAWhitelist = false
 	config.TLS.Extensions.Revocation = false
@@ -314,4 +314,12 @@ func getDefaultConfig() uplink.Config {
 	config := uplink.Config{}
 	cfgstruct.Bind(&pflag.FlagSet{}, &config, true)
 	return config
+}
+
+// atLeastOne returns 1 if value < 1, or value otherwise.
+func atLeastOne(value int) int {
+	if value < 1 {
+		return 1
+	}
+	return value
 }

--- a/internal/testplanet/uplink.go
+++ b/internal/testplanet/uplink.go
@@ -298,10 +298,10 @@ func (uplink *Uplink) GetConfig(satellite *satellite.Peer) uplink.Config {
 	config.Client.SatelliteAddr = satellite.Addr()
 	config.Client.APIKey = uplink.APIKey[satellite.ID()]
 
-	config.RS.MinThreshold = atLeastOne(1 * uplink.StorageNodeCount / 5)
-	config.RS.RepairThreshold = atLeastOne(2 * uplink.StorageNodeCount / 5)
-	config.RS.SuccessThreshold = atLeastOne(3 * uplink.StorageNodeCount / 5)
-	config.RS.MaxThreshold = atLeastOne(4 * uplink.StorageNodeCount / 5)
+	config.RS.MinThreshold = atLeastOne(uplink.StorageNodeCount * 1 / 5)     // 20% of storage nodes
+	config.RS.RepairThreshold = atLeastOne(uplink.StorageNodeCount * 2 / 5)  // 40% of storage nodes
+	config.RS.SuccessThreshold = atLeastOne(uplink.StorageNodeCount * 3 / 5) // 60% of storage nodes
+	config.RS.MaxThreshold = atLeastOne(uplink.StorageNodeCount * 4 / 5)     // 80% of storage nodes
 
 	config.TLS.UsePeerCAWhitelist = false
 	config.TLS.Extensions.Revocation = false


### PR DESCRIPTION
What: 

Changes `testplanet.Uplink.GetConfig` in a way to ensure that any of the redundancy properties will be higher than 0, as `0` or lower is not a valid value for them.

Why:

If a test creates test planet with less than 5 storage nodes then `testplanet.Uplink.GetConfig` will return invalid redundancy configuraiton. 

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
