### PR TITLE
Store repaired Segments and improve Repair Condition

### DIFF
--- a/pkg/storage/ec/client.go
+++ b/pkg/storage/ec/client.go
@@ -218,7 +218,7 @@ func (ec *ecClient) Repair(ctx context.Context, limits []*pb.AddressedOrderLimit
 
 	timer := time.AfterFunc(timeout, func() {
 		if ctx.Err() != context.Canceled {
-			zap.S().Infof("Timer expired. Successfully repaired to %d nodes. Canceling the long tail...", atomic.LoadInt32(&successfulCount))
+			zap.S().Infof("Timer expired. Successfully repaired to %d nodes.", atomic.LoadInt32(&successfulCount))
 			cancel()
 		}
 	})
@@ -240,13 +240,6 @@ func (ec *ecClient) Repair(ctx context.Context, limits []*pb.AddressedOrderLimit
 			Address: limits[info.i].GetStorageNodeAddress(),
 		}
 		successfulHashes[info.i] = info.hash
-
-		if int(atomic.AddInt32(&successfulCount, 1)) == optimalCount {
-			zap.S().Infof("Success threshold (%d nodes) reached by repairing to %d nodes. Canceling the long tail...",
-				rs.OptimalThreshold(), optimalCount)
-			timer.Stop()
-			cancel()
-		}
 	}
 
 	// Ensure timer is stopped in the case the success threshold is not reached

--- a/pkg/storage/ec/client.go
+++ b/pkg/storage/ec/client.go
@@ -261,7 +261,7 @@ func (ec *ecClient) Repair(ctx context.Context, limits []*pb.AddressedOrderLimit
 	}()
 
 	if successfulCount == 0 {
-		return nil, nil, Error.New("successful nodes count %d", successfulCount)
+		return nil, nil, Error.New("repair to all nodes failed")
 	}
 
 	return successfulNodes, successfulHashes, nil

--- a/pkg/storage/ec/client.go
+++ b/pkg/storage/ec/client.go
@@ -260,8 +260,8 @@ func (ec *ecClient) Repair(ctx context.Context, limits []*pb.AddressedOrderLimit
 		}
 	}()
 
-	if successfulCount < int32(optimalCount) {
-		return nil, nil, Error.New("successful nodes count (%d) does not match optimal count (%d) of erasure scheme", successfulCount, optimalCount)
+	if successfulCount > 0 {
+		return nil, nil, Error.New("successful nodes count %d", successfulCount)
 	}
 
 	return successfulNodes, successfulHashes, nil

--- a/pkg/storage/ec/client.go
+++ b/pkg/storage/ec/client.go
@@ -260,7 +260,7 @@ func (ec *ecClient) Repair(ctx context.Context, limits []*pb.AddressedOrderLimit
 		}
 	}()
 
-	if successfulCount > 0 {
+	if successfulCount == 0 {
 		return nil, nil, Error.New("successful nodes count %d", successfulCount)
 	}
 

--- a/pkg/storage/segments/repairer.go
+++ b/pkg/storage/segments/repairer.go
@@ -78,7 +78,7 @@ func (repairer *Repairer) Repair(ctx context.Context, path storj.Path) (err erro
 	}
 
 	// repair not needed
-	if (int32(numHealthy) >= pointer.Remote.Redundancy.MinReq) && (int32(numHealthy) > pointer.Remote.Redundancy.RepairThreshold) {
+	if int32(numHealthy) > pointer.Remote.Redundancy.RepairThreshold {
 		return nil
 	}
 


### PR DESCRIPTION
What: 
1. Repair job should not cutoff longtail.
2. Commit repair pieces even if not hitting the success threshold
3. Remove useless condition.

Why:
1. Main objective for the repair job is file durability and not upload speed.
2. If we managed to upload to 79 instead of 80 nodes we should still write it back to the database. There is no reason to throw an error.
3. `healty > min && healty > success` is a bit useless. `healty > success` will produce the same results because `success > min`

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
