### PR TITLE
v3-1541: Change where the encryption key is being stored for uplink

### DIFF
--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -69,7 +70,13 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	var override map[string]interface{}
+	var (
+		encKeyFilepath = filepath.Join(setupDir, ".enc.key")
+		encKey         []byte
+		override       = map[string]interface{}{
+			"enc.key-filepath": encKeyFilepath,
+		}
+	)
 	if !setupCfg.NonInteractive {
 		_, err = fmt.Print("Enter your Satellite address: ")
 		if err != nil {
@@ -90,6 +97,7 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		if err != nil {
 			return err
 		}
+		override["satellite-addr"] = satelliteAddress
 
 		_, err = fmt.Print("Enter your API key: ")
 		if err != nil {
@@ -104,12 +112,13 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		if apiKey == "" {
 			return errs.New("API key cannot be empty")
 		}
+		override["api-key"] = apiKey
 
 		_, err = fmt.Print("Enter your encryption passphrase: ")
 		if err != nil {
 			return err
 		}
-		encKey, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		encKey, err = terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return err
 		}
@@ -140,12 +149,11 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 			if err != nil {
 				return err
 			}
-		}
-
-		override = map[string]interface{}{
-			"satellite-addr": satelliteAddress,
-			"api-key":        apiKey,
-			"enc.key":        string(encKey),
+		} else {
+			err = SaveEncryptionKey(encKey, encKeyFilepath)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -209,4 +217,38 @@ func ApplyDefaultHostAndPortToAddr(address, defaultAddress string) (string, erro
 
 	// address is host:
 	return net.JoinHostPort(addressParts[0], defaultPort), nil
+}
+
+// SaveEncryptionKey saves the key in a new file which will be stored in
+// filepath.
+// It returns an error if the directory doesn't exist, the file already exists
+// or there is an I/O error.
+func SaveEncryptionKey(key []byte, filepath string) (err error) {
+	f, err := os.OpenFile(filepath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return errors.New("directory path doesn't exist")
+		}
+
+		if os.IsExist(err) {
+			return errors.New("file key already exists")
+		}
+
+		return err
+	}
+
+	defer func() {
+		if err == nil {
+			err = f.Close()
+		} else {
+			_ = f.Close()
+		}
+	}()
+
+	_, err = f.Write(key)
+	if err != nil {
+		return err
+	}
+
+	return f.Chmod(0400)
 }

--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -149,7 +149,8 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	return process.SaveConfigWithAllDefaults(cmd.Flags(), filepath.Join(setupDir, "config.yaml"), override)
+	return process.SaveConfigWithAllDefaults(
+		cmd.Flags(), filepath.Join(setupDir, process.DefaultConfFilename), override)
 }
 
 // ApplyDefaultHostAndPortToAddrFlag applies the default host and/or port if either is missing in the specified flag name.

--- a/cmd/uplink/cmd/setup_test.go
+++ b/cmd/uplink/cmd/setup_test.go
@@ -4,10 +4,15 @@
 package cmd_test
 
 import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"storj.io/storj/cmd/uplink/cmd"
 )
 
@@ -114,4 +119,60 @@ func TestDefaultPortAppliedToSatelliteAddrWithPortColonButNoPort(t *testing.T) {
 
 	assert.Equal(t, "ahost:7777", setupCmd.Flags().Lookup("satellite-addr").Value.String(),
 		"satellite-addr should contain default port when no port specified")
+}
+
+func TestSaveEncriptionKey(t *testing.T) {
+	expKey := make([]byte, rand.Intn(20)+1)
+	_, err := rand.Read(expKey)
+	require.NoError(t, err)
+
+	t.Run("ok", func(t *testing.T) {
+		dir, err := ioutil.TempDir("", "storj-test-cmd-uplink")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(dir) }()
+
+		fname := filepath.Join(dir, ".enc.key")
+		err = cmd.SaveEncryptionKey(expKey, fname)
+		require.NoError(t, err)
+
+		// Read the key from the file to compare that it matches with the saved one.
+		f, err := os.Open(fname)
+		require.NoError(t, err)
+		defer func() { _ = f.Close() }()
+
+		key := make([]byte, len(expKey))
+		_, err = f.Read(key)
+		require.NoError(t, err)
+		assert.Equal(t, expKey, key)
+
+		// Check that the key file has a read only file permissions for the user
+		fi, err := f.Stat()
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0400), fi.Mode().Perm())
+	})
+
+	t.Run("error: unexisting dir", func(t *testing.T) {
+		// Create a directory and remove it for making sure that the path doesn't
+		// exist
+		dir, err := ioutil.TempDir("", "storj-test-cmd-uplink")
+		require.NoError(t, err)
+		err = os.RemoveAll(dir)
+		require.NoError(t, err)
+
+		fname := filepath.Join(dir, "enc.key")
+		err = cmd.SaveEncryptionKey(expKey, fname)
+		assert.Errorf(t, err, "directory path doesn't exist")
+	})
+
+	t.Run("error: file already exists", func(t *testing.T) {
+		// Create an empty file
+		f, err := ioutil.TempFile("", "storj-test-cmd-uplink-key-*")
+		require.NoError(t, err)
+		err = f.Close()
+		require.NoError(t, err)
+		defer func() { _ = os.Remove(f.Name()) }()
+
+		err = cmd.SaveEncryptionKey(expKey, f.Name())
+		assert.Errorf(t, err, "file key already exists")
+	})
 }

--- a/pkg/process/exec_conf.go
+++ b/pkg/process/exec_conf.go
@@ -27,6 +27,9 @@ import (
 	"storj.io/storj/internal/version"
 )
 
+// DefaultConfFilename is the default filename used for storing a configuration.
+const DefaultConfFilename = "config.yaml"
+
 var (
 	mon = monkit.Package()
 
@@ -169,7 +172,7 @@ func cleanup(cmd *cobra.Command) {
 
 		cfgFlag := cmd.Flags().Lookup("config-dir")
 		if cfgFlag != nil && cfgFlag.Value.String() != "" {
-			path := filepath.Join(os.ExpandEnv(cfgFlag.Value.String()), "config.yaml")
+			path := filepath.Join(os.ExpandEnv(cfgFlag.Value.String()), DefaultConfFilename)
 			if cmd.Annotations["type"] != "setup" || fileExists(path) {
 				vip.SetConfigFile(path)
 				err = vip.ReadInConfig()

--- a/uplink/config.go
+++ b/uplink/config.go
@@ -75,6 +75,7 @@ func (kfp keyFilepath) Key() (storj.Key, error) {
 // EncryptionConfig is a configuration struct that keeps details about
 // encrypting segments
 type EncryptionConfig struct {
+	Key         string
 	KeyFilepath string      `help:"the path to the file which contains the root key for encrypting the data"`
 	BlockSize   memory.Size `help:"size (in bytes) of encrypted blocks" default:"1KiB"`
 	DataType    int         `help:"Type of encryption to use for content and metadata (1=AES-GCM, 2=SecretBox)" default:"1"`
@@ -158,6 +159,8 @@ func (c Config) GetMetainfo(ctx context.Context, identity *identity.FullIdentity
 			return nil, nil, err
 		}
 	}
+
+	c.Enc.Key = string(key[:])
 
 	streams, err := streams.NewStreamStore(segments, c.Client.SegmentSize.Int64(), &key, c.Enc.BlockSize.Int(), storj.Cipher(c.Enc.DataType))
 	if err != nil {

--- a/uplink/config.go
+++ b/uplink/config.go
@@ -6,6 +6,9 @@ package uplink
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
+	"os"
 
 	"github.com/vivint/infectious"
 	"github.com/zeebo/errs"
@@ -37,13 +40,45 @@ type RSConfig struct {
 	MaxThreshold     int         `help:"the largest amount of pieces to encode to. n." default:"95" devDefault:"10"`
 }
 
+// keyFilepath is a convenient type to load a key stored in a file.
+type keyFilepath string
+
+func (kfp keyFilepath) Key() (storj.Key, error) {
+	f, err := os.Open(string(kfp))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return storj.Key{}, Error.Wrap(fmt.Errorf("not found key file %q", kfp))
+		}
+
+		return storj.Key{}, errs.Wrap(err)
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		return storj.Key{}, errs.Wrap(err)
+	}
+
+	if p := fi.Mode().Perm(); p != os.FileMode(0400) {
+		return storj.Key{}, Error.Wrap(
+			fmt.Errorf("permissions '%#o' for key file %q are too open", p, kfp),
+		)
+	}
+
+	var key storj.Key
+	if _, err := f.Read(key[:]); err != nil && err != io.EOF {
+		return storj.Key{}, errs.Wrap(err)
+	}
+
+	return key, nil
+}
+
 // EncryptionConfig is a configuration struct that keeps details about
 // encrypting segments
 type EncryptionConfig struct {
-	Key       string      `help:"root key for encrypting the data"`
-	BlockSize memory.Size `help:"size (in bytes) of encrypted blocks" default:"1KiB"`
-	DataType  int         `help:"Type of encryption to use for content and metadata (1=AES-GCM, 2=SecretBox)" default:"1"`
-	PathType  int         `help:"Type of encryption to use for paths (0=Unencrypted, 1=AES-GCM, 2=SecretBox)" default:"1"`
+	KeyFilepath string      `help:"the path to the file which contains the root key for encrypting the data"`
+	BlockSize   memory.Size `help:"size (in bytes) of encrypted blocks" default:"1KiB"`
+	DataType    int         `help:"Type of encryption to use for content and metadata (1=AES-GCM, 2=SecretBox)" default:"1"`
+	PathType    int         `help:"Type of encryption to use for paths (0=Unencrypted, 1=AES-GCM, 2=SecretBox)" default:"1"`
 }
 
 // ClientConfig is a configuration struct for the uplink that controls how
@@ -113,17 +148,25 @@ func (c Config) GetMetainfo(ctx context.Context, identity *identity.FullIdentity
 		return nil, nil, err
 	}
 
-	key := new(storj.Key)
-	copy(key[:], c.Enc.Key)
+	var key storj.Key
+	{
+		kfp := keyFilepath(c.Enc.KeyFilepath)
 
-	streams, err := streams.NewStreamStore(segments, c.Client.SegmentSize.Int64(), key, c.Enc.BlockSize.Int(), storj.Cipher(c.Enc.DataType))
+		var err error
+		key, err = kfp.Key()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	streams, err := streams.NewStreamStore(segments, c.Client.SegmentSize.Int64(), &key, c.Enc.BlockSize.Int(), storj.Cipher(c.Enc.DataType))
 	if err != nil {
 		return nil, nil, Error.New("failed to create stream store: %v", err)
 	}
 
 	buckets := buckets.NewStore(streams)
 
-	return kvmetainfo.New(metainfo, buckets, streams, segments, key, c.Enc.BlockSize.Int32(), rs, c.Client.SegmentSize.Int64()), streams, nil
+	return kvmetainfo.New(metainfo, buckets, streams, segments, &key, c.Enc.BlockSize.Int32(), rs, c.Client.SegmentSize.Int64()), streams, nil
 }
 
 // GetRedundancyScheme returns the configured redundancy scheme for new uploads

--- a/uplink/config_test.go
+++ b/uplink/config_test.go
@@ -1,0 +1,106 @@
+package uplink
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"storj.io/storj/pkg/storj"
+)
+
+func TestKeyFilepath_Key(t *testing.T) {
+	saveKey := func(key []byte) (filepath string, removeFile func()) {
+		f, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
+		require.NoError(t, err)
+		defer func() { _ = f.Close() }()
+
+		_, err = f.Write(key)
+		require.NoError(t, err)
+
+		err = f.Chmod(os.FileMode(0400))
+		require.NoError(t, err)
+
+		return f.Name(), func() { _ = os.Remove(f.Name()) }
+	}
+
+	t.Run("ok: file with key length less or equal than max size", func(t *testing.T) {
+		someKey := make([]byte, rand.Intn(20)+1)
+		_, err := rand.Read(someKey)
+		require.NoError(t, err)
+		fpath, cleanup := saveKey(someKey)
+		defer cleanup()
+
+		var expKey storj.Key
+		copy(expKey[:], someKey)
+
+		kfpath := keyFilepath(fpath)
+		key, err := kfpath.Key()
+		require.NoError(t, err)
+
+		assert.Equal(t, expKey[:], key[:])
+	})
+
+	t.Run("ok: file with key length greater than max size", func(t *testing.T) {
+		expKey := make([]byte, rand.Intn(10)+1+storj.KeySize)
+		_, err := rand.Read(expKey)
+		fpath, cleanup := saveKey(expKey)
+		defer cleanup()
+
+		kfpath := keyFilepath(fpath)
+		key, err := kfpath.Key()
+		require.NoError(t, err)
+
+		assert.Equal(t, expKey[:storj.KeySize], key[:])
+	})
+
+	t.Run("ok: empty file path", func(t *testing.T) {
+		fpath, cleanup := saveKey([]byte{})
+		defer cleanup()
+
+		kfpath := keyFilepath(fpath)
+		key, err := kfpath.Key()
+		require.NoError(t, err)
+		assert.Equal(t, key, storj.Key{})
+	})
+
+	t.Run("error: file not found", func(t *testing.T) {
+		// Create a temp file and delete it, to get a filepath which doesn't exist.
+		f, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
+		require.NoError(t, err)
+		err = f.Close()
+		require.NoError(t, err)
+		err = os.Remove(f.Name())
+		require.NoError(t, err)
+
+		kfpath := keyFilepath(f.Name())
+		_, err = kfpath.Key()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("not found key file %q", f.Name()))
+		assert.True(t, Error.Has(err), "err is not of %q class", Error)
+	})
+
+	t.Run("error: permissions are too open", func(t *testing.T) {
+		// Create a key file and change its permission for not being able to read it
+		f, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
+		require.NoError(t, err)
+		defer func() {
+			_ = f.Close()
+			_ = os.Remove(f.Name())
+		}()
+
+		err = f.Chmod(0401)
+		require.NoError(t, err)
+
+		kfpath := keyFilepath(f.Name())
+		_, err = kfpath.Key()
+		require.Error(t, err)
+		assert.Contains(t,
+			err.Error(), fmt.Sprintf("permissions '0401' for key file %q are too open", f.Name()),
+		)
+		assert.True(t, Error.Has(err), "err is not of %q class", Error)
+	})
+}


### PR DESCRIPTION
What: Encryption key shouldn't be stored in the same configuration file, it should be in a separated file

Why: Because due to security reasons and conventions, the key should be stored outside of the configuration file to be less accessible.

Just moving the file outside of the configuration file isn't alone a secure way to store it, but it's the first step; in the future other security measures will be taken.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
