### PR TITLE
jenkins: run two satellites in integration tests

### DIFF
--- a/scripts/test-sim.sh
+++ b/scripts/test-sim.sh
@@ -18,12 +18,12 @@ export STORJ_NETWORK_DIR=$TMP
 STORJ_NETWORK_HOST4=${STORJ_NETWORK_HOST4:-127.0.0.1}
 
 # setup the network
-storj-sim -x --host $STORJ_NETWORK_HOST4 network setup
+storj-sim -x --satellites 2 --host $STORJ_NETWORK_HOST4 network setup
 
 # run aws-cli tests
-storj-sim -x --host $STORJ_NETWORK_HOST4 network test bash "$SCRIPTDIR"/test-sim-aws.sh
-storj-sim -x --host $STORJ_NETWORK_HOST4 network test bash "$SCRIPTDIR"/test-uplink.sh
-storj-sim -x --host $STORJ_NETWORK_HOST4 network destroy
+storj-sim -x --satellites 2 --host $STORJ_NETWORK_HOST4 network test bash "$SCRIPTDIR"/test-sim-aws.sh
+storj-sim -x --satellites 2 --host $STORJ_NETWORK_HOST4 network test bash "$SCRIPTDIR"/test-uplink.sh
+storj-sim -x --satellites 2 --host $STORJ_NETWORK_HOST4 network destroy
 
 # setup the network with ipv6
 #storj-sim -x --host "::1" network setup


### PR DESCRIPTION
Currently it's easy to forget that network needs to work stable with multiple satellites, hence start multiple satellites in integration tests.

Later improvements could try to upload to both satellites.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
