### PR TITLE
If/v3 1541: Change where the encryption key is being stored for uplink 

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -37,7 +37,7 @@ type GatewayFlags struct {
 	Minio  miniogw.MinioConfig
 
 	uplink.Config
-	EncryptionKey string `default:"" help:"the root key for encrypting the data; when set, it overrides the key stored in the file indicated by the configuration file" setup:"false"`
+	EncryptionKey string `default:"" help:"the root key for encrypting the data; when set, it overrides the key stored in the file indicated by the configuration file"`
 }
 
 var (

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -245,7 +245,7 @@ func (flags GatewayFlags) NewGateway(ctx context.Context, ident *identity.FullId
 		encKey = new(storj.Key)
 		copy(encKey[:], flags.EncryptionKey)
 	} else {
-		k, err := flags.Enc.Key()
+		k, err := flags.Enc.LoadKey()
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/storj-sim/network.go
+++ b/cmd/storj-sim/network.go
@@ -312,8 +312,6 @@ func newNetwork(flags *Flags) (*Processes, error) {
 
 				"--satellite-addr", satellite.Address,
 
-				"--enc.key=TestEncryptionKey",
-
 				"--rs.min-threshold", strconv.Itoa(1 * flags.StorageNodeCount / 5),
 				"--rs.repair-threshold", strconv.Itoa(2 * flags.StorageNodeCount / 5),
 				"--rs.success-threshold", strconv.Itoa(3 * flags.StorageNodeCount / 5),
@@ -324,7 +322,9 @@ func newNetwork(flags *Flags) (*Processes, error) {
 
 				"--debug.addr", net.JoinHostPort(host, port(gatewayPeer, i, debugHTTP)),
 			},
-			"run": {},
+			"run": {
+				"--encryption-key=TestEncryptionKey",
+			},
 		})
 
 		process.ExecBefore["run"] = func(process *Process) error {

--- a/cmd/storj-sim/network.go
+++ b/cmd/storj-sim/network.go
@@ -321,10 +321,9 @@ func newNetwork(flags *Flags) (*Processes, error) {
 				"--tls.use-peer-ca-whitelist=false",
 
 				"--debug.addr", net.JoinHostPort(host, port(gatewayPeer, i, debugHTTP)),
-			},
-			"run": {
 				"--encryption-key=TestEncryptionKey",
 			},
+			"run": {},
 		})
 
 		process.ExecBefore["run"] = func(process *Process) error {

--- a/cmd/uplink/cmd/cp.go
+++ b/cmd/uplink/cmd/cp.go
@@ -19,6 +19,7 @@ import (
 	"storj.io/storj/internal/fpath"
 	libuplink "storj.io/storj/lib/uplink"
 	"storj.io/storj/pkg/process"
+	"storj.io/storj/uplink"
 )
 
 var (
@@ -87,7 +88,7 @@ func upload(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgress 
 
 	var access libuplink.EncryptionAccess
 	access.Key, err = cfg.Enc.LoadKey()
-	if err != nil {
+	if err != nil && err != uplink.ErrKeyFilepathEmpty {
 		return err
 	}
 
@@ -143,7 +144,7 @@ func download(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgres
 		err    error
 	)
 	access.Key, err = cfg.Enc.LoadKey()
-	if err != nil {
+	if err != nil && err != uplink.ErrKeyFilepathEmpty {
 		return err
 	}
 
@@ -225,7 +226,7 @@ func copyObject(ctx context.Context, src fpath.FPath, dst fpath.FPath) error {
 		err    error
 	)
 	access.Key, err = cfg.Enc.LoadKey()
-	if err != nil {
+	if err != nil && err != uplink.ErrKeyFilepathEmpty {
 		return err
 	}
 

--- a/cmd/uplink/cmd/cp.go
+++ b/cmd/uplink/cmd/cp.go
@@ -37,7 +37,7 @@ func init() {
 }
 
 // upload transfers src from local machine to s3 compatible object dst
-func upload(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgress bool) (err error) {
+func upload(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgress bool) error {
 	if !src.IsLocal() {
 		return fmt.Errorf("source must be local path: %s", src)
 	}
@@ -46,7 +46,10 @@ func upload(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgress 
 		return fmt.Errorf("destination must be Storj URL: %s", dst)
 	}
 
-	var expiration time.Time
+	var (
+		expiration time.Time
+		err        error
+	)
 	if *expires != "" {
 		expiration, err = time.Parse(time.RFC3339, *expires)
 		if err != nil {
@@ -83,7 +86,10 @@ func upload(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgress 
 	}
 
 	var access libuplink.EncryptionAccess
-	copy(access.Key[:], []byte(cfg.Enc.Key))
+	access.Key, err = cfg.Enc.LoadKey()
+	if err != nil {
+		return err
+	}
 
 	project, bucket, err := cfg.GetProjectAndBucket(ctx, dst.Bucket(), access)
 	if err != nil {
@@ -123,7 +129,7 @@ func upload(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgress 
 }
 
 // download transfers s3 compatible object src to dst on local machine
-func download(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgress bool) (err error) {
+func download(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgress bool) error {
 	if src.IsLocal() {
 		return fmt.Errorf("source must be Storj URL: %s", src)
 	}
@@ -132,8 +138,14 @@ func download(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgres
 		return fmt.Errorf("destination must be local path: %s", dst)
 	}
 
-	var access libuplink.EncryptionAccess
-	copy(access.Key[:], []byte(cfg.Enc.Key))
+	var (
+		access libuplink.EncryptionAccess
+		err    error
+	)
+	access.Key, err = cfg.Enc.LoadKey()
+	if err != nil {
+		return err
+	}
 
 	project, bucket, err := cfg.GetProjectAndBucket(ctx, src.Bucket(), access)
 	if err != nil {
@@ -199,7 +211,7 @@ func download(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgres
 }
 
 // copy copies s3 compatible object src to s3 compatible object dst
-func copyObject(ctx context.Context, src fpath.FPath, dst fpath.FPath) (err error) {
+func copyObject(ctx context.Context, src fpath.FPath, dst fpath.FPath) error {
 	if src.IsLocal() {
 		return fmt.Errorf("source must be Storj URL: %s", src)
 	}
@@ -208,8 +220,14 @@ func copyObject(ctx context.Context, src fpath.FPath, dst fpath.FPath) (err erro
 		return fmt.Errorf("destination must be Storj URL: %s", dst)
 	}
 
-	var access libuplink.EncryptionAccess
-	copy(access.Key[:], []byte(cfg.Enc.Key))
+	var (
+		access libuplink.EncryptionAccess
+		err    error
+	)
+	access.Key, err = cfg.Enc.LoadKey()
+	if err != nil {
+		return err
+	}
 
 	project, bucket, err := cfg.GetProjectAndBucket(ctx, dst.Bucket(), access)
 	if err != nil {

--- a/cmd/uplink/cmd/cp.go
+++ b/cmd/uplink/cmd/cp.go
@@ -19,7 +19,6 @@ import (
 	"storj.io/storj/internal/fpath"
 	libuplink "storj.io/storj/lib/uplink"
 	"storj.io/storj/pkg/process"
-	"storj.io/storj/uplink"
 )
 
 var (
@@ -88,7 +87,7 @@ func upload(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgress 
 
 	var access libuplink.EncryptionAccess
 	access.Key, err = cfg.Enc.LoadKey()
-	if err != nil && err != uplink.ErrKeyFilepathEmpty {
+	if err != nil {
 		return err
 	}
 
@@ -144,7 +143,7 @@ func download(ctx context.Context, src fpath.FPath, dst fpath.FPath, showProgres
 		err    error
 	)
 	access.Key, err = cfg.Enc.LoadKey()
-	if err != nil && err != uplink.ErrKeyFilepathEmpty {
+	if err != nil {
 		return err
 	}
 
@@ -226,7 +225,7 @@ func copyObject(ctx context.Context, src fpath.FPath, dst fpath.FPath) error {
 		err    error
 	)
 	access.Key, err = cfg.Enc.LoadKey()
-	if err != nil && err != uplink.ErrKeyFilepathEmpty {
+	if err != nil {
 		return err
 	}
 

--- a/cmd/uplink/cmd/ls.go
+++ b/cmd/uplink/cmd/ls.go
@@ -14,6 +14,7 @@ import (
 	libuplink "storj.io/storj/lib/uplink"
 	"storj.io/storj/pkg/process"
 	"storj.io/storj/pkg/storj"
+	"storj.io/storj/uplink"
 )
 
 var (
@@ -44,7 +45,7 @@ func list(cmd *cobra.Command, args []string) error {
 
 	var access libuplink.EncryptionAccess
 	access.Key, err = cfg.Enc.LoadKey()
-	if err != nil {
+	if err != nil && err != uplink.ErrKeyFilepathEmpty {
 		return err
 	}
 

--- a/cmd/uplink/cmd/ls.go
+++ b/cmd/uplink/cmd/ls.go
@@ -14,7 +14,6 @@ import (
 	libuplink "storj.io/storj/lib/uplink"
 	"storj.io/storj/pkg/process"
 	"storj.io/storj/pkg/storj"
-	"storj.io/storj/uplink"
 )
 
 var (
@@ -45,7 +44,7 @@ func list(cmd *cobra.Command, args []string) error {
 
 	var access libuplink.EncryptionAccess
 	access.Key, err = cfg.Enc.LoadKey()
-	if err != nil && err != uplink.ErrKeyFilepathEmpty {
+	if err != nil {
 		return err
 	}
 

--- a/cmd/uplink/cmd/ls.go
+++ b/cmd/uplink/cmd/ls.go
@@ -43,7 +43,10 @@ func list(cmd *cobra.Command, args []string) error {
 	}()
 
 	var access libuplink.EncryptionAccess
-	copy(access.Key[:], []byte(cfg.Enc.Key))
+	access.Key, err = cfg.Enc.LoadKey()
+	if err != nil {
+		return err
+	}
 
 	if len(args) > 0 {
 		src, err := fpath.New(args[0])

--- a/cmd/uplink/cmd/rb.go
+++ b/cmd/uplink/cmd/rb.go
@@ -12,7 +12,6 @@ import (
 	libuplink "storj.io/storj/lib/uplink"
 	"storj.io/storj/pkg/process"
 	"storj.io/storj/pkg/storj"
-	"storj.io/storj/uplink"
 )
 
 func init() {
@@ -45,7 +44,7 @@ func deleteBucket(cmd *cobra.Command, args []string) error {
 
 	var access libuplink.EncryptionAccess
 	access.Key, err = cfg.Enc.LoadKey()
-	if err != nil && err != uplink.ErrKeyFilepathEmpty {
+	if err != nil {
 		return err
 	}
 

--- a/cmd/uplink/cmd/rb.go
+++ b/cmd/uplink/cmd/rb.go
@@ -43,7 +43,10 @@ func deleteBucket(cmd *cobra.Command, args []string) error {
 	}
 
 	var access libuplink.EncryptionAccess
-	copy(access.Key[:], []byte(cfg.Enc.Key))
+	access.Key, err = cfg.Enc.LoadKey()
+	if err != nil {
+		return err
+	}
 
 	project, bucket, err := cfg.GetProjectAndBucket(ctx, dst.Bucket(), access)
 	if err != nil {

--- a/cmd/uplink/cmd/rb.go
+++ b/cmd/uplink/cmd/rb.go
@@ -12,6 +12,7 @@ import (
 	libuplink "storj.io/storj/lib/uplink"
 	"storj.io/storj/pkg/process"
 	"storj.io/storj/pkg/storj"
+	"storj.io/storj/uplink"
 )
 
 func init() {
@@ -44,7 +45,7 @@ func deleteBucket(cmd *cobra.Command, args []string) error {
 
 	var access libuplink.EncryptionAccess
 	access.Key, err = cfg.Enc.LoadKey()
-	if err != nil {
+	if err != nil && err != uplink.ErrKeyFilepathEmpty {
 		return err
 	}
 

--- a/cmd/uplink/cmd/rm.go
+++ b/cmd/uplink/cmd/rm.go
@@ -11,6 +11,7 @@ import (
 	"storj.io/storj/internal/fpath"
 	libuplink "storj.io/storj/lib/uplink"
 	"storj.io/storj/pkg/process"
+	"storj.io/storj/uplink"
 )
 
 func init() {
@@ -39,7 +40,7 @@ func deleteObject(cmd *cobra.Command, args []string) error {
 
 	var access libuplink.EncryptionAccess
 	access.Key, err = cfg.Enc.LoadKey()
-	if err != nil {
+	if err != nil && err != uplink.ErrKeyFilepathEmpty {
 		return err
 	}
 

--- a/cmd/uplink/cmd/rm.go
+++ b/cmd/uplink/cmd/rm.go
@@ -11,7 +11,6 @@ import (
 	"storj.io/storj/internal/fpath"
 	libuplink "storj.io/storj/lib/uplink"
 	"storj.io/storj/pkg/process"
-	"storj.io/storj/uplink"
 )
 
 func init() {
@@ -40,7 +39,7 @@ func deleteObject(cmd *cobra.Command, args []string) error {
 
 	var access libuplink.EncryptionAccess
 	access.Key, err = cfg.Enc.LoadKey()
-	if err != nil && err != uplink.ErrKeyFilepathEmpty {
+	if err != nil {
 		return err
 	}
 

--- a/cmd/uplink/cmd/rm.go
+++ b/cmd/uplink/cmd/rm.go
@@ -38,7 +38,10 @@ func deleteObject(cmd *cobra.Command, args []string) error {
 	}
 
 	var access libuplink.EncryptionAccess
-	copy(access.Key[:], []byte(cfg.Enc.Key))
+	access.Key, err = cfg.Enc.LoadKey()
+	if err != nil {
+		return err
+	}
 
 	project, bucket, err := cfg.GetProjectAndBucket(ctx, dst.Bucket(), access)
 	if err != nil {

--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -96,23 +96,23 @@ func (c *UplinkFlags) GetProject(ctx context.Context) (*libuplink.Project, error
 	cfg.Volatile.MaxInlineSize = c.Client.MaxInlineSize
 	cfg.Volatile.MaxMemory = c.RS.MaxBufferMem
 
-	uplink, err := c.NewUplink(ctx, cfg)
+	uplk, err := c.NewUplink(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 
 	encryptionKey, err := c.Enc.LoadKey()
-	if err != nil {
+	if err != nil && err != uplink.ErrKeyFilepathEmpty {
 		return nil, err
 	}
 
 	opts := &libuplink.ProjectOptions{}
 	opts.Volatile.EncryptionKey = &encryptionKey
 
-	project, err := uplink.OpenProject(ctx, satelliteAddr, apiKey, opts)
+	project, err := uplk.OpenProject(ctx, satelliteAddr, apiKey, opts)
 
 	if err != nil {
-		if err := uplink.Close(); err != nil {
+		if err := uplk.Close(); err != nil {
 			fmt.Printf("error closing uplink: %+v\n", err)
 		}
 	}

--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -102,7 +102,7 @@ func (c *UplinkFlags) GetProject(ctx context.Context) (*libuplink.Project, error
 	}
 
 	encryptionKey, err := c.Enc.LoadKey()
-	if err != nil && err != uplink.ErrKeyFilepathEmpty {
+	if err != nil {
 		return nil, err
 	}
 

--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -101,11 +101,13 @@ func (c *UplinkFlags) GetProject(ctx context.Context) (*libuplink.Project, error
 		return nil, err
 	}
 
-	opts := &libuplink.ProjectOptions{}
+	encryptionKey, err := c.Enc.LoadKey()
+	if err != nil {
+		return nil, err
+	}
 
-	encKey := new(storj.Key)
-	copy(encKey[:], c.Enc.Key)
-	opts.Volatile.EncryptionKey = encKey
+	opts := &libuplink.ProjectOptions{}
+	opts.Volatile.EncryptionKey = &encryptionKey
 
 	project, err := uplink.OpenProject(ctx, satelliteAddr, apiKey, opts)
 

--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -189,7 +189,8 @@ Some things to try next:
 		return nil
 	}
 
-	return process.SaveConfigWithAllDefaults(cmd.Flags(), filepath.Join(setupDir, "config.yaml"), nil)
+	return process.SaveConfigWithAllDefaults(
+		cmd.Flags(), filepath.Join(setupDir, process.DefaultConfFilename), nil)
 }
 
 // ApplyDefaultHostAndPortToAddrFlag applies the default host and/or port if either is missing in the specified flag name.

--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -187,7 +187,8 @@ Please enter numeric choice or enter satellite address manually [1]: `)
 			}
 		}
 
-		err = process.SaveConfigWithAllDefaults(cmd.Flags(), filepath.Join(setupDir, "config.yaml"), override)
+		err = process.SaveConfigWithAllDefaults(
+			cmd.Flags(), filepath.Join(setupDir, process.DefaultConfFilename), override)
 		if err != nil {
 			return nil
 		}

--- a/cmd/uplink/cmd/setup_test.go
+++ b/cmd/uplink/cmd/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"storj.io/storj/cmd/uplink/cmd"
 	"storj.io/storj/internal/testcontext"
+	"storj.io/storj/pkg/storj"
 )
 
 func TestDefaultHostAndPortAppliedToSatelliteAddrWithNoHostOrPort(t *testing.T) {
@@ -122,57 +123,47 @@ func TestDefaultPortAppliedToSatelliteAddrWithPortColonButNoPort(t *testing.T) {
 		"satellite-addr should contain default port when no port specified")
 }
 
-func TestSaveEncriptionKey(t *testing.T) {
-	expectedKey := make([]byte, rand.Intn(20)+1)
-	_, err := rand.Read(expectedKey)
-	require.NoError(t, err)
+func TestSaveEncryptionKey(t *testing.T) {
+	var expectedKey *storj.Key
+	{
+		key := make([]byte, rand.Intn(20)+1)
+		_, err := rand.Read(key)
+		require.NoError(t, err)
+		expectedKey = storj.NewKey(key)
+	}
 
 	t.Run("ok", func(t *testing.T) {
 		ctx := testcontext.New(t)
 		defer ctx.Cleanup()
 
-		filename := ctx.File("storj-test-cmd-uplink", ".enc.key")
-		err = cmd.SaveEncryptionKey(expectedKey, filename)
+		filename := ctx.File("storj-test-cmd-uplink", "encryption.key")
+		err := cmd.SaveEncryptionKey(expectedKey, filename)
 		require.NoError(t, err)
 
-		// Read the key from the file to compare that it matches with the saved one.
-		file, err := os.Open(filename)
+		key, err := ioutil.ReadFile(filename)
 		require.NoError(t, err)
-		defer func() { require.NoError(t, file.Close()) }()
-
-		key := make([]byte, len(expectedKey))
-		_, err = file.Read(key)
-		require.NoError(t, err)
-		assert.Equal(t, expectedKey, key)
-
-		// Check that the key file has a read only file permissions for the user
-		fileInfo, err := file.Stat()
-		require.NoError(t, err)
-		assert.Equal(t, os.FileMode(0400), fileInfo.Mode().Perm())
+		assert.Equal(t, expectedKey, storj.NewKey(key))
 	})
 
 	t.Run("error: unexisting dir", func(t *testing.T) {
 		// Create a directory and remove it for making sure that the path doesn't
 		// exist
-		dir, err := ioutil.TempDir("", "storj-test-cmd-uplink")
-		require.NoError(t, err)
-		err = os.RemoveAll(dir)
-		require.NoError(t, err)
+		ctx := testcontext.New(t)
+		dir := ctx.Dir("storj-test-cmd-uplink")
+		ctx.Cleanup()
 
 		filename := filepath.Join(dir, "enc.key")
-		err = cmd.SaveEncryptionKey(expectedKey, filename)
+		err := cmd.SaveEncryptionKey(expectedKey, filename)
 		require.Errorf(t, err, "directory path doesn't exist")
 	})
 
 	t.Run("error: file already exists", func(t *testing.T) {
-		// Create an empty file
-		file, err := ioutil.TempFile("", "storj-test-cmd-uplink-key-*")
-		require.NoError(t, err)
-		err = file.Close()
-		require.NoError(t, err)
-		defer func() { require.NoError(t, os.Remove(file.Name())) }()
+		ctx := testcontext.New(t)
+		defer ctx.Cleanup()
+		filename := ctx.File("encryption.key")
+		require.NoError(t, ioutil.WriteFile(filename, nil, os.FileMode(0600)))
 
-		err = cmd.SaveEncryptionKey(expectedKey, file.Name())
+		err := cmd.SaveEncryptionKey(expectedKey, filename)
 		require.Errorf(t, err, "file key already exists")
 	})
 }

--- a/cmd/uplink/cmd/setup_test.go
+++ b/cmd/uplink/cmd/setup_test.go
@@ -4,10 +4,15 @@
 package cmd_test
 
 import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"storj.io/storj/cmd/uplink/cmd"
 )
 
@@ -114,4 +119,60 @@ func TestDefaultPortAppliedToSatelliteAddrWithPortColonButNoPort(t *testing.T) {
 
 	assert.Equal(t, "ahost:7777", setupCmd.Flags().Lookup("satellite-addr").Value.String(),
 		"satellite-addr should contain default port when no port specified")
+}
+
+func TestSaveEncriptionKey(t *testing.T) {
+	expKey := make([]byte, rand.Intn(20)+1)
+	_, err := rand.Read(expKey)
+	require.NoError(t, err)
+
+	t.Run("ok", func(t *testing.T) {
+		dir, err := ioutil.TempDir("", "storj-test-cmd-uplink")
+		require.NoError(t, err)
+		defer func() { _ = os.RemoveAll(dir) }()
+
+		fname := filepath.Join(dir, ".enc.key")
+		err = cmd.SaveEncryptionKey(expKey, fname)
+		require.NoError(t, err)
+
+		// Read the key from the file to compare that it matches with the saved one.
+		f, err := os.Open(fname)
+		require.NoError(t, err)
+		defer func() { _ = f.Close() }()
+
+		key := make([]byte, len(expKey))
+		_, err = f.Read(key)
+		require.NoError(t, err)
+		assert.Equal(t, expKey, key)
+
+		// Check that the key file has a read only file permissions for the user
+		fi, err := f.Stat()
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0400), fi.Mode().Perm())
+	})
+
+	t.Run("error: unexisting dir", func(t *testing.T) {
+		// Create a directory and remove it for making sure that the path doesn't
+		// exist
+		dir, err := ioutil.TempDir("", "storj-test-cmd-uplink")
+		require.NoError(t, err)
+		err = os.RemoveAll(dir)
+		require.NoError(t, err)
+
+		fname := filepath.Join(dir, "enc.key")
+		err = cmd.SaveEncryptionKey(expKey, fname)
+		assert.Errorf(t, err, "directory path doesn't exist")
+	})
+
+	t.Run("error: file already exists", func(t *testing.T) {
+		// Create an empty file
+		f, err := ioutil.TempFile("", "storj-test-cmd-uplink-key-*")
+		require.NoError(t, err)
+		err = f.Close()
+		require.NoError(t, err)
+		defer func() { _ = os.Remove(f.Name()) }()
+
+		err = cmd.SaveEncryptionKey(expKey, f.Name())
+		assert.Errorf(t, err, "file key already exists")
+	})
 }

--- a/cmd/uplink/cmd/setup_test.go
+++ b/cmd/uplink/cmd/setup_test.go
@@ -4,18 +4,11 @@
 package cmd_test
 
 import (
-	"io/ioutil"
-	"math/rand"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"storj.io/storj/cmd/uplink/cmd"
-	"storj.io/storj/internal/testcontext"
-	"storj.io/storj/pkg/storj"
 )
 
 func TestDefaultHostAndPortAppliedToSatelliteAddrWithNoHostOrPort(t *testing.T) {
@@ -121,49 +114,4 @@ func TestDefaultPortAppliedToSatelliteAddrWithPortColonButNoPort(t *testing.T) {
 
 	assert.Equal(t, "ahost:7777", setupCmd.Flags().Lookup("satellite-addr").Value.String(),
 		"satellite-addr should contain default port when no port specified")
-}
-
-func TestSaveEncryptionKey(t *testing.T) {
-	var expectedKey *storj.Key
-	{
-		key := make([]byte, rand.Intn(20)+1)
-		_, err := rand.Read(key)
-		require.NoError(t, err)
-		expectedKey = storj.NewKey(key)
-	}
-
-	t.Run("ok", func(t *testing.T) {
-		ctx := testcontext.New(t)
-		defer ctx.Cleanup()
-
-		filename := ctx.File("storj-test-cmd-uplink", "encryption.key")
-		err := cmd.SaveEncryptionKey(expectedKey, filename)
-		require.NoError(t, err)
-
-		key, err := ioutil.ReadFile(filename)
-		require.NoError(t, err)
-		assert.Equal(t, expectedKey, storj.NewKey(key))
-	})
-
-	t.Run("error: unexisting dir", func(t *testing.T) {
-		// Create a directory and remove it for making sure that the path doesn't
-		// exist
-		ctx := testcontext.New(t)
-		dir := ctx.Dir("storj-test-cmd-uplink")
-		ctx.Cleanup()
-
-		filename := filepath.Join(dir, "enc.key")
-		err := cmd.SaveEncryptionKey(expectedKey, filename)
-		require.Errorf(t, err, "directory path doesn't exist")
-	})
-
-	t.Run("error: file already exists", func(t *testing.T) {
-		ctx := testcontext.New(t)
-		defer ctx.Cleanup()
-		filename := ctx.File("encryption.key")
-		require.NoError(t, ioutil.WriteFile(filename, nil, os.FileMode(0600)))
-
-		err := cmd.SaveEncryptionKey(expectedKey, filename)
-		require.Errorf(t, err, "file key already exists")
-	})
 }

--- a/pkg/process/exec_conf.go
+++ b/pkg/process/exec_conf.go
@@ -30,6 +30,9 @@ import (
 	"storj.io/storj/internal/version"
 )
 
+// DefaultConfFilename is the default filename used for storing a configuration.
+const DefaultConfFilename = "config.yaml"
+
 var (
 	mon = monkit.Package()
 
@@ -175,7 +178,7 @@ func cleanup(cmd *cobra.Command) {
 
 		cfgFlag := cmd.Flags().Lookup("config-dir")
 		if cfgFlag != nil && cfgFlag.Value.String() != "" {
-			path := filepath.Join(os.ExpandEnv(cfgFlag.Value.String()), "config.yaml")
+			path := filepath.Join(os.ExpandEnv(cfgFlag.Value.String()), DefaultConfFilename)
 			if cmd.Annotations["type"] != "setup" || fileExists(path) {
 				vip.SetConfigFile(path)
 				err = vip.ReadInConfig()

--- a/pkg/storj/encryption.go
+++ b/pkg/storj/encryption.go
@@ -131,6 +131,13 @@ const (
 	NonceSize = 24
 )
 
+// NewKey creates a new key from a passphrase
+func NewKey(passphrase []byte) *Key {
+	key := &Key{}
+	copy(key[:], passphrase)
+	return key
+}
+
 // Key represents the largest key used by any encryption protocol
 type Key [KeySize]byte
 

--- a/pkg/storj/encryption.go
+++ b/pkg/storj/encryption.go
@@ -133,6 +133,7 @@ const (
 
 // NewKey creates a new key from a passphrase
 func NewKey(passphrase []byte) *Key {
+	// TODO: if/v3-1541 This function should return an error when len(passphrase) == 0
 	key := &Key{}
 	copy(key[:], passphrase)
 	return key
@@ -144,6 +145,11 @@ type Key [KeySize]byte
 // Raw returns the key as a raw byte array pointer
 func (key *Key) Raw() *[KeySize]byte {
 	return (*[KeySize]byte)(key)
+}
+
+// IsZero returns true if key is nil or it points to its zero value
+func (key *Key) IsZero() bool {
+	return key == nil || *key == (Key{})
 }
 
 // Nonce represents the largest nonce used by any encryption protocol

--- a/pkg/storj/encryption_test.go
+++ b/pkg/storj/encryption_test.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package storj_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"storj.io/storj/pkg/storj"
+)
+
+func TestNewKey(t *testing.T) {
+	t.Run("nil passphrase", func(t *testing.T) {
+		key := storj.NewKey(nil)
+		require.Equal(t, &storj.Key{}, key)
+	})
+
+	t.Run("empty passphrase", func(t *testing.T) {
+		key := storj.NewKey([]byte{})
+		require.Equal(t, &storj.Key{}, key)
+	})
+
+	t.Run("passphrase length less than or equal KeySize", func(t *testing.T) {
+		passphrase := make([]byte, rand.Intn(storj.KeySize)+1)
+		_, err := rand.Read(passphrase)
+		require.NoError(t, err)
+		key := storj.NewKey(passphrase)
+		assert.Equal(t, passphrase, key[:len(passphrase)])
+		assert.Equal(t, make([]byte, storj.KeySize-len(passphrase)), key[len(passphrase):])
+	})
+
+	t.Run("passphrase length greater than KeySize", func(t *testing.T) {
+		passphrase := make([]byte, rand.Intn(10)+storj.KeySize+1)
+		_, err := rand.Read(passphrase)
+		require.NoError(t, err)
+		key := storj.NewKey(passphrase)
+		assert.Equal(t, passphrase[:storj.KeySize], key[:])
+	})
+}

--- a/pkg/storj/encryption_test.go
+++ b/pkg/storj/encryption_test.go
@@ -14,16 +14,19 @@ import (
 
 func TestNewKey(t *testing.T) {
 	t.Run("nil passphrase", func(t *testing.T) {
+		t.Parallel()
 		key := storj.NewKey(nil)
 		require.Equal(t, &storj.Key{}, key)
 	})
 
 	t.Run("empty passphrase", func(t *testing.T) {
+		t.Parallel()
 		key := storj.NewKey([]byte{})
 		require.Equal(t, &storj.Key{}, key)
 	})
 
 	t.Run("passphrase length less than or equal KeySize", func(t *testing.T) {
+		t.Parallel()
 		passphrase := make([]byte, rand.Intn(storj.KeySize)+1)
 		_, err := rand.Read(passphrase)
 		require.NoError(t, err)
@@ -33,10 +36,33 @@ func TestNewKey(t *testing.T) {
 	})
 
 	t.Run("passphrase length greater than KeySize", func(t *testing.T) {
+		t.Parallel()
 		passphrase := make([]byte, rand.Intn(10)+storj.KeySize+1)
 		_, err := rand.Read(passphrase)
 		require.NoError(t, err)
 		key := storj.NewKey(passphrase)
 		assert.Equal(t, passphrase[:storj.KeySize], key[:])
+	})
+}
+
+func TestKey_IsZero(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var key *storj.Key
+		require.True(t, key.IsZero())
+
+		wrapperFn := func(key *storj.Key) bool {
+			return key.IsZero()
+		}
+		require.True(t, wrapperFn(nil))
+	})
+
+	t.Run("zero", func(t *testing.T) {
+		key := &storj.Key{}
+		require.True(t, key.IsZero())
+	})
+
+	t.Run("no nil/zero", func(t *testing.T) {
+		key := &storj.Key{'k'}
+		require.False(t, key.IsZero())
 	})
 }

--- a/uplink/config.go
+++ b/uplink/config.go
@@ -57,7 +57,7 @@ type EncryptionConfig struct {
 //
 // It returns an error if:
 //
-// * If KeyFilepath field is an empty string.
+// * KeyFilepath field is an empty string. Err value will be ErrKeyFilepathEmpty
 // * The file doesn't exist.
 // * There is an I/O error.
 //
@@ -66,7 +66,7 @@ type EncryptionConfig struct {
 // several different types as a type of storj.Key, [32]byte, etc.
 func (cfg *EncryptionConfig) LoadKey() (key storj.Key, err error) {
 	if cfg.KeyFilepath == "" {
-		return storj.Key{}, Error.New("KeyFilepath is empty")
+		return storj.Key{}, ErrKeyFilepathEmpty
 	}
 
 	file, err := os.Open(cfg.KeyFilepath)
@@ -110,6 +110,9 @@ var (
 
 	// Error is the errs class of standard End User Client errors
 	Error = errs.Class("Uplink configuration error")
+	// ErrKeyFilepathEmpty is returned when trying to load from the file the
+	// encryption key but the filepath value is an empty string.
+	ErrKeyFilepathEmpty = Error.New("KeyFilepath is empty")
 )
 
 // GetMetainfo returns an implementation of storj.Metainfo

--- a/uplink/config.go
+++ b/uplink/config.go
@@ -73,7 +73,7 @@ func (encCfg *EncryptionConfig) Key() (storj.Key, error) {
 	f, err := os.Open(encCfg.KeyFilepath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return storj.Key{}, Error.Wrap(fmt.Errorf("not found key file %q", encCfg.KeyFilepath))
+			return storj.Key{}, Error.New("not found key file %q", encCfg.KeyFilepath)
 		}
 
 		return storj.Key{}, errs.Wrap(err)

--- a/uplink/config.go
+++ b/uplink/config.go
@@ -66,7 +66,7 @@ type EncryptionConfig struct {
 // several different types as a type of storj.Key, [32]byte, etc.
 func (cfg *EncryptionConfig) LoadKey() (key storj.Key, err error) {
 	if cfg.KeyFilepath == "" {
-		return storj.Key{}, ErrKeyFilepathEmpty
+		return storj.Key{}, Error.New("KeyFilepath is empty")
 	}
 
 	file, err := os.Open(cfg.KeyFilepath)
@@ -95,7 +95,7 @@ func (cfg *EncryptionConfig) LoadKey() (key storj.Key, err error) {
 // directory doesn't exist, the file already exists or there is an I/O error.
 func (cfg *EncryptionConfig) SaveKey(key *storj.Key) error {
 	if cfg.KeyFilepath == "" {
-		return ErrKeyFilepathEmpty
+		return Error.New("KeyFilepath is empty")
 	}
 
 	if key.IsZero() {
@@ -146,9 +146,6 @@ var (
 
 	// Error is the errs class of standard End User Client errors
 	Error = errs.Class("Uplink configuration error")
-	// ErrKeyFilepathEmpty is returned when trying to load from the file the
-	// encryption key but the filepath value is an empty string.
-	ErrKeyFilepathEmpty = Error.New("KeyFilepath is empty")
 )
 
 // GetMetainfo returns an implementation of storj.Metainfo

--- a/uplink/config.go
+++ b/uplink/config.go
@@ -43,7 +43,7 @@ type RSConfig struct {
 // EncryptionConfig is a configuration struct that keeps details about
 // encrypting segments
 type EncryptionConfig struct {
-	// TODO: WIP#if/v3-1541 read TODO in Key method why the following field cannot
+	// TODO: if/v3-1541 read TODO in Key method why the following field cannot
 	// be added
 	// RootKey     *storj.Key  // The root key for encrypting the data and read it from KeyFilepath, see Key method.
 	KeyFilepath string      `help:"the path to the file which contains the root key for encrypting the data"`
@@ -61,8 +61,8 @@ type EncryptionConfig struct {
 // * The file doesn't exist.
 // * There is an I/O error.
 //
-// TODO: WIP#if/v3-1541 refactor cache the key after the firs read. The problem
-// is with pkg/cfgstruct which is inflexible on accepting unexported keys nor
+// TODO: if/v3-1541 refactor cache the key after the firs read. The problem is
+// with pkg/cfgstruct which is inflexible on accepting unexported keys nor
 // several different types as a type of storj.Key, [32]byte, etc.
 func (cfg *EncryptionConfig) LoadKey() (key storj.Key, err error) {
 	if cfg.KeyFilepath == "" {

--- a/uplink/config_test.go
+++ b/uplink/config_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
 package uplink
 
 import (

--- a/uplink/config_test.go
+++ b/uplink/config_test.go
@@ -15,7 +15,7 @@ import (
 	"storj.io/storj/pkg/storj"
 )
 
-func TestKeyFilepath_Key(t *testing.T) {
+func TestEncryptionConfig_Key(t *testing.T) {
 	saveKey := func(key []byte) (filepath string, removeFile func()) {
 		f, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
 		require.NoError(t, err)
@@ -40,8 +40,10 @@ func TestKeyFilepath_Key(t *testing.T) {
 		var expKey storj.Key
 		copy(expKey[:], someKey)
 
-		kfpath := keyFilepath(fpath)
-		key, err := kfpath.Key()
+		encCfg := &EncryptionConfig{
+			KeyFilepath: fpath,
+		}
+		key, err := encCfg.Key()
 		require.NoError(t, err)
 
 		assert.Equal(t, expKey[:], key[:])
@@ -54,8 +56,10 @@ func TestKeyFilepath_Key(t *testing.T) {
 		fpath, cleanup := saveKey(expKey)
 		defer cleanup()
 
-		kfpath := keyFilepath(fpath)
-		key, err := kfpath.Key()
+		encCfg := &EncryptionConfig{
+			KeyFilepath: fpath,
+		}
+		key, err := encCfg.Key()
 		require.NoError(t, err)
 
 		assert.Equal(t, expKey[:storj.KeySize], key[:])
@@ -65,8 +69,10 @@ func TestKeyFilepath_Key(t *testing.T) {
 		fpath, cleanup := saveKey([]byte{})
 		defer cleanup()
 
-		kfpath := keyFilepath(fpath)
-		key, err := kfpath.Key()
+		encCfg := &EncryptionConfig{
+			KeyFilepath: fpath,
+		}
+		key, err := encCfg.Key()
 		require.NoError(t, err)
 		assert.Equal(t, key, storj.Key{})
 	})
@@ -80,8 +86,10 @@ func TestKeyFilepath_Key(t *testing.T) {
 		err = os.Remove(f.Name())
 		require.NoError(t, err)
 
-		kfpath := keyFilepath(f.Name())
-		_, err = kfpath.Key()
+		encCfg := &EncryptionConfig{
+			KeyFilepath: f.Name(),
+		}
+		_, err = encCfg.Key()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), fmt.Sprintf("not found key file %q", f.Name()))
 		assert.True(t, Error.Has(err), "err is not of %q class", Error)
@@ -99,8 +107,10 @@ func TestKeyFilepath_Key(t *testing.T) {
 		err = f.Chmod(0401)
 		require.NoError(t, err)
 
-		kfpath := keyFilepath(f.Name())
-		_, err = kfpath.Key()
+		encCfg := &EncryptionConfig{
+			KeyFilepath: f.Name(),
+		}
+		_, err = encCfg.Key()
 		require.Error(t, err)
 		assert.Contains(t,
 			err.Error(), fmt.Sprintf("permissions '0401' for key file %q are too open", f.Name()),

--- a/uplink/config_test.go
+++ b/uplink/config_test.go
@@ -47,6 +47,7 @@ func TestKeyFilepath_Key(t *testing.T) {
 	t.Run("ok: file with key length greater than max size", func(t *testing.T) {
 		expKey := make([]byte, rand.Intn(10)+1+storj.KeySize)
 		_, err := rand.Read(expKey)
+		require.NoError(t, err)
 		fpath, cleanup := saveKey(expKey)
 		defer cleanup()
 

--- a/uplink/config_test.go
+++ b/uplink/config_test.go
@@ -80,8 +80,8 @@ func TestEncryptionConfig_LoadKey(t *testing.T) {
 
 		_, err := encCfg.LoadKey()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "KeyFilepath is empty")
 		assert.True(t, Error.Has(err), "err is not of %q class", Error)
+		assert.Equal(t, ErrKeyFilepathEmpty, err, "unexpected error value")
 	})
 
 	t.Run("error: file not found", func(t *testing.T) {

--- a/uplink/config_test.go
+++ b/uplink/config_test.go
@@ -17,31 +17,33 @@ import (
 
 func TestEncryptionConfig_Key(t *testing.T) {
 	saveKey := func(key []byte) (filepath string, removeFile func()) {
-		f, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
-		require.NoError(t, err)
-		defer func() { _ = f.Close() }()
+		t.Helper()
 
-		_, err = f.Write(key)
+		file, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
+		require.NoError(t, err)
+		defer func() { require.NoError(t, file.Close()) }()
+
+		_, err = file.Write(key)
 		require.NoError(t, err)
 
-		err = f.Chmod(os.FileMode(0400))
+		err = file.Chmod(os.FileMode(0400))
 		require.NoError(t, err)
 
-		return f.Name(), func() { _ = os.Remove(f.Name()) }
+		return file.Name(), func() { require.NoError(t, os.Remove(file.Name())) }
 	}
 
 	t.Run("ok: file with key length less or equal than max size", func(t *testing.T) {
 		someKey := make([]byte, rand.Intn(20)+1)
 		_, err := rand.Read(someKey)
 		require.NoError(t, err)
-		fpath, cleanup := saveKey(someKey)
+		filename, cleanup := saveKey(someKey)
 		defer cleanup()
 
 		var expKey storj.Key
 		copy(expKey[:], someKey)
 
 		encCfg := &EncryptionConfig{
-			KeyFilepath: fpath,
+			KeyFilepath: filename,
 		}
 		key, err := encCfg.Key()
 		require.NoError(t, err)
@@ -53,11 +55,11 @@ func TestEncryptionConfig_Key(t *testing.T) {
 		expKey := make([]byte, rand.Intn(10)+1+storj.KeySize)
 		_, err := rand.Read(expKey)
 		require.NoError(t, err)
-		fpath, cleanup := saveKey(expKey)
+		filename, cleanup := saveKey(expKey)
 		defer cleanup()
 
 		encCfg := &EncryptionConfig{
-			KeyFilepath: fpath,
+			KeyFilepath: filename,
 		}
 		key, err := encCfg.Key()
 		require.NoError(t, err)
@@ -66,11 +68,11 @@ func TestEncryptionConfig_Key(t *testing.T) {
 	})
 
 	t.Run("ok: empty file path", func(t *testing.T) {
-		fpath, cleanup := saveKey([]byte{})
+		filename, cleanup := saveKey([]byte{})
 		defer cleanup()
 
 		encCfg := &EncryptionConfig{
-			KeyFilepath: fpath,
+			KeyFilepath: filename,
 		}
 		key, err := encCfg.Key()
 		require.NoError(t, err)
@@ -79,41 +81,42 @@ func TestEncryptionConfig_Key(t *testing.T) {
 
 	t.Run("error: file not found", func(t *testing.T) {
 		// Create a temp file and delete it, to get a filepath which doesn't exist.
-		f, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
+		file, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
 		require.NoError(t, err)
-		err = f.Close()
+		err = file.Close()
 		require.NoError(t, err)
-		err = os.Remove(f.Name())
+		err = os.Remove(file.Name())
 		require.NoError(t, err)
 
 		encCfg := &EncryptionConfig{
-			KeyFilepath: f.Name(),
+			KeyFilepath: file.Name(),
 		}
 		_, err = encCfg.Key()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), fmt.Sprintf("not found key file %q", f.Name()))
+		assert.Contains(t, err.Error(), fmt.Sprintf("not found key file %q", file.Name()))
 		assert.True(t, Error.Has(err), "err is not of %q class", Error)
 	})
 
 	t.Run("error: permissions are too open", func(t *testing.T) {
 		// Create a key file and change its permission for not being able to read it
-		f, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
+		file, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
 		require.NoError(t, err)
 		defer func() {
-			_ = f.Close()
-			_ = os.Remove(f.Name())
+			require.NoError(t, file.Close())
+			require.NoError(t, os.Remove(file.Name()))
 		}()
 
-		err = f.Chmod(0401)
+		err = file.Chmod(0401)
 		require.NoError(t, err)
 
 		encCfg := &EncryptionConfig{
-			KeyFilepath: f.Name(),
+			KeyFilepath: file.Name(),
 		}
 		_, err = encCfg.Key()
 		require.Error(t, err)
 		assert.Contains(t,
-			err.Error(), fmt.Sprintf("permissions '0401' for key file %q are too open", f.Name()),
+			err.Error(),
+			fmt.Sprintf("permissions '0401' for key file %q are too open", file.Name()),
 		)
 		assert.True(t, Error.Has(err), "err is not of %q class", Error)
 	})

--- a/uplink/config_test.go
+++ b/uplink/config_test.go
@@ -1,0 +1,106 @@
+package uplink
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"storj.io/storj/pkg/storj"
+)
+
+func TestKeyFilepath_Key(t *testing.T) {
+	saveKey := func(key []byte) (filepath string, removeFile func()) {
+		f, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
+		require.NoError(t, err)
+		defer func() { _ = f.Close() }()
+
+		_, err = f.Write(key)
+		require.NoError(t, err)
+
+		err = f.Chmod(os.FileMode(0400))
+		require.NoError(t, err)
+
+		return f.Name(), func() { _ = os.Remove(f.Name()) }
+	}
+
+	t.Run("ok: file with key length less or equal than max size", func(t *testing.T) {
+		someKey := make([]byte, rand.Intn(20)+1)
+		_, err := rand.Read(someKey)
+		require.NoError(t, err)
+		fpath, cleanup := saveKey(someKey)
+		defer cleanup()
+
+		var expKey storj.Key
+		copy(expKey[:], someKey)
+
+		kfpath := keyFilepath(fpath)
+		key, err := kfpath.Key()
+		require.NoError(t, err)
+
+		assert.Equal(t, expKey[:], key[:])
+	})
+
+	t.Run("ok: file with key length greater than max size", func(t *testing.T) {
+		expKey := make([]byte, rand.Intn(10)+1+storj.KeySize)
+		_, err := rand.Read(expKey)
+		fpath, cleanup := saveKey(expKey)
+		defer cleanup()
+
+		kfpath := keyFilepath(fpath)
+		key, err := kfpath.Key()
+		require.NoError(t, err)
+
+		assert.Equal(t, expKey[:storj.KeySize], key[:])
+	})
+
+	t.Run("ok: empty file path", func(t *testing.T) {
+		fpath, cleanup := saveKey([]byte{})
+		defer cleanup()
+
+		kfpath := keyFilepath(fpath)
+		key, err := kfpath.Key()
+		require.NoError(t, err)
+		assert.Equal(t, key, storj.Key{})
+	})
+
+	t.Run("error: file not found", func(t *testing.T) {
+		// Create a temp file and delete it, to get a filepath which doesn't exist.
+		f, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
+		require.NoError(t, err)
+		err = f.Close()
+		require.NoError(t, err)
+		err = os.Remove(f.Name())
+		require.NoError(t, err)
+
+		kfpath := keyFilepath(f.Name())
+		_, err = kfpath.Key()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("not found key file %q", f.Name()))
+		assert.True(t, Error.Has(err), "err is not of %q class", Error)
+	})
+
+	t.Run("error: permissions are too open", func(t *testing.T) {
+		// Create a key file and change its permission for not being able to read it
+		f, err := ioutil.TempFile("", "storj-test-uplink-keyfilepath-*")
+		require.NoError(t, err)
+		defer func() {
+			_ = f.Close()
+			_ = os.Remove(f.Name())
+		}()
+
+		err = f.Chmod(0401)
+		require.NoError(t, err)
+
+		kfpath := keyFilepath(f.Name())
+		_, err = kfpath.Key()
+		require.Error(t, err)
+		assert.Contains(t,
+			err.Error(), fmt.Sprintf("permissions '0401' for key file %q are too open", f.Name()),
+		)
+		assert.True(t, Error.Has(err), "err is not of %q class", Error)
+	})
+}

--- a/uplink/config_test.go
+++ b/uplink/config_test.go
@@ -63,7 +63,7 @@ func TestEncryptionConfig_LoadKey(t *testing.T) {
 		assert.Equal(t, expectedKey[:storj.KeySize], key[:])
 	})
 
-	t.Run("ok: empty file path", func(t *testing.T) {
+	t.Run("ok: empty file", func(t *testing.T) {
 		filename, cleanup := saveKey([]byte{})
 		defer cleanup()
 
@@ -73,6 +73,15 @@ func TestEncryptionConfig_LoadKey(t *testing.T) {
 		key, err := encCfg.LoadKey()
 		require.NoError(t, err)
 		assert.Equal(t, key, storj.Key{})
+	})
+
+	t.Run("error: KeyFilepath is empty", func(t *testing.T) {
+		encCfg := &EncryptionConfig{}
+
+		_, err := encCfg.LoadKey()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "KeyFilepath is empty")
+		assert.True(t, Error.Has(err), "err is not of %q class", Error)
 	})
 
 	t.Run("error: file not found", func(t *testing.T) {

--- a/uplink/config_test.go
+++ b/uplink/config_test.go
@@ -81,8 +81,8 @@ func TestEncryptionConfig_LoadKey(t *testing.T) {
 
 		_, err := encCfg.LoadKey()
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "KeyFilepath is empty")
 		assert.True(t, Error.Has(err), "err is not of %q class", Error)
-		assert.Equal(t, ErrKeyFilepathEmpty, err, "unexpected error value")
 	})
 
 	t.Run("error: file not found", func(t *testing.T) {


### PR DESCRIPTION
What: Encryption key shouldn't be stored in the same configuration file, it should be in a separated file

Why: Because due to security reasons and conventions, the key should be stored outside of the configuration file to be less accessible.

Just moving the file outside of the configuration file isn't alone a secure way to store it, but it's the first step; in the future other security measures will be taken.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
