### PR TITLE
cmd/uplink: Fix error on interactive setup when --config-dir flag is used.

### DIFF
--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -194,7 +194,9 @@ Please enter numeric choice or enter satellite address manually [1]: `)
 
 	// if there is an error with this we cannot do that much and the setup process
 	// has ended OK, so we ignore it.
-	_, _ = fmt.Println(`
+	_, _ = fmt.Printf(`
+Your encryption key is saved to: %s
+
 Your Uplink CLI is configured and ready to use!
 
 Some things to try next:
@@ -202,7 +204,7 @@ Some things to try next:
 * Run 'uplink --help' to see the operations that can be performed
 
 * See https://github.com/storj/docs/blob/master/Uplink-CLI.md#usage for some example commands
-	`)
+	`, usedEncryptionKeyFilepath)
 
 	return nil
 }

--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -29,10 +29,9 @@ var (
 		Annotations: map[string]string{"type": "setup"},
 	}
 
-	setupCfg              UplinkFlags
-	confDir               string
-	encryptionKeyFilepath string
-	defaults              cfgstruct.BindOpt
+	setupCfg UplinkFlags
+	confDir  string
+	defaults cfgstruct.BindOpt
 
 	// Error is the default uplink setup errs class
 	Error = errs.Class("uplink setup error")
@@ -44,9 +43,6 @@ func init() {
 	defaults = cfgstruct.DefaultsFlag(RootCmd)
 	RootCmd.AddCommand(setupCmd)
 	cfgstruct.BindSetup(setupCmd.Flags(), &setupCfg, defaults, cfgstruct.ConfDir(confDir))
-
-	defaultEncryptionKeyFilepath := filepath.Join(defaultConfDir, ".encryption.key")
-	cfgstruct.SetupFlag(zap.L(), setupCmd, &encryptionKeyFilepath, "enc.key-filepath", defaultEncryptionKeyFilepath, "path to the file which contains the encryption key")
 }
 
 func cmdSetup(cmd *cobra.Command, args []string) (err error) {
@@ -76,10 +72,7 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 	// value in the config file but commented out.
 	usedEncryptionKeyFilepath := setupCfg.Enc.KeyFilepath
 	if usedEncryptionKeyFilepath == "" {
-		usedEncryptionKeyFilepath, err = filepath.Abs(encryptionKeyFilepath)
-		if err != nil {
-			return err
-		}
+		usedEncryptionKeyFilepath = filepath.Join(setupDir, ".encryption.key")
 	}
 
 	if setupCfg.NonInteractive {


### PR DESCRIPTION
What: `uplink` CLI interactive `setup` returns an error when `--config-dir` flag is set.

Why: because the `--config-dir` value wasn't considered for creating the encryption key file and the default one was used, so if the directory didn't exist the file couldn't be stored and if it would have existed then the encryption file was not going to be stored where the user indicates.

**NOTE** commit message provides relevant information of the changes, please consider to read them if you have any doubt on it, before commenting/asking.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
