### PR TITLE
don't encrypt bucket info

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -239,16 +239,13 @@ func (flags GatewayFlags) NewGateway(ctx context.Context, ident *identity.FullId
 		return nil, err
 	}
 
-	encKey := new(storj.Key)
-	copy(encKey[:], flags.Enc.Key)
-
-	var opts libuplink.ProjectOptions
-	opts.Volatile.EncryptionKey = encKey
-
-	project, err := uplink.OpenProject(ctx, flags.Client.SatelliteAddr, apiKey, &opts)
+	project, err := uplink.OpenProject(ctx, flags.Client.SatelliteAddr, apiKey, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	encKey := new(storj.Key)
+	copy(encKey[:], flags.Enc.Key)
 
 	return miniogw.NewStorjGateway(
 		project,

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -239,19 +239,15 @@ func (flags GatewayFlags) NewGateway(ctx context.Context, ident *identity.FullId
 		return nil, err
 	}
 
-	project, err := uplink.OpenProject(ctx, flags.Client.SatelliteAddr, apiKey, nil)
+	project, err := uplink.OpenProject(ctx, flags.Client.SatelliteAddr, apiKey)
 	if err != nil {
 		return nil, err
 	}
 
-	encKey := new(storj.Key)
-	copy(encKey[:], flags.Enc.Key)
-
 	return miniogw.NewStorjGateway(
 		project,
-		encKey,
-		storj.Cipher(flags.Enc.PathType).ToCipherSuite(),
-		flags.GetEncryptionScheme().ToEncryptionParameters(),
+		storj.Cipher(flags.Enc.PathType).ToCipherSuite(), //{do i need to remove these?}
+		flags.GetEncryptionScheme().ToEncryptionParameters(), //{maybe these should point to object flags, rather than bucket}
 		flags.GetRedundancyScheme(),
 		flags.Client.SegmentSize,
 	), nil

--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -101,13 +101,7 @@ func (c *UplinkFlags) GetProject(ctx context.Context) (*libuplink.Project, error
 		return nil, err
 	}
 
-	opts := &libuplink.ProjectOptions{}
-
-	encKey := new(storj.Key)
-	copy(encKey[:], c.Enc.Key)
-	opts.Volatile.EncryptionKey = encKey
-
-	project, err := uplink.OpenProject(ctx, satelliteAddr, apiKey, opts)
+	project, err := uplink.OpenProject(ctx, satelliteAddr, apiKey, nil)
 
 	if err != nil {
 		if err := uplink.Close(); err != nil {

--- a/lib/uplink/bucket.go
+++ b/lib/uplink/bucket.go
@@ -81,8 +81,7 @@ type UploadOptions struct {
 	// or go away entirely between releases. Be careful when using them!
 	Volatile struct {
 		// EncryptionParameters determines the cipher suite to use for
-		// the Object's data encryption. If not set, the Bucket's
-		// defaults will be used.
+		// the Object's data encryption. Must be set, there is no longer a bucket default
 		EncryptionParameters storj.EncryptionParameters
 
 		// RedundancyScheme determines the Reed-Solomon and/or Forward
@@ -118,12 +117,7 @@ func (b *Bucket) UploadObject(ctx context.Context, path storj.Path, data io.Read
 	if opts.Volatile.RedundancyScheme.TotalShares == 0 {
 		opts.Volatile.RedundancyScheme.TotalShares = b.Volatile.RedundancyScheme.TotalShares
 	}
-	if opts.Volatile.EncryptionParameters.CipherSuite == storj.EncUnspecified {
-		opts.Volatile.EncryptionParameters.CipherSuite = b.EncryptionParameters.CipherSuite
-	}
-	if opts.Volatile.EncryptionParameters.BlockSize == 0 {
-		opts.Volatile.EncryptionParameters.BlockSize = b.EncryptionParameters.BlockSize
-	}
+
 	createInfo := storj.CreateObject{
 		ContentType:      opts.ContentType,
 		Metadata:         opts.Metadata,

--- a/lib/uplink/bucket_attrs_test.go
+++ b/lib/uplink/bucket_attrs_test.go
@@ -42,7 +42,7 @@ func testPlanetWithLibUplink(t *testing.T, cfg testConfig, encKey *storj.Key,
 			t.Fatalf("could not create new Uplink object: %v", err)
 		}
 		defer ctx.Check(uplink.Close)
-		
+
 		proj, err := uplink.OpenProject(ctx, satellite.Addr(), apiKey)
 		if err != nil {
 			t.Fatalf("could not open project from libuplink under testplanet: %v", err)
@@ -64,11 +64,6 @@ func TestBucketAttrs(t *testing.T) {
 		access         = simpleEncryptionAccess("voxmachina")
 		bucketName     = "mightynein"
 		inBucketConfig = BucketConfig{
-			PathCipher: storj.EncSecretBox,
-			EncryptionParameters: storj.EncryptionParameters{
-				CipherSuite: storj.EncAESGCM,
-				BlockSize:   512,
-			},
 			Volatile: struct {
 				RedundancyScheme storj.RedundancyScheme
 				SegmentsSize     memory.Size
@@ -100,8 +95,6 @@ func TestBucketAttrs(t *testing.T) {
 			defer ctx.Check(got.Close)
 
 			assert.Equal(t, bucketName, got.Name)
-			assert.Equal(t, inBucketConfig.PathCipher, got.PathCipher)
-			assert.Equal(t, inBucketConfig.EncryptionParameters, got.EncryptionParameters)
 			assert.Equal(t, inBucketConfig.Volatile.RedundancyScheme, got.Volatile.RedundancyScheme)
 			assert.Equal(t, inBucketConfig.Volatile.SegmentsSize, got.Volatile.SegmentsSize)
 
@@ -120,11 +113,6 @@ func TestBucketAttrsApply(t *testing.T) {
 		objectPath1    = "vax/vex/vox"
 		objectContents = "Willingham,Ray,Jaffe,Johnson,Riegel,O'Brien,Bailey,Mercer"
 		inBucketConfig = BucketConfig{
-			PathCipher: storj.EncSecretBox,
-			EncryptionParameters: storj.EncryptionParameters{
-				CipherSuite: storj.EncSecretBox,
-				BlockSize:   768,
-			},
 			Volatile: struct {
 				RedundancyScheme storj.RedundancyScheme
 				SegmentsSize     memory.Size
@@ -164,7 +152,6 @@ func TestBucketAttrsApply(t *testing.T) {
 			require.NoError(t, err)
 			defer ctx.Check(readBack.Close)
 
-			assert.Equal(t, inBucketConfig.EncryptionParameters, readBack.Meta.Volatile.EncryptionParameters)
 			assert.Equal(t, inBucketConfig.Volatile.RedundancyScheme, readBack.Meta.Volatile.RedundancyScheme)
 			assert.Equal(t, inBucketConfig.Volatile.SegmentsSize.Int64(), readBack.Meta.Volatile.SegmentsSize)
 

--- a/lib/uplink/bucket_attrs_test.go
+++ b/lib/uplink/bucket_attrs_test.go
@@ -42,9 +42,8 @@ func testPlanetWithLibUplink(t *testing.T, cfg testConfig, encKey *storj.Key,
 			t.Fatalf("could not create new Uplink object: %v", err)
 		}
 		defer ctx.Check(uplink.Close)
-		var projectOptions ProjectOptions
-		projectOptions.Volatile.EncryptionKey = encKey
-		proj, err := uplink.OpenProject(ctx, satellite.Addr(), apiKey, &projectOptions)
+		
+		proj, err := uplink.OpenProject(ctx, satellite.Addr(), apiKey)
 		if err != nil {
 			t.Fatalf("could not open project from libuplink under testplanet: %v", err)
 		}

--- a/lib/uplink/uplink.go
+++ b/lib/uplink/uplink.go
@@ -153,7 +153,7 @@ func (u *Uplink) OpenProject(ctx context.Context, satelliteAddr string, apiKey A
 		return nil, err
 	}
 
-	// TODO: we shouldn't really need encoding parameters to manage buckets.
+	// TODO: we shouldn't really need encoding parameters to manage buckets. {JJ}
 	whoCares := 1
 	fc, err := infectious.NewFEC(whoCares, whoCares)
 	if err != nil {
@@ -167,9 +167,7 @@ func (u *Uplink) OpenProject(ctx context.Context, satelliteAddr string, apiKey A
 	// volatile warning: we're setting an encryption key of all zeros, but there
 	// just shouldn't be an encryption key here at all.
 	// TODO: fix before the final alpha network wipe
-	encryptionKey := new(storj.Key)
-	streams, err := streams.NewStreamStore(segments, maxBucketMetaSize.Int64(),
-		encryptionKey, memory.KiB.Int(), storj.AESGCM)
+	streams, err := streams.NewStreamStore(segments, maxBucketMetaSize.Int64(), memory.KiB.Int())
 	if err != nil {
 		return nil, Error.New("failed to create stream store: %v", err)
 	}
@@ -180,7 +178,6 @@ func (u *Uplink) OpenProject(ctx context.Context, satelliteAddr string, apiKey A
 		metainfo:      metainfo,
 		project:       kvmetainfo.NewProject(buckets.NewStore(streams), memory.KiB.Int32(), rs, 64*memory.MiB.Int64()),
 		maxInlineSize: u.cfg.Volatile.MaxInlineSize,
-		encryptionKey: encryptionKey,
 	}, nil
 }
 

--- a/lib/uplink/uplink.go
+++ b/lib/uplink/uplink.go
@@ -146,9 +146,6 @@ func NewUplink(ctx context.Context, cfg *Config) (*Uplink, error) {
 
 // ProjectOptions allows configuration of various project options during opening
 type ProjectOptions struct {
-	Volatile struct {
-		EncryptionKey *storj.Key
-	}
 }
 
 // OpenProject returns a Project handle with the given APIKey
@@ -171,15 +168,10 @@ func (u *Uplink) OpenProject(ctx context.Context, satelliteAddr string, apiKey A
 		return nil, Error.New("failed to create redundancy strategy: %v", err)
 	}
 	segments := segments.NewSegmentStore(metainfo, nil, rs, maxBucketMetaSize.Int(), maxBucketMetaSize.Int64())
-	var encryptionKey *storj.Key
-	if opts != nil {
-		encryptionKey = opts.Volatile.EncryptionKey
-	}
-	if encryptionKey == nil {
-		// volatile warning: we're setting an encryption key of all zeros when one isn't provided.
-		// TODO: fix before the final alpha network wipe
-		encryptionKey = new(storj.Key)
-	}
+	// volatile warning: we're setting an encryption key of all zeros, but there
+	// just shouldn't be an encryption key here at all.
+	// TODO: fix before the final alpha network wipe
+	encryptionKey := new(storj.Key)
 	streams, err := streams.NewStreamStore(segments, maxBucketMetaSize.Int64(),
 		encryptionKey, memory.KiB.Int(), storj.AESGCM)
 	if err != nil {

--- a/lib/uplink/uplink.go
+++ b/lib/uplink/uplink.go
@@ -144,12 +144,8 @@ func NewUplink(ctx context.Context, cfg *Config) (*Uplink, error) {
 	}, nil
 }
 
-// ProjectOptions allows configuration of various project options during opening
-type ProjectOptions struct {
-}
-
 // OpenProject returns a Project handle with the given APIKey
-func (u *Uplink) OpenProject(ctx context.Context, satelliteAddr string, apiKey APIKey, opts *ProjectOptions) (p *Project, err error) {
+func (u *Uplink) OpenProject(ctx context.Context, satelliteAddr string, apiKey APIKey) (p *Project, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	metainfo, err := metainfo.NewClient(ctx, u.tc, satelliteAddr, apiKey.key)

--- a/pkg/metainfo/kvmetainfo/metainfo.go
+++ b/pkg/metainfo/kvmetainfo/metainfo.go
@@ -38,9 +38,9 @@ type DB struct {
 }
 
 // New creates a new metainfo database
-func New(metainfo metainfo.Client, buckets buckets.Store, streams streams.Store, segments segments.Store, rootKey *storj.Key, encryptedBlockSize int32, redundancy eestream.RedundancyStrategy, segmentsSize int64) *DB {
+func New(metainfo metainfo.Client, buckets buckets.Store, streams streams.Store, segments segments.Store, rootKey *storj.Key, redundancy eestream.RedundancyStrategy, segmentsSize int64) *DB {
 	return &DB{
-		Project:  NewProject(buckets, encryptedBlockSize, redundancy, segmentsSize),
+		Project:  NewProject(buckets, redundancy, segmentsSize),
 		metainfo: metainfo,
 		streams:  streams,
 		segments: segments,

--- a/pkg/metainfo/kvmetainfo/project.go
+++ b/pkg/metainfo/kvmetainfo/project.go
@@ -17,10 +17,9 @@ type Project struct {
 }
 
 // NewProject constructs a *Project
-func NewProject(buckets buckets.Store, encryptedBlockSize int32, redundancy eestream.RedundancyStrategy, segmentsSize int64) *Project {
+func NewProject(buckets buckets.Store, redundancy eestream.RedundancyStrategy, segmentsSize int64) *Project {
 	return &Project{
 		buckets:            buckets,
-		encryptedBlockSize: encryptedBlockSize,
 		redundancy:         redundancy,
 		segmentsSize:       segmentsSize,
 	}

--- a/pkg/miniogw/gateway_test.go
+++ b/pkg/miniogw/gateway_test.go
@@ -728,9 +728,7 @@ func initEnv(ctx context.Context, planet *testplanet.Planet) (minio.ObjectLayer,
 		return nil, nil, nil, err
 	}
 
-	var projectOptions libuplink.ProjectOptions
-	projectOptions.Volatile.EncryptionKey = encKey
-	proj, err := uplink.OpenProject(ctx, planet.Satellites[0].Addr(), parsedAPIKey, &projectOptions)
+	proj, err := uplink.OpenProject(ctx, planet.Satellites[0].Addr(), parsedAPIKey)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/miniogw/integration_test.go
+++ b/pkg/miniogw/integration_test.go
@@ -194,9 +194,7 @@ func runGateway(ctx context.Context, gwCfg config, uplinkCfg uplink.Config, log 
 	encKey := new(storj.Key)
 	copy(encKey[:], uplinkCfg.Enc.Key)
 
-	var projectOptions libuplink.ProjectOptions
-	projectOptions.Volatile.EncryptionKey = encKey
-	project, err := uplink.OpenProject(ctx, uplinkCfg.Client.SatelliteAddr, apiKey, &projectOptions)
+	project, err := uplink.OpenProject(ctx, uplinkCfg.Client.SatelliteAddr, apiKey)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/segments/store.go
+++ b/pkg/storage/segments/store.go
@@ -61,13 +61,12 @@ type segmentStore struct {
 }
 
 // NewSegmentStore creates a new instance of segmentStore
-func NewSegmentStore(metainfo metainfo.Client, ec ecclient.Client, rs eestream.RedundancyStrategy, threshold int, maxEncryptedSegmentSize int64) Store {
+func NewSegmentStore(metainfo metainfo.Client, ec ecclient.Client, rs eestream.RedundancyStrategy, threshold int) Store {
 	return &segmentStore{
 		metainfo:                metainfo,
 		ec:                      ec,
 		rs:                      rs,
 		thresholdSize:           threshold,
-		maxEncryptedSegmentSize: maxEncryptedSegmentSize,
 	}
 }
 

--- a/pkg/storage/streams/store.go
+++ b/pkg/storage/streams/store.go
@@ -67,23 +67,23 @@ type streamStore struct {
 }
 
 // NewStreamStore stuff
-func NewStreamStore(segments segments.Store, segmentSize int64, rootKey *storj.Key, encBlockSize int, cipher storj.Cipher) (Store, error) {
+func NewStreamStore(segments segments.Store, segmentSize int64, rootKey *storj.Key) (Store, error) {
 	if segmentSize <= 0 {
 		return nil, errs.New("segment size must be larger than 0")
 	}
 	if rootKey == nil {
 		return nil, errs.New("encryption key must not be empty")
 	}
-	if encBlockSize <= 0 {
-		return nil, errs.New("encryption block size must be larger than 0")
-	}
+	// if encBlockSize <= 0 {
+	// 	return nil, errs.New("encryption block size must be larger than 0")
+	// }
 
 	return &streamStore{
 		segments:     segments,
 		segmentSize:  segmentSize,
 		rootKey:      rootKey,
-		encBlockSize: encBlockSize,
-		cipher:       cipher,
+		// encBlockSize: encBlockSize,
+		// cipher:       cipher,
 	}, nil
 }
 

--- a/pkg/storage/streams/store_test.go
+++ b/pkg/storage/streams/store_test.go
@@ -89,7 +89,7 @@ func TestStreamStoreMeta(t *testing.T) {
 			Meta(gomock.Any(), gomock.Any()).
 			Return(test.segmentMeta, test.segmentError)
 
-		streamStore, err := NewStreamStore(mockSegmentStore, 10, new(storj.Key), 10, storj.AESGCM)
+		streamStore, err := NewStreamStore(mockSegmentStore, 10, new(storj.Key))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -168,7 +168,7 @@ func TestStreamStorePut(t *testing.T) {
 			Delete(gomock.Any(), gomock.Any()).
 			Return(test.segmentError)
 
-		streamStore, err := NewStreamStore(mockSegmentStore, segSize, new(storj.Key), encBlockSize, dataCipher)
+		streamStore, err := NewStreamStore(mockSegmentStore, segSize, new(storj.Key))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -277,7 +277,7 @@ func TestStreamStoreGet(t *testing.T) {
 
 		gomock.InOrder(calls...)
 
-		streamStore, err := NewStreamStore(mockSegmentStore, segSize, new(storj.Key), encBlockSize, dataCipher)
+		streamStore, err := NewStreamStore(mockSegmentStore, segSize, new(storj.Key))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -326,7 +326,7 @@ func TestStreamStoreDelete(t *testing.T) {
 			Delete(gomock.Any(), gomock.Any()).
 			Return(test.segmentError)
 
-		streamStore, err := NewStreamStore(mockSegmentStore, 10, new(storj.Key), 10, 0)
+		streamStore, err := NewStreamStore(mockSegmentStore, 10, new(storj.Key))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -370,7 +370,7 @@ func TestStreamStoreList(t *testing.T) {
 			List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(test.segments, test.segmentMore, test.segmentError)
 
-		streamStore, err := NewStreamStore(mockSegmentStore, 10, new(storj.Key), 10, 0)
+		streamStore, err := NewStreamStore(mockSegmentStore, 10, new(storj.Key))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Background: see https://github.com/storj/storj/pull/1761

Summary: we should not require an encryption key to manage buckets
(though we require an encryption key to manage objects within a
bucket), so that bucket management can be done in the web interface.
This means the encryption key used when opening a project is going away.

We have a network wipe planned for next release, so for that wipe let's
make sure data and buckets uploaded after that wipe do not require an
encryption key.


## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
