### PR TITLE
removed unused .List() method

### DIFF
--- a/pkg/overlay/cache.go
+++ b/pkg/overlay/cache.go
@@ -42,8 +42,6 @@ type DB interface {
 	Get(ctx context.Context, nodeID storj.NodeID) (*NodeDossier, error)
 	// GetAll looks up nodes based on the ids from the overlay cache
 	GetAll(ctx context.Context, nodeIDs storj.NodeIDList) ([]*NodeDossier, error)
-	// List lists nodes starting from cursor
-	List(ctx context.Context, cursor storj.NodeID, limit int) ([]*NodeDossier, error)
 	// Paginate will page through the database nodes
 	Paginate(ctx context.Context, offset int64, limit int) ([]*NodeDossier, bool, error)
 
@@ -135,13 +133,6 @@ func (cache *Cache) Close() error { return nil }
 func (cache *Cache) Inspect(ctx context.Context) (storage.Keys, error) {
 	// TODO: implement inspection tools
 	return nil, errors.New("not implemented")
-}
-
-// List returns a list of nodes from the cache DB
-func (cache *Cache) List(ctx context.Context, cursor storj.NodeID, limit int) (_ []*NodeDossier, err error) {
-	defer mon.Task()(&ctx)(&err)
-
-	return cache.db.List(ctx, cursor, limit)
 }
 
 // Paginate returns a list of `limit` nodes starting from `start` offset.

--- a/pkg/overlay/cache_test.go
+++ b/pkg/overlay/cache_test.go
@@ -101,12 +101,6 @@ func testCache(ctx context.Context, t *testing.T, store overlay.DB) {
 		// TODO: add erroring database test
 	}
 
-	{ // List
-		list, err := cache.List(ctx, storj.NodeID{}, 3)
-		assert.NoError(t, err)
-		assert.NotNil(t, list)
-	}
-
 	{ // Paginate
 
 		// should return two nodes

--- a/satellite/satellitedb/locked.go
+++ b/satellite/satellitedb/locked.go
@@ -710,13 +710,6 @@ func (m *lockedOverlayCache) GetAll(ctx context.Context, nodeIDs storj.NodeIDLis
 	return m.db.GetAll(ctx, nodeIDs)
 }
 
-// List lists nodes starting from cursor
-func (m *lockedOverlayCache) List(ctx context.Context, cursor storj.NodeID, limit int) ([]*overlay.NodeDossier, error) {
-	m.Lock()
-	defer m.Unlock()
-	return m.db.List(ctx, cursor, limit)
-}
-
 // Paginate will page through the database nodes
 func (m *lockedOverlayCache) Paginate(ctx context.Context, offset int64, limit int) ([]*overlay.NodeDossier, bool, error) {
 	m.Lock()

--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -169,28 +169,6 @@ func (cache *overlaycache) GetAll(ctx context.Context, ids storj.NodeIDList) ([]
 	return infos, nil
 }
 
-// List lists nodes starting from cursor
-func (cache *overlaycache) List(ctx context.Context, cursor storj.NodeID, limit int) ([]*overlay.NodeDossier, error) {
-	// TODO: handle this nicer
-	if limit <= 0 || limit > storage.LookupLimit {
-		limit = storage.LookupLimit
-	}
-
-	dbxInfos, err := cache.db.Limited_Node_By_Id_GreaterOrEqual_OrderBy_Asc_Id(ctx, dbx.Node_Id(cursor.Bytes()), limit, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	infos := make([]*overlay.NodeDossier, len(dbxInfos))
-	for i, dbxInfo := range dbxInfos {
-		infos[i], err = convertDBNode(dbxInfo)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return infos, nil
-}
-
 // Paginate will run through
 func (cache *overlaycache) Paginate(ctx context.Context, offset int64, limit int) ([]*overlay.NodeDossier, bool, error) {
 	cursor := storj.NodeID{}


### PR DESCRIPTION
What: 
Removed unused .List() method

Why:
Less is more