### PR TITLE
pkg/kademlia: fix timeout test slowness

### DIFF
--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -80,7 +80,7 @@ func (transport *Transport) DialNode(ctx context.Context, node *pb.Node, opts ..
 		}),
 	}, opts...)
 
-	timedCtx, cancel := context.WithTimeout(ctx, defaultDialTimeout)
+	timedCtx, cancel := context.WithTimeout(ctx, transport.requestTimeout)
 	defer cancel()
 
 	conn, err = grpc.DialContext(timedCtx, node.GetAddress().Address, options...)
@@ -118,7 +118,7 @@ func (transport *Transport) DialAddress(ctx context.Context, address string, opt
 		}),
 	}, opts...)
 
-	timedCtx, cancel := context.WithTimeout(ctx, defaultDialTimeout)
+	timedCtx, cancel := context.WithTimeout(ctx, transport.requestTimeout)
 	defer cancel()
 
 	conn, err = grpc.DialContext(timedCtx, address, options...)


### PR DESCRIPTION
The timeout tests were configured to use very short timeouts but
for some reason they took many seconds to complete. This commit
fixes two issues:

1. The transports were always using the default timeout rather than
   the timeout specified.

2. The tests were possibly calling t.FailNow inside of the non-test
   goroutine which causes it to exit, possibly losing an error from
   the error group. Additionally, it didn't seem to be testing that
   the error came back as a deadline wrapped in a transport error.

The tests run in ~3s instead of ~60s now.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
