### PR TITLE
repair segment reassess it missing pieces just before repair

### DIFF
--- a/pkg/datarepair/checker/checker.go
+++ b/pkg/datarepair/checker/checker.go
@@ -121,7 +121,7 @@ func (checker *Checker) IdentifyInjuredSegments(ctx context.Context) (err error)
 					continue
 				}
 
-				missingPieces, err := checker.getMissingPieces(ctx, pieces)
+				missingPieces, err := checker.overlay.GetMissingPieces(ctx, pieces)
 				if err != nil {
 					return Error.New("error getting missing pieces %s", err)
 				}
@@ -182,26 +182,6 @@ func (checker *Checker) IdentifyInjuredSegments(ctx context.Context) (err error)
 	mon.IntVal("remote_files_lost").Observe(int64(len(remoteSegmentInfo)))
 
 	return nil
-}
-
-func (checker *Checker) getMissingPieces(ctx context.Context, pieces []*pb.RemotePiece) (missingPieces []int32, err error) {
-	var nodeIDs storj.NodeIDList
-	for _, p := range pieces {
-		nodeIDs = append(nodeIDs, p.NodeId)
-	}
-	badNodeIDs, err := checker.overlay.KnownUnreliableOrOffline(ctx, nodeIDs)
-	if err != nil {
-		return nil, Error.New("error getting nodes %s", err)
-	}
-
-	for _, p := range pieces {
-		for _, nodeID := range badNodeIDs {
-			if nodeID == p.NodeId {
-				missingPieces = append(missingPieces, p.GetPieceNum())
-			}
-		}
-	}
-	return missingPieces, nil
 }
 
 // checks for a string in slice

--- a/pkg/datarepair/repairer/repairer.go
+++ b/pkg/datarepair/repairer/repairer.go
@@ -50,7 +50,7 @@ func (c Config) GetSegmentRepairer(ctx context.Context, tc transport.Client, met
 
 // SegmentRepairer is a repairer for segments
 type SegmentRepairer interface {
-	Repair(ctx context.Context, path storj.Path, lostPieces []int32) (err error)
+	Repair(ctx context.Context, path storj.Path) (err error)
 }
 
 // Service contains the information needed to run the repair service
@@ -124,7 +124,7 @@ func (service *Service) process(ctx context.Context) error {
 		}
 
 		service.Limiter.Go(ctx, func() {
-			err := service.repairer.Repair(ctx, seg.GetPath(), seg.GetLostPieces())
+			err := service.repairer.Repair(ctx, seg.GetPath())
 			if err != nil {
 				zap.L().Error("repair failed", zap.Error(err))
 			}

--- a/pkg/overlay/cache.go
+++ b/pkg/overlay/cache.go
@@ -306,3 +306,24 @@ func (cache *Cache) ConnSuccess(ctx context.Context, node *pb.Node) {
 		zap.L().Debug("error updating node connection info", zap.Error(err))
 	}
 }
+
+// GetMissingPieces returns the list of offline nodes
+func (cache *Cache) GetMissingPieces(ctx context.Context, pieces []*pb.RemotePiece) (missingPieces []int32, err error) {
+	var nodeIDs storj.NodeIDList
+	for _, p := range pieces {
+		nodeIDs = append(nodeIDs, p.NodeId)
+	}
+	badNodeIDs, err := cache.KnownUnreliableOrOffline(ctx, nodeIDs)
+	if err != nil {
+		return nil, Error.New("error getting nodes %s", err)
+	}
+
+	for _, p := range pieces {
+		for _, nodeID := range badNodeIDs {
+			if nodeID == p.NodeId {
+				missingPieces = append(missingPieces, p.GetPieceNum())
+			}
+		}
+	}
+	return missingPieces, nil
+}

--- a/pkg/storage/segments/repairer_test.go
+++ b/pkg/storage/segments/repairer_test.go
@@ -100,7 +100,7 @@ func TestSegmentStoreRepair(t *testing.T) {
 		repairer := segments.NewSegmentRepairer(metainfo, os, oc, ec, satellite.Identity, time.Minute)
 		assert.NotNil(t, repairer)
 
-		err = repairer.Repair(ctx, path, lostPieces)
+		err = repairer.Repair(ctx, path)
 		assert.NoError(t, err)
 
 		// kill one of the nodes kept alive to ensure repair worked


### PR DESCRIPTION
What: 
Reassess what pieces needs to be rebuilt in repair just before repairs, so newly built pieces are not just overlap and also not sent to the same storagenode. 
Why:
There is a possibility that a piece is built and sent to already existing storagenode, causing info.db UNIQUE error
https://storjlabs.atlassian.net/browse/V3-1650
Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
