### PR TITLE
call GetRemotePieces once

### DIFF
--- a/pkg/storage/segments/repairer.go
+++ b/pkg/storage/segments/repairer.go
@@ -85,7 +85,7 @@ func (repairer *Repairer) Repair(ctx context.Context, path storj.Path) (err erro
 	lostPiecesSet := sliceToSet(missingPieces)
 
 	// Populate healthyPieces with all pieces from the pointer except those correlating to indices in lostPieces
-	for _, piece := range pointer.GetRemote().GetRemotePieces() {
+	for _, piece := range pieces {
 		excludeNodeIDs = append(excludeNodeIDs, piece.NodeId)
 		if _, ok := lostPiecesSet[piece.GetPieceNum()]; !ok {
 			healthyPieces = append(healthyPieces, piece)

--- a/pkg/storage/segments/repairer.go
+++ b/pkg/storage/segments/repairer.go
@@ -79,7 +79,7 @@ func (repairer *Repairer) Repair(ctx context.Context, path storj.Path) (err erro
 
 	// repair not needed
 	if int32(numHealthy) > pointer.Remote.Redundancy.RepairThreshold {
-		return Error.New("piece %v with %d pieces above repiar threshold %d", path, numHealthy, pointer.Remote.Redundancy.RepairThreshold)
+		return Error.New("piece %v with %d pieces above repair threshold %d", path, numHealthy, pointer.Remote.Redundancy.RepairThreshold)
 	}
 
 	lostPiecesSet := sliceToSet(missingPieces)


### PR DESCRIPTION
What: 
reuse previous call to pointer.GetRemote().GetRemotePieces()

Why:
slightly better