### PR TITLE
adds UpdateContained function to overlay cache

### DIFF
--- a/pkg/overlay/cache.go
+++ b/pkg/overlay/cache.go
@@ -53,6 +53,8 @@ type DB interface {
 	UpdateStats(ctx context.Context, request *UpdateRequest) (stats *NodeStats, err error)
 	// UpdateNodeInfo updates node dossier with info requested from the node itself like node type, email, wallet, capacity, and version.
 	UpdateNodeInfo(ctx context.Context, node storj.NodeID, nodeInfo *pb.InfoResponse) (stats *NodeDossier, err error)
+	// UpdateContained updates node's contained status in node dossier
+	UpdateContained(ctx context.Context, nodeID storj.NodeID, isContained bool) (err error)
 	// UpdateUptime updates a single storagenode's uptime stats.
 	UpdateUptime(ctx context.Context, nodeID storj.NodeID, isUp bool) (stats *NodeStats, err error)
 }
@@ -271,6 +273,12 @@ func (cache *Cache) UpdateStats(ctx context.Context, request *UpdateRequest) (st
 func (cache *Cache) UpdateNodeInfo(ctx context.Context, node storj.NodeID, nodeInfo *pb.InfoResponse) (stats *NodeDossier, err error) {
 	defer mon.Task()(&ctx)(&err)
 	return cache.db.UpdateNodeInfo(ctx, node, nodeInfo)
+}
+
+// UpdateContained updates node's contained status in node dossier
+func (cache *Cache) UpdateContained(ctx context.Context, nodeID storj.NodeID, isContained bool) (err error) {
+	defer mon.Task()(&ctx)(&err)
+	return cache.db.UpdateContained(ctx, nodeID, isContained)
 }
 
 // UpdateUptime updates a single storagenode's uptime stats.

--- a/pkg/overlay/cache_test.go
+++ b/pkg/overlay/cache_test.go
@@ -121,6 +121,10 @@ func TestUpdateContained(t *testing.T) {
 		err = cache.UpdateContained(ctx, nodeID0, true)
 		require.NoError(t, err)
 
+		node0, err = cache.Get(ctx, nodeID0)
+		require.NoError(t, err)
+		require.True(t, node0.Contained)
+
 		// sets to false when it's already false
 		err = cache.UpdateContained(ctx, nodeID1, false)
 		require.NoError(t, err)

--- a/pkg/overlay/cache_test.go
+++ b/pkg/overlay/cache_test.go
@@ -103,7 +103,6 @@ func TestUpdateContained(t *testing.T) {
 		cache := planet.Satellites[0].DB.OverlayCache()
 
 		nodeID0 := planet.StorageNodes[0].ID()
-		nodeID1 := planet.StorageNodes[1].ID()
 
 		// check that contained default is false
 		node0, err := cache.Get(ctx, nodeID0)
@@ -124,6 +123,8 @@ func TestUpdateContained(t *testing.T) {
 		node0, err = cache.Get(ctx, nodeID0)
 		require.NoError(t, err)
 		require.True(t, node0.Contained)
+
+		nodeID1 := planet.StorageNodes[1].ID()
 
 		// sets to false when it's already false
 		err = cache.UpdateContained(ctx, nodeID1, false)

--- a/satellite/satellitedb/locked.go
+++ b/satellite/satellitedb/locked.go
@@ -688,6 +688,13 @@ func (m *lockedOverlayCache) UpdateAddress(ctx context.Context, value *pb.Node) 
 	return m.db.UpdateAddress(ctx, value)
 }
 
+// UpdateContained updates node's contained status in node dossier
+func (m *lockedOverlayCache) UpdateContained(ctx context.Context, nodeID storj.NodeID, isContained bool) (err error) {
+	m.Lock()
+	defer m.Unlock()
+	return m.db.UpdateContained(ctx, nodeID, isContained)
+}
+
 // UpdateNodeInfo updates node dossier with info requested from the node itself like node type, email, wallet, capacity, and version.
 func (m *lockedOverlayCache) UpdateNodeInfo(ctx context.Context, node storj.NodeID, nodeInfo *pb.InfoResponse) (stats *overlay.NodeDossier, err error) {
 	m.Lock()

--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -467,6 +467,18 @@ func (cache *overlaycache) UpdateNodeInfo(ctx context.Context, nodeID storj.Node
 	return convertDBNode(updatedDBNode)
 }
 
+// UpdateContained updates node's contained status in node dossier
+func (cache *overlaycache) UpdateContained(ctx context.Context, nodeID storj.NodeID, isContained bool) (err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	updateField := dbx.Node_Update_Fields{
+		Contained: dbx.Node_Contained(isContained),
+	}
+
+	_, err = cache.db.Update_Node_By_Id(ctx, dbx.Node_Id(nodeID.Bytes()), updateField)
+	return Error.Wrap(err)
+}
+
 // UpdateUptime updates a single storagenode's uptime stats in the db
 func (cache *overlaycache) UpdateUptime(ctx context.Context, nodeID storj.NodeID, isUp bool) (stats *overlay.NodeStats, err error) {
 	defer mon.Task()(&ctx)(&err)


### PR DESCRIPTION
What:
- Adds UpdateContained function to overlay cache and a test for it

Why:
- The existing functions for updating a node dossier (e.g. UpdateNodeInfo) did not allow a way to update a node's `contained` field, which will be needed for containment mode to work.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
