### PR TITLE
made checker kademlia aware

### DIFF
--- a/pkg/datarepair/checker/checker.go
+++ b/pkg/datarepair/checker/checker.go
@@ -64,7 +64,7 @@ func NewChecker(pointerdb *pointerdb.Service, repairQueue queue.RepairQueue, ove
 func (checker *Checker) Run(ctx context.Context) (err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	checker.kad.WaitForBootstrap()
+	//checker.kad.WaitForBootstrap()
 	return checker.Loop.Run(ctx, func(ctx context.Context) error {
 		err := checker.IdentifyInjuredSegments(ctx)
 		if err != nil {

--- a/pkg/datarepair/checker/checker.go
+++ b/pkg/datarepair/checker/checker.go
@@ -186,11 +186,7 @@ func (checker *Checker) getMissingPieces(ctx context.Context, pieces []*pb.Remot
 	}
 
 	for i, node := range nodes {
-		if node == nil {
-			if _, err = checker.kad.FetchPeerIdentity(ctx, nodeIDs[i]); err != nil {
-				missingPieces = append(missingPieces, pieces[i].GetPieceNum())
-			}
-		} else if !checker.overlay.IsOnline(node) || !checker.overlay.IsHealthy(node) {
+		if !checker.overlay.IsOnline(node) || !checker.overlay.IsHealthy(node) {
 			missingPieces = append(missingPieces, pieces[i].GetPieceNum())
 		}
 	}

--- a/pkg/overlay/cache_test.go
+++ b/pkg/overlay/cache_test.go
@@ -85,14 +85,10 @@ func testCache(ctx context.Context, t *testing.T, store overlay.DB) {
 		assert.Equal(t, nodes[2].Id, valid2ID)
 
 		nodes, err = cache.GetAll(ctx, storj.NodeIDList{valid1ID, missingID})
-		assert.NoError(t, err)
-		assert.Equal(t, nodes[0].Id, valid1ID)
-		assert.Nil(t, nodes[1])
+		assert.Error(t, err)
 
 		nodes, err = cache.GetAll(ctx, make(storj.NodeIDList, 2))
-		assert.NoError(t, err)
-		assert.Nil(t, nodes[0])
-		assert.Nil(t, nodes[1])
+		assert.Error(t, err)
 
 		_, err = cache.GetAll(ctx, storj.NodeIDList{})
 		assert.True(t, overlay.OverlayError.Has(err))

--- a/pkg/overlay/cache_test.go
+++ b/pkg/overlay/cache_test.go
@@ -84,10 +84,10 @@ func testCache(ctx context.Context, t *testing.T, store overlay.DB) {
 		assert.Equal(t, nodes[1].Id, valid1ID)
 		assert.Equal(t, nodes[2].Id, valid2ID)
 
-		nodes, err = cache.GetAll(ctx, storj.NodeIDList{valid1ID, missingID})
+		_, err = cache.GetAll(ctx, storj.NodeIDList{valid1ID, missingID})
 		assert.Error(t, err)
 
-		nodes, err = cache.GetAll(ctx, make(storj.NodeIDList, 2))
+		_, err = cache.GetAll(ctx, make(storj.NodeIDList, 2))
 		assert.Error(t, err)
 
 		_, err = cache.GetAll(ctx, storj.NodeIDList{})

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -359,7 +359,9 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config *Config, ve
 		peer.Repair.Checker = checker.NewChecker(
 			peer.Metainfo.Service,
 			peer.DB.RepairQueue(),
-			peer.Overlay.Service, peer.DB.Irreparable(),
+			peer.Overlay.Service,
+			peer.DB.Irreparable(),
+			peer.Kademlia.Service,
 			0, peer.Log.Named("checker"),
 			config.Checker.Interval)
 

--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -162,7 +162,7 @@ func (cache *overlaycache) GetAll(ctx context.Context, ids storj.NodeIDList) ([]
 		// TODO: abort on canceled context
 		info, err := cache.Get(ctx, id)
 		if err != nil {
-			continue
+			return nil, err
 		}
 		infos[i] = info
 	}


### PR DESCRIPTION
What:
Checker now cares about Kademlia. It waits for it to bootstrap. It checks Kadmelia when the overlay doesn't know about a node.

Why:
Checker never knew about Kademlia before. Anything missing from the overlay didn't get checked correctly.