### PR TITLE
properly check last iteration of checker

### DIFF
--- a/pkg/datarepair/checker/checker.go
+++ b/pkg/datarepair/checker/checker.go
@@ -100,10 +100,9 @@ func (checker *Checker) IdentifyInjuredSegments(ctx context.Context) (err error)
 				it.Next(&nextItem)
 				// start at the next item in the next call
 				checker.lastChecked = nextItem.Key.String()
-				// if keys are equal, start from the beginning in the next call
-				if nextItem.Key.String() == item.Key.String() {
-					checker.lastChecked = ""
 
+				// if we have finished iterating, send and reset durability stats
+				if checker.lastChecked == "" {
 					// send durability stats
 					mon.IntVal("remote_files_checked").Observe(checker.durabilityStats.remoteFilesChecked)
 					mon.IntVal("remote_segments_checked").Observe(checker.durabilityStats.remoteSegmentsChecked)


### PR DESCRIPTION
What: 
Change how we determine that the checker has finished iterating

Why:
Monkit stats were never being properly sent because the case being checked was never true

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
