### PR TITLE
storagenode: getting signee cert always asked the kademlia network

### DIFF
--- a/storagenode/trust/service.go
+++ b/storagenode/trust/service.go
@@ -97,9 +97,6 @@ func (pool *Pool) VerifyUplinkID(ctx context.Context, id storj.NodeID) error {
 // GetSignee gets the corresponding signee for verifying signatures.
 // It ignores passed in ctx cancellation to avoid miscaching between concurrent requests.
 func (pool *Pool) GetSignee(ctx context.Context, id storj.NodeID) (signing.Signee, error) {
-	// creating a new context here to avoid request context canceling fetching peer identity
-	nestedContext := context.Background()
-
 	// lookup peer identity with id
 	pool.mu.RLock()
 	info, ok := pool.trustedSatellites[id]
@@ -127,7 +124,7 @@ func (pool *Pool) GetSignee(ctx context.Context, id storj.NodeID) (signing.Signe
 	defer info.mu.Unlock()
 
 	if info.identity == nil {
-		identity, err := pool.kademlia.FetchPeerIdentity(nestedContext, id)
+		identity, err := pool.kademlia.FetchPeerIdentity(ctx, id)
 		if err != nil {
 			if err == context.Canceled {
 				return nil, err

--- a/storagenode/trust/service.go
+++ b/storagenode/trust/service.go
@@ -126,7 +126,7 @@ func (pool *Pool) GetSignee(ctx context.Context, id storj.NodeID) (signing.Signe
 	info.mu.Lock()
 	defer info.mu.Unlock()
 
-	if info.identity != nil {
+	if info.identity == nil {
 		identity, err := pool.kademlia.FetchPeerIdentity(nestedContext, id)
 		if err != nil {
 			if err == context.Canceled {

--- a/storagenode/trust/service_test.go
+++ b/storagenode/trust/service_test.go
@@ -33,17 +33,13 @@ func TestGetSignee(t *testing.T) {
 
 	var group errgroup.Group
 	group.Go(func() error {
-		cert, err := trust.GetSignee(canceledContext, planet.Satellites[0].ID())
-		if err != context.Canceled {
+		_, err := trust.GetSignee(canceledContext, planet.Satellites[0].ID())
+		if err == context.Canceled {
 			return nil
 		}
-		if err != nil {
-			return err
-		}
-		if cert != nil {
-			return errors.New("got certificate")
-		}
-		return nil
+		// if the other goroutine races us,
+		// then we might get the certificate from the cache, however we shouldn't get an error
+		return err
 	})
 
 	group.Go(func() error {


### PR DESCRIPTION
The logic for caching was correct, however not the reading of the value in the cache. Simplify the implementation using a mutex per cert.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
