### PR TITLE
Reverting uplink(V3-1717) and gateway(V3-1718) enc key changes

### DIFF
--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -133,14 +133,9 @@ Please enter numeric choice or enter satellite address manually [1]: `)
 		if err != nil {
 			return err
 		}
-
 		_, err = fmt.Println()
 		if err != nil {
 			return err
-		}
-
-		if len(encKey) == 0 {
-			return errs.New("Encryption passphrase cannot be empty")
 		}
 
 		_, err = fmt.Print("Enter your encryption passphrase again: ")
@@ -158,6 +153,13 @@ Please enter numeric choice or enter satellite address manually [1]: `)
 
 		if !bytes.Equal(encKey, repeatedEncKey) {
 			return errs.New("encryption passphrases doesn't match")
+		}
+
+		if len(encKey) == 0 {
+			_, err = fmt.Println("Warning: Encryption passphrase is empty!")
+			if err != nil {
+				return err
+			}
 		}
 
 		override = map[string]interface{}{

--- a/pkg/cfgstruct/utils.go
+++ b/pkg/cfgstruct/utils.go
@@ -128,10 +128,6 @@ func PromptForEncryptionKey() (string, error) {
 		return "", err
 	}
 
-	if len(encKey) == 0 {
-		return "", errs.New("Encryption passphrase cannot be empty")
-	}
-
 	_, err = fmt.Print("Enter your encryption passphrase again: ")
 	if err != nil {
 		return "", err
@@ -147,6 +143,13 @@ func PromptForEncryptionKey() (string, error) {
 
 	if !bytes.Equal(encKey, repeatedEncKey) {
 		return "", errs.New("encryption passphrases doesn't match")
+	}
+
+	if len(encKey) == 0 {
+		_, err = fmt.Println("Warning: Encryption passphrase is empty!")
+		if err != nil {
+			return "", err
+		}
 	}
 
 	return string(encKey), nil


### PR DESCRIPTION
What: 
Not want to encrypt paths so we get ordered listing
Why:
With encrypted paths you can’t get alphabetical listing, which means we cant not require enc.key

Will be reverting changes associated with Tickets V3-1717(PR #1952) & V3-1718(PR #1923)
Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
