### PR TITLE
checker kad aware

### DIFF
--- a/cmd/overlay/cache.go
+++ b/cmd/overlay/cache.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"
@@ -31,5 +32,5 @@ func (c cacheConfig) open(ctx context.Context) (cache *overlay.Cache, dbClose fu
 		}
 	}
 
-	return overlay.NewCache(zap.L(), database.OverlayCache(), overlay.NodeSelectionConfig{}), dbClose, nil
+	return overlay.NewCache(zap.L(), database.OverlayCache(), overlay.NodeSelectionConfig{OnlineWindow: time.Hour}), dbClose, nil
 }

--- a/internal/testplanet/planet.go
+++ b/internal/testplanet/planet.go
@@ -451,6 +451,7 @@ func (planet *Planet) newSatellites(count int) ([]*satellite.Peer, error) {
 					AuditSuccessRatio: 0,
 					AuditCount:        0,
 					NewNodePercentage: 0,
+					OnlineWindow:      time.Hour,
 				},
 			},
 			Discovery: discovery.Config{

--- a/pkg/overlay/cache_test.go
+++ b/pkg/overlay/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,7 +41,7 @@ func testCache(ctx context.Context, t *testing.T, store overlay.DB) {
 	_, _ = rand.Read(valid2ID[:])
 	_, _ = rand.Read(missingID[:])
 
-	cache := overlay.NewCache(zaptest.NewLogger(t), store, overlay.NodeSelectionConfig{})
+	cache := overlay.NewCache(zaptest.NewLogger(t), store, overlay.NodeSelectionConfig{OnlineWindow: time.Hour})
 
 	{ // Put
 		err := cache.Put(ctx, valid1ID, pb.Node{Id: valid1ID})
@@ -165,11 +166,12 @@ func testRandomizedSelection(t *testing.T, reputable bool) {
 			var err error
 
 			if reputable {
-				nodes, err = cache.SelectStorageNodes(ctx, numNodesToSelect, &overlay.NodeCriteria{})
+				nodes, err = cache.SelectStorageNodes(ctx, numNodesToSelect, &overlay.NodeCriteria{OnlineWindow: time.Hour})
 				require.NoError(t, err)
 			} else {
 				nodes, err = cache.SelectNewStorageNodes(ctx, numNodesToSelect, &overlay.NodeCriteria{
-					AuditCount: 1,
+					OnlineWindow: time.Hour,
+					AuditCount:   1,
 				})
 				require.NoError(t, err)
 			}

--- a/pkg/overlay/config.go
+++ b/pkg/overlay/config.go
@@ -40,7 +40,7 @@ type NodeSelectionConfig struct {
 	AuditCount        int64         `help:"the number of times a node has been audited to not be considered a New Node" releaseDefault:"500" devDefault:"0"`
 	NewNodePercentage float64       `help:"the percentage of new nodes allowed per request" default:"0.05"` // TODO: fix, this is not percentage, it's ratio
 	MinimumVersion    string        `help:"the minimum node software version for node selection queries" default:""`
-	OnlineWindow      time.Duration `help:"the amount of time without seeing a node before its considered offline" default:"1h"` //todo:  wire up instead of constants
+	OnlineWindow      time.Duration `help:"the amount of time without seeing a node before its considered offline" default:"1h"`
 }
 
 // ParseIDs converts the base58check encoded node ID strings from the config into node IDs

--- a/pkg/overlay/selection_test.go
+++ b/pkg/overlay/selection_test.go
@@ -5,6 +5,7 @@ package overlay_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zeebo/errs"
@@ -54,6 +55,7 @@ func TestNodeSelection(t *testing.T) {
 				Preferences: overlay.NodeSelectionConfig{
 					AuditCount:        0,
 					NewNodePercentage: 0,
+					OnlineWindow:      time.Hour,
 				},
 				RequestCount:  5,
 				ExpectedCount: 5,
@@ -62,6 +64,7 @@ func TestNodeSelection(t *testing.T) {
 				Preferences: overlay.NodeSelectionConfig{
 					AuditCount:        0,
 					NewNodePercentage: 1,
+					OnlineWindow:      time.Hour,
 				},
 				RequestCount:  5,
 				ExpectedCount: 5,
@@ -70,6 +73,7 @@ func TestNodeSelection(t *testing.T) {
 				Preferences: overlay.NodeSelectionConfig{
 					AuditCount:        1,
 					NewNodePercentage: 1,
+					OnlineWindow:      time.Hour,
 				},
 				RequestCount:  5,
 				ExpectedCount: 6,
@@ -78,6 +82,7 @@ func TestNodeSelection(t *testing.T) {
 				Preferences: overlay.NodeSelectionConfig{
 					AuditCount:        5,
 					NewNodePercentage: 1,
+					OnlineWindow:      time.Hour,
 				},
 				RequestCount:  2,
 				ExpectedCount: 4,
@@ -86,6 +91,7 @@ func TestNodeSelection(t *testing.T) {
 				Preferences: overlay.NodeSelectionConfig{
 					AuditCount:        5,
 					NewNodePercentage: 0.5,
+					OnlineWindow:      time.Hour,
 				},
 				RequestCount:  4,
 				ExpectedCount: 6,
@@ -94,6 +100,7 @@ func TestNodeSelection(t *testing.T) {
 				Preferences: overlay.NodeSelectionConfig{
 					AuditCount:        8,
 					NewNodePercentage: 1,
+					OnlineWindow:      time.Hour,
 				},
 				RequestCount:  1,
 				ExpectedCount: 2,
@@ -102,6 +109,7 @@ func TestNodeSelection(t *testing.T) {
 				Preferences: overlay.NodeSelectionConfig{
 					AuditCount:        9,
 					NewNodePercentage: 1,
+					OnlineWindow:      time.Hour,
 				},
 				RequestCount:   2,
 				ExpectedCount:  3,
@@ -111,6 +119,7 @@ func TestNodeSelection(t *testing.T) {
 				Preferences: overlay.NodeSelectionConfig{
 					AuditCount:        50,
 					NewNodePercentage: 1,
+					OnlineWindow:      time.Hour,
 				},
 				RequestCount:   2,
 				ExpectedCount:  2,
@@ -120,6 +129,7 @@ func TestNodeSelection(t *testing.T) {
 				Preferences: overlay.NodeSelectionConfig{
 					AuditCount:        9,
 					NewNodePercentage: 0,
+					OnlineWindow:      time.Hour,
 				},
 				RequestCount:  1,
 				ExpectedCount: 1,
@@ -128,6 +138,7 @@ func TestNodeSelection(t *testing.T) {
 				Preferences: overlay.NodeSelectionConfig{
 					AuditCount:        0,
 					NewNodePercentage: 1,
+					OnlineWindow:      time.Hour,
 				},
 				RequestCount:  1,
 				ExpectedCount: 1,
@@ -136,6 +147,7 @@ func TestNodeSelection(t *testing.T) {
 				Preferences: overlay.NodeSelectionConfig{
 					AuditCount:        5,
 					NewNodePercentage: 0,
+					OnlineWindow:      time.Hour,
 				},
 				ExcludeCount:   7,
 				RequestCount:   5,

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -359,7 +359,9 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config *Config, ve
 		peer.Repair.Checker = checker.NewChecker(
 			peer.Metainfo.Service,
 			peer.DB.RepairQueue(),
-			peer.Overlay.Service, peer.DB.Irreparable(),
+			peer.Overlay.Service,
+			peer.DB.Irreparable(),
+			peer.Kademlia.Service,
 			0, peer.Log.Named("checker"),
 			config.Checker.Interval)
 

--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -47,7 +47,7 @@ func (cache *overlaycache) SelectStorageNodes(ctx context.Context, count int, cr
 	args := append(make([]interface{}, 0, 13),
 		nodeType, criteria.FreeBandwidth, criteria.FreeDisk,
 		criteria.AuditCount, criteria.AuditSuccessRatio, criteria.UptimeCount, criteria.UptimeSuccessRatio,
-		time.Now().Add(-overlay.OnlineWindow))
+		time.Now().Add(-criteria.OnlineWindow))
 
 	if criteria.MinimumVersion != "" {
 		v, err := version.NewSemVer(criteria.MinimumVersion)
@@ -73,7 +73,7 @@ func (cache *overlaycache) SelectNewStorageNodes(ctx context.Context, count int,
 		  AND last_contact_success > ?
 		  AND last_contact_success > last_contact_failure`
 	args := append(make([]interface{}, 0, 10),
-		nodeType, criteria.FreeBandwidth, criteria.FreeDisk, criteria.AuditCount, criteria.AuditSuccessRatio, time.Now().Add(-overlay.OnlineWindow))
+		nodeType, criteria.FreeBandwidth, criteria.FreeDisk, criteria.AuditCount, criteria.AuditSuccessRatio, time.Now().Add(-criteria.OnlineWindow))
 
 	if criteria.MinimumVersion != "" {
 		v, err := version.NewSemVer(criteria.MinimumVersion)


### PR DESCRIPTION
What: 
Checker now cares about Kademlia.  It waits for it to bootstrap.  It checks Kadmelia when the overlay doesn't know about a node.

Why:
Checker never knew about Kademlia before.  Anything missing from the overlay didn't get checked correctly.