### PR TITLE
uplink: return error on load key when no key filepath

### DIFF
--- a/uplink/config_test.go
+++ b/uplink/config_test.go
@@ -63,7 +63,7 @@ func TestEncryptionConfig_LoadKey(t *testing.T) {
 		assert.Equal(t, expectedKey[:storj.KeySize], key[:])
 	})
 
-	t.Run("ok: empty file path", func(t *testing.T) {
+	t.Run("ok: empty file", func(t *testing.T) {
 		filename, cleanup := saveKey([]byte{})
 		defer cleanup()
 
@@ -73,6 +73,15 @@ func TestEncryptionConfig_LoadKey(t *testing.T) {
 		key, err := encCfg.LoadKey()
 		require.NoError(t, err)
 		assert.Equal(t, key, storj.Key{})
+	})
+
+	t.Run("error: KeyFilepath is empty", func(t *testing.T) {
+		encCfg := &EncryptionConfig{}
+
+		_, err := encCfg.LoadKey()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "KeyFilepath is empty")
+		assert.True(t, Error.Has(err), "err is not of %q class", Error)
 	})
 
 	t.Run("error: file not found", func(t *testing.T) {


### PR DESCRIPTION
What: 
For avoiding the false sense of security the LoadKey method of the
encryption configuration must return an error when the key file path is
empty, however for not breaking other existing tests on different
packages the GetMetainfo must skip to load the key when path it's empty
and use the zero value key.


Why: show another solution to the worry expressed in the review of PR #1782 (https://github.com/storj/storj/pull/1782#discussion_r278416351)

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
