### PR TITLE
pkg/process: add --debug.trace-out option to binaries

### DIFF
--- a/pkg/process/exec_conf.go
+++ b/pkg/process/exec_conf.go
@@ -21,8 +21,11 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/zeebo/errs"
 	"go.uber.org/zap"
 	monkit "gopkg.in/spacemonkeygo/monkit.v2"
+	"gopkg.in/spacemonkeygo/monkit.v2/collect"
+	"gopkg.in/spacemonkeygo/monkit.v2/present"
 
 	"storj.io/storj/internal/version"
 )
@@ -154,6 +157,9 @@ func cleanup(cmd *cobra.Command) {
 	if internalRun == nil {
 		return
 	}
+
+	traceOut := cmd.Flags().String("debug.trace-out", "", "If set, a path to write a process trace SVG to")
+
 	cmd.RunE = func(cmd *cobra.Command, args []string) (err error) {
 		ctx := context.Background()
 		defer mon.TaskNamed("root")(&ctx)(&err)
@@ -232,16 +238,35 @@ func cleanup(cmd *cobra.Command) {
 			logger.Error("failed to start debug endpoints", zap.Error(err))
 		}
 
-		contextMtx.Lock()
-		contexts[cmd] = ctx
-		contextMtx.Unlock()
-		defer func() {
+		var workErr error
+		work := func(ctx context.Context) {
 			contextMtx.Lock()
-			delete(contexts, cmd)
+			contexts[cmd] = ctx
 			contextMtx.Unlock()
-		}()
+			defer func() {
+				contextMtx.Lock()
+				delete(contexts, cmd)
+				contextMtx.Unlock()
+			}()
 
-		err = internalRun(cmd, args)
+			workErr = internalRun(cmd, args)
+		}
+
+		if *traceOut != "" {
+			fh, err := os.Create(*traceOut)
+			if err != nil {
+				return err
+			}
+			err = present.SpansToSVG(fh, collect.CollectSpans(ctx, work))
+			err = errs.Combine(err, fh.Close())
+			if err != nil {
+				logger.Error("failed to write svg", zap.Error(err))
+			}
+		} else {
+			work(ctx)
+		}
+
+		err = workErr
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Fatal error: %v\n", err)
 			logger.Sugar().Debugf("Fatal error: %+v", err)


### PR DESCRIPTION
this adds a flag to all pkg/process binaries where if set, will write a process-level trace for all monkit-instrumented functions as an svg to the target path.

usage like:

  uplink cp --debug.trace-out=trace.svg file sj://bucket/file

Note that this feature only works with codepaths that are kicked off in a *cobra.Cmd using process.Ctx() as the starting context, and it's important to note that this is much more useful when `defer mon.Task()(&ctx)(&err)` is littered everywhere

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
