### PR TITLE
wired up IsHealthy to config

### DIFF
--- a/pkg/datarepair/checker/checker.go
+++ b/pkg/datarepair/checker/checker.go
@@ -175,20 +175,14 @@ func (checker *Checker) getMissingPieces(ctx context.Context, pieces []*pb.Remot
 	for _, p := range pieces {
 		nodeIDs = append(nodeIDs, p.NodeId)
 	}
-
 	nodes, err := checker.overlay.GetAll(ctx, nodeIDs)
-
-	maxStats := &overlay.NodeStats{
-		AuditSuccessRatio: 0, // TODO: update when we have stats added to overlay
-		UptimeRatio:       0, // TODO: update when we have stats added to overlay
-	}
 
 	if err != nil {
 		return nil, Error.New("error getting nodes %s", err)
 	}
 
 	for i, node := range nodes {
-		if node == nil || !node.Online() || !node.VettedFor(maxStats) {
+		if node == nil || !checker.overlay.IsOnline(node) || !checker.overlay.IsHealthy(node) {
 			missingPieces = append(missingPieces, pieces[i].GetPieceNum())
 		}
 	}

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -41,19 +41,21 @@ func TestCache_Graveyard(t *testing.T) {
 		satellite.Discovery.Service.Graveyard.Pause()
 		satellite.Discovery.Service.Discovery.Pause()
 
+		overlay := satellite.Overlay.Service
+
 		// mark node as offline in overlay cache
-		_, err := satellite.Overlay.Service.UpdateUptime(ctx, offlineID, false)
+		_, err := overlay.UpdateUptime(ctx, offlineID, false)
 		require.NoError(t, err)
 
-		node, err := satellite.Overlay.Service.Get(ctx, offlineID)
+		node, err := overlay.Get(ctx, offlineID)
 		assert.NoError(t, err)
-		assert.False(t, node.Online())
+		assert.False(t, overlay.IsOnline(node))
 
 		satellite.Discovery.Service.Graveyard.TriggerWait()
 
-		found, err := satellite.Overlay.Service.Get(ctx, offlineID)
+		found, err := overlay.Get(ctx, offlineID)
 		assert.NoError(t, err)
 		assert.Equal(t, offlineID, found.Id)
-		assert.True(t, found.Online())
+		assert.True(t, overlay.IsOnline(found))
 	})
 }

--- a/pkg/overlay/cache.go
+++ b/pkg/overlay/cache.go
@@ -171,7 +171,7 @@ func (cache *Cache) Get(ctx context.Context, nodeID storj.NodeID) (_ *NodeDossie
 
 // IsNew checks if a node is 'new' based on the collected statistics.
 func (cache *Cache) IsNew(node *NodeDossier) bool {
-	return node.Reputation.AuditCount > cache.preferences.AuditCount
+	return node.Reputation.AuditCount < cache.preferences.AuditCount
 }
 
 // IsOnline checks if a node is 'online' based on the collected statistics.

--- a/satellite/inspector/inspector.go
+++ b/satellite/inspector/inspector.go
@@ -145,7 +145,7 @@ func (endpoint *Endpoint) SegmentHealth(ctx context.Context, in *pb.SegmentHealt
 
 	onlineNodeCount := int32(0)
 	for _, n := range nodes {
-		if n.Online() {
+		if endpoint.cache.IsOnline(n) {
 			onlineNodeCount++
 		}
 	}

--- a/satellite/orders/service.go
+++ b/satellite/orders/service.go
@@ -129,7 +129,7 @@ func (service *Service) CreateGetOrderLimits(ctx context.Context, uplink *identi
 			node.Type.DPanicOnInvalid("order service get order limits")
 		}
 
-		if !node.Online() {
+		if !service.cache.IsOnline(node) {
 			service.log.Debug("node is offline", zap.String("ID", node.Id.String()))
 			combinedErrs = errs.Combine(combinedErrs, Error.New("node is offline: %s", node.Id.String()))
 			continue
@@ -266,7 +266,7 @@ func (service *Service) CreateDeleteOrderLimits(ctx context.Context, uplink *ide
 			node.Type.DPanicOnInvalid("order service delete order limits")
 		}
 
-		if !node.Online() {
+		if !service.cache.IsOnline(node) {
 			service.log.Debug("node is offline", zap.String("ID", node.Id.String()))
 			combinedErrs = errs.Combine(combinedErrs, Error.New("node is offline: %s", node.Id.String()))
 			continue
@@ -346,7 +346,7 @@ func (service *Service) CreateAuditOrderLimits(ctx context.Context, auditor *ide
 			node.Type.DPanicOnInvalid("order service audit order limits")
 		}
 
-		if !node.Online() {
+		if !service.cache.IsOnline(node) {
 			service.log.Debug("node is offline", zap.String("ID", node.Id.String()))
 			combinedErrs = errs.Combine(combinedErrs, Error.New("node is offline: %s", node.Id.String()))
 			continue
@@ -429,7 +429,7 @@ func (service *Service) CreateGetRepairOrderLimits(ctx context.Context, repairer
 			node.Type.DPanicOnInvalid("order service get repair order limits")
 		}
 
-		if !node.Online() {
+		if !service.cache.IsOnline(node) {
 			service.log.Debug("node is offline", zap.String("ID", node.Id.String()))
 			combinedErrs = errs.Combine(combinedErrs, Error.New("node is offline: %s", node.Id.String()))
 			continue


### PR DESCRIPTION
What: 
Rename Online to IsOnline, VettedFor to IsHealthy.  added IsNew.
Made node IsOnline, IsNew, IsHealthy tests part of overlay
Wired IsHealthy up to configs

Why:
I liked those names better.  :P
IsOnline, IsNew, IsHealthy need to be config driven
Valid IsHealthy configs required for checker to produce valid results.

What is not included:
IsOnline is still hard-coded amd not wired up to configs, will accomplish in another PR
