### PR TITLE
Gateway should not require identity

### DIFF
--- a/pkg/miniogw/gateway_test.go
+++ b/pkg/miniogw/gateway_test.go
@@ -716,7 +716,6 @@ func initEnv(ctx context.Context, planet *testplanet.Planet) (minio.ObjectLayer,
 	}{
 		SkipPeerCAWhitelist: true,
 	}
-	cfg.Volatile.UseIdentity = planet.Uplinks[0].Identity
 
 	uplink, err := libuplink.NewUplink(ctx, &cfg)
 	if err != nil {

--- a/pkg/miniogw/integration_test.go
+++ b/pkg/miniogw/integration_test.go
@@ -177,7 +177,6 @@ func runGateway(ctx context.Context, gwCfg config, uplinkCfg uplink.Config, log 
 		SkipPeerCAWhitelist: !uplinkCfg.TLS.UsePeerCAWhitelist,
 		PeerCAWhitelistPath: uplinkCfg.TLS.PeerCAWhitelistPath,
 	}
-	cfg.Volatile.UseIdentity = ident
 	cfg.Volatile.MaxInlineSize = uplinkCfg.Client.MaxInlineSize
 	cfg.Volatile.MaxMemory = uplinkCfg.RS.MaxBufferMem
 


### PR DESCRIPTION
What: 

Same as #1920, but for the S3 Gateway.

Why:

Because the S3 Gateway should not require designated identity anymore. Libuplink will internally generate a disposable identity with difficulty 0 whenever the gateway is started.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
