### PR TITLE
using config for online, added IsValid

### DIFF
--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -41,19 +41,21 @@ func TestCache_Graveyard(t *testing.T) {
 		satellite.Discovery.Service.Graveyard.Pause()
 		satellite.Discovery.Service.Discovery.Pause()
 
+		overlay := satellite.Overlay.Service
+
 		// mark node as offline in overlay cache
-		_, err := satellite.Overlay.Service.UpdateUptime(ctx, offlineID, false)
+		_, err := overlay.UpdateUptime(ctx, offlineID, false)
 		require.NoError(t, err)
 
-		node, err := satellite.Overlay.Service.Get(ctx, offlineID)
+		node, err := overlay.Get(ctx, offlineID)
 		assert.NoError(t, err)
-		assert.False(t, node.Online())
+		assert.False(t, overlay.IsOnline(node))
 
 		satellite.Discovery.Service.Graveyard.TriggerWait()
 
-		found, err := satellite.Overlay.Service.Get(ctx, offlineID)
+		found, err := overlay.Get(ctx, offlineID)
 		assert.NoError(t, err)
 		assert.Equal(t, offlineID, found.Id)
-		assert.True(t, found.Online())
+		assert.True(t, overlay.IsOnline(found))
 	})
 }

--- a/pkg/overlay/cache_test.go
+++ b/pkg/overlay/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -165,10 +166,13 @@ func testRandomizedSelection(t *testing.T, reputable bool) {
 			var err error
 
 			if reputable {
-				nodes, err = cache.SelectStorageNodes(ctx, numNodesToSelect, &overlay.NodeCriteria{})
+				nodes, err = cache.SelectStorageNodes(ctx, numNodesToSelect, &overlay.NodeCriteria{
+					OnlineWindow: time.Hour,
+				})
 				require.NoError(t, err)
 			} else {
 				nodes, err = cache.SelectNewStorageNodes(ctx, numNodesToSelect, &overlay.NewNodeCriteria{
+					OnlineWindow:   time.Hour,
 					AuditThreshold: 1,
 				})
 				require.NoError(t, err)

--- a/pkg/overlay/config.go
+++ b/pkg/overlay/config.go
@@ -5,6 +5,7 @@ package overlay
 
 import (
 	"strings"
+	"time"
 
 	"github.com/zeebo/errs"
 	monkit "gopkg.in/spacemonkeygo/monkit.v2"
@@ -33,15 +34,14 @@ type LookupConfig struct {
 // NodeSelectionConfig is a configuration struct to determine the minimum
 // values for nodes to select
 type NodeSelectionConfig struct {
-	UptimeRatio       float64 `help:"a node's ratio of being up/online vs. down/offline" default:"0"`
-	UptimeCount       int64   `help:"the number of times a node's uptime has been checked" default:"0"`
-	AuditSuccessRatio float64 `help:"a node's ratio of successful audits" default:"0"`
-	AuditCount        int64   `help:"the number of times a node has been audited" default:"0"`
-
-	NewNodeAuditThreshold int64   `help:"the number of audits a node must have to not be considered a New Node" default:"0"`
-	NewNodePercentage     float64 `help:"the percentage of new nodes allowed per request" default:"0.05"` // TODO: fix, this is not percentage, it's ratio
-
-	MinimumVersion string `help:"the minimum node software version for node selection queries" default:""`
+	UptimeRatio           float64       `help:"a node's ratio of being up/online vs. down/offline" default:"0"`
+	UptimeCount           int64         `help:"the number of times a node's uptime has been checked" default:"0"` // to be returned by SelectStorageNodes
+	AuditSuccessRatio     float64       `help:"a node's ratio of successful audits" default:"0"`
+	AuditCount            int64         `help:"the number of times a node has been audited" default:"0"`                           // to be returned by SelectStorageNodes
+	NewNodeAuditThreshold int64         `help:"the number of audits a node must have to not be considered a New Node" default:"0"` // to be returned by SelectNewStorageNodes
+	NewNodePercentage     float64       `help:"the percentage of new nodes allowed per request" default:"0.05"`                    // TODO: fix, this is not percentage, it's ratio
+	MinimumVersion        string        `help:"the minimum node software version for node selection queries" default:""`
+	OnlineWindow          time.Duration `help:"the amount of time without seeing a node before its considered offline" default:"1h"`
 }
 
 // ParseIDs converts the base58check encoded node ID strings from the config into node IDs

--- a/satellite/inspector/inspector.go
+++ b/satellite/inspector/inspector.go
@@ -145,7 +145,7 @@ func (endpoint *Endpoint) SegmentHealth(ctx context.Context, in *pb.SegmentHealt
 
 	onlineNodeCount := int32(0)
 	for _, n := range nodes {
-		if n.Online() {
+		if endpoint.cache.IsOnline(n) {
 			onlineNodeCount++
 		}
 	}

--- a/satellite/orders/service.go
+++ b/satellite/orders/service.go
@@ -129,7 +129,7 @@ func (service *Service) CreateGetOrderLimits(ctx context.Context, uplink *identi
 			node.Type.DPanicOnInvalid("order service get order limits")
 		}
 
-		if !node.Online() {
+		if !service.cache.IsOnline(node) {
 			service.log.Debug("node is offline", zap.String("ID", node.Id.String()))
 			combinedErrs = errs.Combine(combinedErrs, Error.New("node is offline: %s", node.Id.String()))
 			continue
@@ -266,7 +266,7 @@ func (service *Service) CreateDeleteOrderLimits(ctx context.Context, uplink *ide
 			node.Type.DPanicOnInvalid("order service delete order limits")
 		}
 
-		if !node.Online() {
+		if !service.cache.IsOnline(node) {
 			service.log.Debug("node is offline", zap.String("ID", node.Id.String()))
 			combinedErrs = errs.Combine(combinedErrs, Error.New("node is offline: %s", node.Id.String()))
 			continue
@@ -346,7 +346,7 @@ func (service *Service) CreateAuditOrderLimits(ctx context.Context, auditor *ide
 			node.Type.DPanicOnInvalid("order service audit order limits")
 		}
 
-		if !node.Online() {
+		if !service.cache.IsOnline(node) {
 			service.log.Debug("node is offline", zap.String("ID", node.Id.String()))
 			combinedErrs = errs.Combine(combinedErrs, Error.New("node is offline: %s", node.Id.String()))
 			continue
@@ -429,7 +429,7 @@ func (service *Service) CreateGetRepairOrderLimits(ctx context.Context, repairer
 			node.Type.DPanicOnInvalid("order service get repair order limits")
 		}
 
-		if !node.Online() {
+		if !service.cache.IsOnline(node) {
 			service.log.Debug("node is offline", zap.String("ID", node.Id.String()))
 			combinedErrs = errs.Combine(combinedErrs, Error.New("node is offline: %s", node.Id.String()))
 			continue

--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -47,7 +47,7 @@ func (cache *overlaycache) SelectStorageNodes(ctx context.Context, count int, cr
 	args := append(make([]interface{}, 0, 13),
 		nodeType, criteria.FreeBandwidth, criteria.FreeDisk,
 		criteria.AuditCount, criteria.AuditSuccessRatio, criteria.UptimeCount, criteria.UptimeSuccessRatio,
-		time.Now().Add(-overlay.OnlineWindow))
+		time.Now().Add(-criteria.OnlineWindow))
 
 	if criteria.MinimumVersion != "" {
 		v, err := version.NewSemVer(criteria.MinimumVersion)
@@ -72,7 +72,7 @@ func (cache *overlaycache) SelectNewStorageNodes(ctx context.Context, count int,
 		  AND last_contact_success > ?
 		  AND last_contact_success > last_contact_failure`
 	args := append(make([]interface{}, 0, 10),
-		nodeType, criteria.FreeBandwidth, criteria.FreeDisk, criteria.AuditThreshold, time.Now().Add(-overlay.OnlineWindow))
+		nodeType, criteria.FreeBandwidth, criteria.FreeDisk, criteria.AuditThreshold, time.Now().Add(-criteria.OnlineWindow))
 
 	if criteria.MinimumVersion != "" {
 		v, err := version.NewSemVer(criteria.MinimumVersion)


### PR DESCRIPTION
What: 
Previously the definition of a node being 'online' was hard-coded to one hour.  Now its configurable.

Why:
General cleanup in preparation for other tickets.