### PR TITLE
set delete-tallies default to false

### DIFF
--- a/internal/testplanet/planet.go
+++ b/internal/testplanet/planet.go
@@ -487,7 +487,7 @@ func (planet *Planet) newSatellites(count int) ([]*satellite.Peer, error) {
 			Rollup: rollup.Config{
 				Interval:      2 * time.Minute,
 				MaxAlphaUsage: 25 * memory.GB,
-				DeleteTallies: true,
+				DeleteTallies: false,
 			},
 			Mail: mailservice.Config{
 				SMTPServerAddress: "smtp.mail.example.com:587",

--- a/pkg/accounting/rollup/rollup.go
+++ b/pkg/accounting/rollup/rollup.go
@@ -19,7 +19,7 @@ import (
 type Config struct {
 	Interval      time.Duration `help:"how frequently rollup should run" devDefault:"120s" releaseDefault:"24h"`
 	MaxAlphaUsage memory.Size   `help:"the bandwidth and storage usage limit for the alpha release" default:"25GB"`
-	DeleteTallies bool          `help:"option for deleting tallies after they are rolled up" default:"true"`
+	DeleteTallies bool          `help:"option for deleting tallies after they are rolled up" default:"false"`
 }
 
 // Service is the rollup service for totalling data on storage nodes on daily intervals

--- a/pkg/accounting/rollup/rollup_test.go
+++ b/pkg/accounting/rollup/rollup_test.go
@@ -27,13 +27,7 @@ type testData struct {
 
 func TestRollupNoDeletes(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
-		SatelliteCount: 1, StorageNodeCount: 10, UplinkCount: 0,
-		Reconfigure: testplanet.Reconfigure{
-			Satellite: func(log *zap.Logger, index int, config *satellite.Config) {
-				config.Rollup.DeleteTallies = false
-			},
-		},
-	},
+		SatelliteCount: 1, StorageNodeCount: 10, UplinkCount: 0},
 		func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 			days := 5
 			testData := createData(planet, days)
@@ -87,7 +81,13 @@ func TestRollupNoDeletes(t *testing.T) {
 }
 func TestRollupDeletes(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
-		SatelliteCount: 1, StorageNodeCount: 10, UplinkCount: 0},
+		SatelliteCount: 1, StorageNodeCount: 10, UplinkCount: 0,
+		Reconfigure: testplanet.Reconfigure{
+			Satellite: func(log *zap.Logger, index int, config *satellite.Config) {
+				config.Rollup.DeleteTallies = true
+			},
+		},
+	},
 		func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 			days := 5
 			testData := createData(planet, days)


### PR DESCRIPTION
What: sets satellite and testplanet delete-tallies config to false to avoid forgetting to update the config values

Why: safety precaution until we make sure we want to turn deletes back on


## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
