### PR TITLE
Fix download error threshold

### DIFF
--- a/pkg/eestream/decode.go
+++ b/pkg/eestream/decode.go
@@ -115,7 +115,7 @@ func (dr *decodedReader) Close() error {
 		dr.closeErr = errs.Combine(allErrors...)
 	})
 	// TODO this is workaround, we need reorganize to return multiple errors or divide into fatal, non fatal
-	if errorThreshold <= 0 {
+	if errorThreshold < 0 {
 		return dr.closeErr
 	}
 	if dr.closeErr != nil {


### PR DESCRIPTION
What: 

Fixes the calculation of error threshold during download. Before this change, `required+1` number good nodes were required for a successful download, whereas only `required` number of nodes are really necessary.

Why:

This issue failed downloads of files with lower RS scheme (like 2/4/6/8). If only one storage node was problematic, those downloads would fail.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
