### PR TITLE
Revert "storage/postgreskv: use batch size 1000"

### DIFF
--- a/storage/postgreskv/client.go
+++ b/storage/postgreskv/client.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultBatchSize = 1000
+	defaultBatchSize = 10000
 	defaultBucket    = ""
 )
 


### PR DESCRIPTION
Reverts storj/storj#1988

My own tests are showing the opposite; using 10000 is faster than 1000 with the setup I have (with PostgreSQL running on the same machine, macOS, and connecting to PG over a unix domain socket).

But as far as I can tell, defaultBatchSize _shouldn't_ affect these tests, so whether this change makes it faster or slower, I want to understand why before we commit the change.