### PR TITLE
longer repair window

### DIFF
--- a/pkg/datarepair/repairer/repairer.go
+++ b/pkg/datarepair/repairer/repairer.go
@@ -35,7 +35,7 @@ var (
 type Config struct {
 	MaxRepair    int           `help:"maximum segments that can be repaired concurrently" default:"10"`
 	Interval     time.Duration `help:"how frequently checker should audit segments" default:"0h5m0s"`
-	Timeout      time.Duration `help:"time limit for uploading repaired pieces to new storage nodes" default:"1m0s"`
+	Timeout      time.Duration `help:"time limit for uploading repaired pieces to new storage nodes" default:"10m0s"`
 	MaxBufferMem memory.Size   `help:"maximum buffer memory (in bytes) to be allocated for read buffers" default:"4M"`
 }
 


### PR DESCRIPTION
What: 
Repair previously timed out in 1 minute.  We made that 10.

Why:
Stefan was seeing repair exit after exactly 1 minute quite often in his logs.
It was timing out before it could complete.
