### PR TITLE
hardcode debug ports for storj-sim

### DIFF
--- a/cmd/storj-sim/network.go
+++ b/cmd/storj-sim/network.go
@@ -53,7 +53,7 @@ const (
 // port creates a port with a consistent format for storj-sim services.
 // The port format is: "1PXXE", where P is the peer class, XX is the index of the instance, and E is the endpoint.
 func port(peerclass, index, endpoint int) string {
-	port := 10000 + int(peerclass)*1000 + index*10 + endpoint
+	port := 10000 + peerclass*1000 + index*10 + endpoint
 	return strconv.Itoa(port)
 }
 

--- a/cmd/storj-sim/network.go
+++ b/cmd/storj-sim/network.go
@@ -148,17 +148,22 @@ func newNetwork(flags *Flags) (*Processes, error) {
 	processes := NewProcesses(flags.Directory)
 
 	var (
-		host                   = flags.Host
-		gatewayPort            = 9000
-		bootstrapPort          = 9999
-		bootstrapPrivatePort   = 9988
-		satellitePort          = 10000
-		satellitePrivatePort   = 11000
-		storageNodePort        = 12000
-		storageNodePrivatePort = 13000
-		consolePort            = 10100
-		bootstrapWebPort       = 10010
-		versioncontrolPort     = 10011
+		host                    = flags.Host
+		gatewayPort             = 9000
+		gatewayDebugPort        = 9500
+		bootstrapPort           = 9999
+		bootstrapPrivatePort    = 9988
+		bootstrapDebugPort      = 9977
+		satellitePort           = 10000
+		satellitePrivatePort    = 11000
+		satelliteDebugPort      = 11500
+		storageNodePort         = 12000
+		storageNodePrivatePort  = 13000
+		storageNodeDebugPort    = 13500
+		consolePort             = 10100
+		bootstrapWebPort        = 10010
+		versioncontrolPort      = 10011
+		versioncontrolDebugPort = 10012
 	)
 
 	versioncontrol := processes.New(Info{
@@ -171,6 +176,7 @@ func newNetwork(flags *Flags) (*Processes, error) {
 	versioncontrol.Arguments = withCommon(versioncontrol.Directory, Arguments{
 		"setup": {
 			"--address", versioncontrol.Address,
+			"--debug.addr", net.JoinHostPort("127.0.0.1", strconv.Itoa(versioncontrolDebugPort)),
 		},
 		"run": {},
 	})
@@ -206,6 +212,8 @@ func newNetwork(flags *Flags) (*Processes, error) {
 			"--server.use-peer-ca-whitelist=false",
 
 			"--version.server-address", fmt.Sprintf("http://%s/", versioncontrol.Address),
+
+			"--debug.addr", net.JoinHostPort("127.0.0.1", strconv.Itoa(bootstrapDebugPort)),
 		},
 		"run": {},
 	})
@@ -256,6 +264,7 @@ func newNetwork(flags *Flags) (*Processes, error) {
 				"--mail.template-path", filepath.Join(storjRoot, "web/satellite/static/emails"),
 
 				"--version.server-address", fmt.Sprintf("http://%s/", versioncontrol.Address),
+				"--debug.addr", net.JoinHostPort("127.0.0.1", strconv.Itoa(satelliteDebugPort+i)),
 			},
 			"run": {},
 		})
@@ -297,6 +306,8 @@ func newNetwork(flags *Flags) (*Processes, error) {
 
 				"--tls.extensions.revocation=false",
 				"--tls.use-peer-ca-whitelist=false",
+
+				"--debug.addr", net.JoinHostPort(host, strconv.Itoa(gatewayDebugPort+i)),
 			},
 			"run": {},
 		})
@@ -391,6 +402,7 @@ func newNetwork(flags *Flags) (*Processes, error) {
 				"--storage.satellite-id-restriction=false",
 
 				"--version.server-address", fmt.Sprintf("http://%s/", versioncontrol.Address),
+				"--debug.addr", net.JoinHostPort("127.0.0.1", strconv.Itoa(storageNodeDebugPort+i)),
 			},
 			"run": {},
 		})

--- a/cmd/storj-sim/network.go
+++ b/cmd/storj-sim/network.go
@@ -43,9 +43,6 @@ const (
 	bootstrapPeer      = 3
 	storagenodePeer    = 4
 
-	// Index for peers with one instance (i.e. version control and bootstrap)
-	singleIndex = 0
-
 	// Endpoint
 	publicGRPC  = 0
 	privateGRPC = 1
@@ -181,7 +178,7 @@ func newNetwork(flags *Flags) (*Processes, error) {
 	processes := NewProcesses(flags.Directory)
 
 	var host = flags.Host
-	publicPort, err := port(versioncontrolPeer, singleIndex, publicGRPC)
+	publicPort, err := port(versioncontrolPeer, 0, publicGRPC)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +189,7 @@ func newNetwork(flags *Flags) (*Processes, error) {
 		Address:    net.JoinHostPort(host, publicPort),
 	})
 
-	debugPort, err := port(versioncontrolPeer, singleIndex, debugHTTP)
+	debugPort, err := port(versioncontrolPeer, 0, debugHTTP)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +205,7 @@ func newNetwork(flags *Flags) (*Processes, error) {
 		return readConfigString(&versioncontrol.Address, versioncontrol.Directory, "address")
 	}
 
-	publicPort, err = port(bootstrapPeer, singleIndex, publicGRPC)
+	publicPort, err = port(bootstrapPeer, 0, publicGRPC)
 	if err != nil {
 		return nil, err
 	}
@@ -222,15 +219,15 @@ func newNetwork(flags *Flags) (*Processes, error) {
 	// gateway must wait for the versioncontrol to start up
 	bootstrap.WaitForStart(versioncontrol)
 
-	webPort, err := port(bootstrapPeer, singleIndex, publicHTTP)
+	webPort, err := port(bootstrapPeer, 0, publicHTTP)
 	if err != nil {
 		return nil, err
 	}
-	privatePort, err := port(bootstrapPeer, singleIndex, privateGRPC)
+	privatePort, err := port(bootstrapPeer, 0, privateGRPC)
 	if err != nil {
 		return nil, err
 	}
-	debugPort, err = port(bootstrapPeer, singleIndex, debugHTTP)
+	debugPort, err = port(bootstrapPeer, 0, debugHTTP)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
What:  Hardcode the debug ports for storj-sim

Why: The default behavior is to pick a port at random for debug, however this is annoying because if you want to use debug endpoints, you have to go search for what the port is.


## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
