### PR TITLE
uplink: Don't save EncryptionKey in config

### DIFF
--- a/uplink/config.go
+++ b/uplink/config.go
@@ -42,7 +42,7 @@ type RSConfig struct {
 // EncryptionConfig is a configuration struct that keeps details about
 // encrypting segments
 type EncryptionConfig struct {
-	EncryptionKey string      `help:"the root key for encrypting the data; when set, it overrides the key stored in the file indicated by the key-filepath flag"`
+	EncryptionKey string      `help:"the root key for encrypting the data; when set, it overrides the key stored in the file indicated by the key-filepath flag" setup:"true"`
 	KeyFilepath   string      `help:"the path to the file which contains the root key for encrypting the data"`
 	BlockSize     memory.Size `help:"size (in bytes) of encrypted blocks" default:"1KiB"`
 	DataType      int         `help:"Type of encryption to use for content and metadata (1=AES-GCM, 2=SecretBox)" default:"1"`


### PR DESCRIPTION
What: 
The encryption key configuration field MUST NOT be present in the
configuration file.

Why:
Without the `setup:"true"` the field is set in the `config.yaml`
commented out, however this value MUST NEVER be there because it's
insecure and moreover is never read.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
