### PR TITLE
Uplink CLI should not require identity

### DIFF
--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -16,7 +16,6 @@ import (
 	"storj.io/storj/internal/fpath"
 	libuplink "storj.io/storj/lib/uplink"
 	"storj.io/storj/pkg/cfgstruct"
-	"storj.io/storj/pkg/identity"
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/uplink"
 )
@@ -24,7 +23,6 @@ import (
 // UplinkFlags configuration flags
 type UplinkFlags struct {
 	NonInteractive bool `help:"disable interactive mode" default:"false" setup:"true"`
-	Identity       identity.Config
 	uplink.Config
 }
 
@@ -71,16 +69,6 @@ func (c *UplinkFlags) GetProject(ctx context.Context) (*libuplink.Project, error
 
 	satelliteAddr := c.Client.SatelliteAddr
 
-	identity, err := c.Identity.Load()
-	if err != nil {
-		return nil, err
-	}
-
-	identityVersion, err := identity.Version()
-	if err != nil {
-		return nil, err
-	}
-
 	cfg := &libuplink.Config{}
 
 	cfg.Volatile.TLS = struct {
@@ -91,8 +79,6 @@ func (c *UplinkFlags) GetProject(ctx context.Context) (*libuplink.Project, error
 		PeerCAWhitelistPath: c.TLS.PeerCAWhitelistPath,
 	}
 
-	cfg.Volatile.UseIdentity = identity
-	cfg.Volatile.IdentityVersion = identityVersion
 	cfg.Volatile.MaxInlineSize = c.Client.MaxInlineSize
 	cfg.Volatile.MaxMemory = c.RS.MaxBufferMem
 


### PR DESCRIPTION
Fixes https://storjlabs.atlassian.net/browse/V3-1713

What: 

Removes the identity from the uplink configuration.

Why:

Because it is not required to have a designated identity anymore. Libuplink will internally generate a disposable identity with difficulty 0 whenever the uplink CLI is used.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
