### PR TITLE
Fix to issue error for empty enc key

### DIFF
--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -133,9 +133,14 @@ Please enter numeric choice or enter satellite address manually [1]: `)
 		if err != nil {
 			return err
 		}
+
 		_, err = fmt.Println()
 		if err != nil {
 			return err
+		}
+
+		if len(encKey) == 0 {
+			return errs.New("Encryption passphrase cannot be empty")
 		}
 
 		_, err = fmt.Print("Enter your encryption passphrase again: ")
@@ -153,13 +158,6 @@ Please enter numeric choice or enter satellite address manually [1]: `)
 
 		if !bytes.Equal(encKey, repeatedEncKey) {
 			return errs.New("encryption passphrases doesn't match")
-		}
-
-		if len(encKey) == 0 {
-			_, err = fmt.Println("Warning: Encryption passphrase is empty!")
-			if err != nil {
-				return err
-			}
 		}
 
 		override = map[string]interface{}{


### PR DESCRIPTION
What: 
Require an encryption key to be set when the user runs the uplink setup command
https://storjlabs.atlassian.net/browse/V3-1717
Why:
An encryption key is required to be set
Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
