### PR TITLE
transport: separate dial from request timeouts

### DIFF
--- a/internal/testplanet/uplink.go
+++ b/internal/testplanet/uplink.go
@@ -303,7 +303,8 @@ func (uplink *Uplink) GetConfig(satellite *satellite.Peer) uplink.Config {
 	config := getDefaultConfig()
 	config.Client.SatelliteAddr = satellite.Addr()
 	config.Client.APIKey = uplink.APIKey[satellite.ID()]
-	config.Client.Timeout = 10 * time.Second
+	config.Client.RequestTimeout = 10 * time.Second
+	config.Client.DialTimeout = 10 * time.Second
 
 	config.RS.MinThreshold = atLeastOne(uplink.StorageNodeCount * 1 / 5)     // 20% of storage nodes
 	config.RS.RepairThreshold = atLeastOne(uplink.StorageNodeCount * 2 / 5)  // 40% of storage nodes

--- a/pkg/kademlia/dialer_test.go
+++ b/pkg/kademlia/dialer_test.go
@@ -183,7 +183,9 @@ func TestSlowDialerHasTimeout(t *testing.T) {
 		tlsOpts, err := tlsopts.NewOptions(self.Identity, tlsopts.Config{})
 		require.NoError(t, err)
 
-		self.Transport = transport.NewClientWithTimeout(tlsOpts, 20*time.Millisecond)
+		self.Transport = transport.NewClientWithTimeouts(tlsOpts, transport.Timeouts{
+			Dial: 20 * time.Millisecond,
+		})
 
 		network := &transport.SimulatedNetwork{
 			DialLatency:    200 * time.Second,
@@ -217,7 +219,9 @@ func TestSlowDialerHasTimeout(t *testing.T) {
 		tlsOpts, err := tlsopts.NewOptions(self.Identity, tlsopts.Config{})
 		require.NoError(t, err)
 
-		self.Transport = transport.NewClientWithTimeout(tlsOpts, 20*time.Millisecond)
+		self.Transport = transport.NewClientWithTimeouts(tlsOpts, transport.Timeouts{
+			Dial: 20 * time.Millisecond,
+		})
 
 		network := &transport.SimulatedNetwork{
 			DialLatency:    200 * time.Second,
@@ -252,7 +256,9 @@ func TestSlowDialerHasTimeout(t *testing.T) {
 		tlsOpts, err := tlsopts.NewOptions(self.Identity, tlsopts.Config{})
 		require.NoError(t, err)
 
-		self.Transport = transport.NewClientWithTimeout(tlsOpts, 20*time.Millisecond)
+		self.Transport = transport.NewClientWithTimeouts(tlsOpts, transport.Timeouts{
+			Dial: 20 * time.Millisecond,
+		})
 
 		network := &transport.SimulatedNetwork{
 			DialLatency:    200 * time.Second,

--- a/pkg/kademlia/kademlia_planet_test.go
+++ b/pkg/kademlia/kademlia_planet_test.go
@@ -67,7 +67,9 @@ func TestPingTimeout(t *testing.T) {
 		tlsOpts, err := tlsopts.NewOptions(self.Identity, tlsopts.Config{})
 		require.NoError(t, err)
 
-		self.Transport = transport.NewClientWithTimeout(tlsOpts, 1*time.Millisecond)
+		self.Transport = transport.NewClientWithTimeouts(tlsOpts, transport.Timeouts{
+			Request: 1 * time.Millisecond,
+		})
 
 		network := &transport.SimulatedNetwork{
 			DialLatency:    300 * time.Second,

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -30,24 +30,37 @@ type Client interface {
 	WithObservers(obs ...Observer) Client
 }
 
+// Timeouts contains all of the timeouts configurable for a transport
+type Timeouts struct {
+	Request time.Duration
+	Dial    time.Duration
+}
+
 // Transport interface structure
 type Transport struct {
-	tlsOpts        *tlsopts.Options
-	observers      []Observer
-	requestTimeout time.Duration
+	tlsOpts   *tlsopts.Options
+	observers []Observer
+	timeouts  Timeouts
 }
 
 // NewClient returns a transport client with a default timeout for requests
 func NewClient(tlsOpts *tlsopts.Options, obs ...Observer) Client {
-	return NewClientWithTimeout(tlsOpts, defaultRequestTimeout, obs...)
+	return NewClientWithTimeouts(tlsOpts, Timeouts{}, obs...)
 }
 
-// NewClientWithTimeout returns a transport client with a specified timeout for requests
-func NewClientWithTimeout(tlsOpts *tlsopts.Options, requestTimeout time.Duration, obs ...Observer) Client {
+// NewClientWithTimeouts returns a transport client with a specified timeout for requests
+func NewClientWithTimeouts(tlsOpts *tlsopts.Options, timeouts Timeouts, obs ...Observer) Client {
+	if timeouts.Request == 0 {
+		timeouts.Request = defaultRequestTimeout
+	}
+	if timeouts.Dial == 0 {
+		timeouts.Dial = defaultDialTimeout
+	}
+
 	return &Transport{
-		tlsOpts:        tlsOpts,
-		requestTimeout: requestTimeout,
-		observers:      obs,
+		tlsOpts:   tlsOpts,
+		timeouts:  timeouts,
+		observers: obs,
 	}
 }
 
@@ -76,11 +89,11 @@ func (transport *Transport) DialNode(ctx context.Context, node *pb.Node, opts ..
 			if err != nil {
 				return nil, err
 			}
-			return &timeoutConn{conn: conn, timeout: transport.requestTimeout}, nil
+			return &timeoutConn{conn: conn, timeout: transport.timeouts.Request}, nil
 		}),
 	}, opts...)
 
-	timedCtx, cancel := context.WithTimeout(ctx, transport.requestTimeout)
+	timedCtx, cancel := context.WithTimeout(ctx, transport.timeouts.Dial)
 	defer cancel()
 
 	conn, err = grpc.DialContext(timedCtx, node.GetAddress().Address, options...)
@@ -114,11 +127,11 @@ func (transport *Transport) DialAddress(ctx context.Context, address string, opt
 			if err != nil {
 				return nil, err
 			}
-			return &timeoutConn{conn: conn, timeout: transport.requestTimeout}, nil
+			return &timeoutConn{conn: conn, timeout: transport.timeouts.Request}, nil
 		}),
 	}, opts...)
 
-	timedCtx, cancel := context.WithTimeout(ctx, transport.requestTimeout)
+	timedCtx, cancel := context.WithTimeout(ctx, transport.timeouts.Dial)
 	defer cancel()
 
 	conn, err = grpc.DialContext(timedCtx, address, options...)
@@ -135,7 +148,7 @@ func (transport *Transport) Identity() *identity.FullIdentity {
 
 // WithObservers returns a new transport including the listed observers.
 func (transport *Transport) WithObservers(obs ...Observer) Client {
-	tr := &Transport{tlsOpts: transport.tlsOpts, requestTimeout: transport.requestTimeout}
+	tr := &Transport{tlsOpts: transport.tlsOpts, timeouts: transport.timeouts}
 	tr.observers = append(tr.observers, transport.observers...)
 	tr.observers = append(tr.observers, obs...)
 	return tr

--- a/uplink/config.go
+++ b/uplink/config.go
@@ -50,11 +50,12 @@ type EncryptionConfig struct {
 // ClientConfig is a configuration struct for the uplink that controls how
 // to talk to the rest of the network.
 type ClientConfig struct {
-	APIKey        string        `default:"" help:"the api key to use for the satellite" noprefix:"true"`
-	SatelliteAddr string        `releaseDefault:"127.0.0.1:7777" devDefault:"127.0.0.1:10000" help:"the address to use for the satellite" noprefix:"true"`
-	MaxInlineSize memory.Size   `help:"max inline segment size in bytes" default:"4KiB"`
-	SegmentSize   memory.Size   `help:"the size of a segment in bytes" default:"64MiB"`
-	Timeout       time.Duration `help:"timeout for request" default:"0h0m20s"`
+	APIKey         string        `default:"" help:"the api key to use for the satellite" noprefix:"true"`
+	SatelliteAddr  string        `releaseDefault:"127.0.0.1:7777" devDefault:"127.0.0.1:10000" help:"the address to use for the satellite" noprefix:"true"`
+	MaxInlineSize  memory.Size   `help:"max inline segment size in bytes" default:"4KiB"`
+	SegmentSize    memory.Size   `help:"the size of a segment in bytes" default:"64MiB"`
+	RequestTimeout time.Duration `help:"timeout for request" default:"0h0m20s"`
+	DialTimeout    time.Duration `help:"timeout for dials" default:"0h0m20s"`
 }
 
 // Config uplink configuration
@@ -83,7 +84,10 @@ func (c Config) GetMetainfo(ctx context.Context, identity *identity.FullIdentity
 
 	// ToDo: Handle Versioning for Uplinks here
 
-	tc := transport.NewClientWithTimeout(tlsOpts, c.Client.Timeout)
+	tc := transport.NewClientWithTimeouts(tlsOpts, transport.Timeouts{
+		Request: c.Client.RequestTimeout,
+		Dial:    c.Client.DialTimeout,
+	})
 
 	if c.Client.SatelliteAddr == "" {
 		return nil, nil, errors.New("satellite address not specified")


### PR DESCRIPTION
## What / Why

A previous change reused the same timeout for dialing as well as
requesting in order to speed up some tests. This change introduces
a distinct timeout so that the different operations can have different
timeouts.

Discussed some previously at https://github.com/storj/storj/pull/1545#discussion_r268168062

---

**Note to reviewers:** I changed a config struct. I assume there's something I have to do about flags or whatever, but I don't know.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
