### PR TITLE
Shorten timeout for stalled builds

### DIFF
--- a/Jenkinsfile.public
+++ b/Jenkinsfile.public
@@ -6,7 +6,7 @@ pipeline {
         }
     }
     options {
-          timeout(time: 30, unit: 'MINUTES')
+          timeout(time: 10, unit: 'MINUTES')
     }
     stages {
         stage('Build') {


### PR DESCRIPTION
What: Decrease timeout from 30 to 10 minutes.

Why: Normal builds are done in less than 5 minutes, no need to wait more than twice as that.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
