### PR TITLE
Move collect to a more appropriate package

### DIFF
--- a/internal/errs2/collect.go
+++ b/internal/errs2/collect.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-package utils
+package errs2
 
 import (
 	"time"
@@ -9,8 +9,8 @@ import (
 	"github.com/zeebo/errs"
 )
 
-// CollectErrors returns first error from channel and all errors that happen within duration
-func CollectErrors(errch chan error, duration time.Duration) error {
+// Collect returns first error from channel and all errors that happen within duration
+func Collect(errch chan error, duration time.Duration) error {
 	errch = discardNil(errch)
 	errlist := []error{<-errch}
 	timeout := time.After(duration)

--- a/internal/errs2/collect_test.go
+++ b/internal/errs2/collect_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-package utils_test
+package errs2_test
 
 import (
 	"testing"
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zeebo/errs"
 
-	"storj.io/storj/pkg/utils"
+	"storj.io/storj/internal/errs2"
 )
 
 func TestCollectSingleError(t *testing.T) {
@@ -21,12 +21,12 @@ func TestCollectSingleError(t *testing.T) {
 		errchan <- errs.New("error")
 	}()
 
-	err := utils.CollectErrors(errchan, 1*time.Second)
+	err := errs2.Collect(errchan, 1*time.Second)
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "error")
 }
 
-func TestCollecMultipleError(t *testing.T) {
+func TestCollectMultipleError(t *testing.T) {
 	errchan := make(chan error)
 	defer close(errchan)
 
@@ -36,7 +36,7 @@ func TestCollecMultipleError(t *testing.T) {
 		errchan <- errs.New("error3")
 	}()
 
-	err := utils.CollectErrors(errchan, 1*time.Second)
+	err := errs2.Collect(errchan, 1*time.Second)
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "error1; error2; error3")
 }


### PR DESCRIPTION
`utils` packages tend to end up as kithcen-sinks, move the last func to a more appropriate place remove the utils package entirely.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
