### PR TITLE
Remove UseIdentity and IdentityVersion from libuplink volatile config

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -167,11 +167,7 @@ func checkCfg(ctx context.Context) (err error) {
 	defer func() { err = errs.Combine(err, proj.Close()) }()
 
 	_, err = proj.ListBuckets(ctx, &storj.BucketListOptions{Direction: storj.After})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // Run starts a Minio Gateway given proper config

--- a/cmd/storj-sim/network.go
+++ b/cmd/storj-sim/network.go
@@ -463,6 +463,11 @@ func identitySetup(network *Processes) (*Processes, error) {
 	processes := NewProcesses(network.Directory)
 
 	for _, process := range network.List {
+		if process.Info.Executable == "gateway" {
+			// gateways don't need an identity
+			continue
+		}
+
 		identity := processes.New(Info{
 			Name:       "identity/" + process.Info.Name,
 			Executable: "identity",


### PR DESCRIPTION
What: 

- Removes `UseIdentity` and `IdentityVersion` from libuplink `Config.Volatile`. We shouldn't have aby use case for these two anymore.
- storj-sim does not generate identity for gateway anymore
- Gateway properly closes the libuplink project when verifying the satellite config

Why:

These changes address additional comments left in #1920 and #1921.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
