### PR TITLE
check results in verifier test

### DIFF
--- a/pkg/audit/newverifier_test.go
+++ b/pkg/audit/newverifier_test.go
@@ -14,6 +14,7 @@ import (
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testplanet"
 	"storj.io/storj/pkg/audit"
+	"storj.io/storj/uplink"
 )
 
 func TestVerifierHappyPath(t *testing.T) {
@@ -23,12 +24,17 @@ func TestVerifierHappyPath(t *testing.T) {
 		err := planet.Satellites[0].Audit.Service.Close()
 		require.NoError(t, err)
 
-		uplink := planet.Uplinks[0]
+		ul := planet.Uplinks[0]
 		testData := make([]byte, 1*memory.MiB)
 		_, err = rand.Read(testData)
 		require.NoError(t, err)
 
-		err = uplink.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
+		err = ul.UploadWithConfig(ctx, planet.Satellites[0], &uplink.RSConfig{
+			MinThreshold:     4,
+			RepairThreshold:  5,
+			SuccessThreshold: 6,
+			MaxThreshold:     6,
+		}, "testbucket", "test/path", testData)
 		require.NoError(t, err)
 
 		metainfo := planet.Satellites[0].Metainfo.Service
@@ -57,7 +63,11 @@ func TestVerifierHappyPath(t *testing.T) {
 		_, err = planet.Satellites[0].Overlay.Service.UpdateUptime(ctx, planet.StorageNodes[1].ID(), false)
 		require.NoError(t, err)
 
-		_, err = verifier.Verify(ctx, stripe)
+		verifiedNodes, err := verifier.Verify(ctx, stripe)
 		require.NoError(t, err)
+
+		require.Len(t, verifiedNodes.SuccessNodeIDs, 4)
+		require.Len(t, verifiedNodes.FailNodeIDs, 0)
+		require.Len(t, verifiedNodes.OfflineNodeIDs, 0)
 	})
 }


### PR DESCRIPTION
What: 
In newverifier_test.go, upload to a specific number of nodes, and check that the result returned by verifier.Verify determines the correct number of successful/failed/offline nodes

Why:
We should add more test cases for using the verifier over testplanet, and this test should be a basis for the others

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
