### PR TITLE
made inspector segment health care about healthy nodes

### DIFF
--- a/satellite/inspector/inspector.go
+++ b/satellite/inspector/inspector.go
@@ -144,7 +144,7 @@ func (endpoint *Endpoint) SegmentHealth(ctx context.Context, in *pb.SegmentHealt
 
 	onlineNodeCount := int32(0)
 	for _, n := range nodes {
-		if endpoint.cache.IsOnline(n) {
+		if endpoint.cache.IsOnline(n) && endpoint.cache.IsHealthy(n) {
 			onlineNodeCount++
 		}
 	}


### PR DESCRIPTION
What: 
Only consider "healthy" nodes in inspector segment health check.

Why:
It strongly appears like inspector intends to measure what checker / repairer cares about.  Previously, inspector measured segment health only by what was "online", while checker also cares about if the node uptime, if it has failed too many audits, etc.  This change makes them care about the same thing.