### PR TITLE
v3-1660: improvement of test-satellite-cfg-change and related things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,13 +91,9 @@ test-sim: ## Test source with storj-sim (jenkins)
 	@./scripts/test-sim.sh
 
 .PHONY: test-satellite-cfg-change
-test-satellite-cfg-change: ## Test if the satellite config file has changed
+test-satellite-cfg-change: ## Test if the satellite config file has changed (jenkins)
 	@echo "Running ${@}"
 	@cd scripts; ./test-satellite-cfg-change.sh
-
-.PHONY: test-update-satellite-cfg-lock
-test-update-satellite-cfg-lock: ## Update the satellite config lock file
-	@cd scripts; ./update-satellite-cfg-lock.sh
 
 .PHONY: test-certificate-signing
 test-certificate-signing: ## Test certificate signing service and storagenode setup (jenkins)
@@ -272,3 +268,16 @@ clean-images:
 test-docker-clean: ## Clean up Docker environment used in test-docker target
 	-docker-compose down --rmi all
 
+
+##@ Tooling
+
+.PHONY: update-satellite-cfg-lock
+update-satellite-cfg-lock: ## Update the satellite config lock file
+	@docker run -ti --rm \
+		-v ${GOPATH}/pkg/mod:/go/pkg/mod \
+		-v $(shell pwd):/storj \
+		-v $(shell go env GOCACHE):/go-cache \
+		-e "GOCACHE=/go-cache" \
+		-u root:root \
+		golang:${GO_VERSION} \
+		/bin/bash -c "cd /storj/scripts; ./update-satellite-cfg-lock.sh"


### PR DESCRIPTION
What: 
* Clarifies that the test-satellite-cfg-change is for being run by
  Jenkins as others are.
* Move the target for updating the satellite configuration lock file to
  a new Makefile group, called "Tooling".
* Change how it's run the script update-satellite-cfg-lock.sh for
  ensuring that the outcome is the same when running from different
  machines.

Why: It wasn't clear that one of the targets is for running it from Jenkins and the other one didn't produce the same outcome from different machines.


@mobyvb this should be fixed what you spotted and commented in https://github.com/storj/storj/pull/1898#pullrequestreview-234701092
@wthorp removing it was an easy solution and if I wouldn't have come up with this solution I would do it, but this solution should be better than removing it.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
