### PR TITLE
pkg/audit: Readdress ignored Verifier tests

### DIFF
--- a/pkg/audit/verifier.go
+++ b/pkg/audit/verifier.go
@@ -76,9 +76,9 @@ func (verifier *Verifier) Verify(ctx context.Context, stripe *Stripe) (verifiedN
 	sharesToAudit := make(map[int]Share)
 
 	for pieceNum, share := range shares {
-		if shares[pieceNum].Error != nil {
+		if share.Error != nil {
 			// TODO(kaloyan): we need to check the logic here if we correctly identify offline nodes from those that didn't respond.
-			if shares[pieceNum].Error == context.DeadlineExceeded || !transport.Error.Has(shares[pieceNum].Error) {
+			if share.Error == context.DeadlineExceeded || !transport.Error.Has(share.Error) {
 				containedNodes[pieceNum] = nodes[pieceNum]
 			} else {
 				offlineNodes = append(offlineNodes, nodes[pieceNum])

--- a/pkg/audit/verifier_test.go
+++ b/pkg/audit/verifier_test.go
@@ -1,105 +1,15 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build ignore
-
-package audit_test
+package audit
 
 import (
 	"context"
-	"crypto/rand"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vivint/infectious"
-
-	"storj.io/storj/internal/teststorj"
-	"storj.io/storj/pkg/audit"
-	"storj.io/storj/pkg/pb"
-	"storj.io/storj/pkg/storj"
 )
-
-type mockDownloader struct {
-	shares map[int]audit.Share
-}
-
-func TestPassingAudit(t *testing.T) {
-	ctx := context.Background()
-	mockShares := make(map[int]audit.Share)
-
-	for _, tt := range []struct {
-		nodeAmt  int
-		shareAmt int
-		required int
-		total    int
-		err      error
-	}{
-		{nodeAmt: 30, shareAmt: 30, required: 20, total: 40, err: nil},
-	} {
-		someData := randData(32 * 1024)
-		for i := 0; i < tt.shareAmt; i++ {
-			mockShares[i] = audit.Share{
-				Error:       tt.err,
-				PieceNumber: i,
-				Data:        someData,
-			}
-		}
-		md := mockDownloader{shares: mockShares}
-		verifier := &audit.Verifier{downloader: &md}
-		pointer := makePointer(tt.nodeAmt)
-		verifiedNodes, err := verifier.Verify(ctx, &audit.Stripe{Index: 6, Segment: pointer, PBA: nil})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if len(verifiedNodes.SuccessNodeIDs) == 0 {
-			t.Fatal("expected there to be passing nodes")
-		}
-	}
-}
-
-func TestSomeNodesPassAudit(t *testing.T) {
-	ctx := context.Background()
-	mockShares := make(map[int]share)
-
-	for _, tt := range []struct {
-		nodeAmt  int
-		shareAmt int
-		required int
-		total    int
-		err0     error
-		err1     error
-	}{
-		{nodeAmt: 30, shareAmt: 30, required: 20, total: 40, err0: Error.New("unable to get node"), err1: nil},
-	} {
-		someData := randData(32 * 1024)
-		for i := 0; i < 10; i++ {
-			mockShares[i] = share{
-				Error:       tt.err0,
-				PieceNumber: i,
-				Data:        someData,
-			}
-		}
-		for i := 10; i < tt.shareAmt; i++ {
-			mockShares[i] = share{
-				Error:       tt.err1,
-				PieceNumber: i,
-				Data:        someData,
-			}
-		}
-
-		md := mockDownloader{shares: mockShares}
-		verifier := &audit.Verifier{downloader: &md}
-		pointer := makePointer(tt.nodeAmt)
-		verifiedNodes, err := verifier.verify(ctx, &audit.Stripe{Index: 6, Segment: pointer, PBA: nil})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		assert.Equal(t, len(verifiedNodes.OfflineNodeIDs), 10)
-	}
-}
 
 func TestFailingAudit(t *testing.T) {
 	const (
@@ -137,22 +47,26 @@ func TestFailingAudit(t *testing.T) {
 	badPieceNums := []int{0, 2, 3, 4}
 
 	ctx := context.Background()
-	auditPkgShares := make(map[int]audit.Share, len(modifiedShares))
+	auditPkgShares := make(map[int]Share, len(modifiedShares))
 	for i := range modifiedShares {
-		auditPkgShares[modifiedShares[i].Number] = audit.Share{
-			PieceNumber: modifiedShares[i].Number,
-			Data:        append([]byte(nil), modifiedShares[i].Data...),
+		auditPkgShares[modifiedShares[i].Number] = Share{
+			PieceNum: modifiedShares[i].Number,
+			Data:     append([]byte(nil), modifiedShares[i].Data...),
 		}
 	}
-	pieceNums, err := auditShares(ctx, 8, 14, auditPkgShares)
+
+	pieceNums, correctedShares, err := auditShares(ctx, 8, 14, auditPkgShares)
 	if err != nil {
 		panic(err)
 	}
+
 	for i, num := range pieceNums {
 		if num != badPieceNums[i] {
 			t.Fatal("expected nums in pieceNums to be same as in badPieceNums")
 		}
 	}
+
+	assert.Equal(t, shares, correctedShares)
 }
 
 func TestNotEnoughShares(t *testing.T) {
@@ -179,74 +93,13 @@ func TestNotEnoughShares(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	auditPkgShares := make(map[int]share, len(shares))
+	auditPkgShares := make(map[int]Share, len(shares))
 	for i := range shares {
-		auditPkgShares[shares[i].Number] = share{
-			PieceNumber: shares[i].Number,
-			Data:        append([]byte(nil), shares[i].Data...),
+		auditPkgShares[shares[i].Number] = Share{
+			PieceNum: shares[i].Number,
+			Data:     append([]byte(nil), shares[i].Data...),
 		}
 	}
-	_, err = auditShares(ctx, 20, 40, auditPkgShares)
+	_, _, err = auditShares(ctx, 20, 40, auditPkgShares)
 	assert.Contains(t, err.Error(), "infectious: must specify at least the number of required shares")
-}
-
-func TestCalcPadded(t *testing.T) {
-	for _, tt := range []struct {
-		segSize    int64
-		blockSize  int
-		paddedSize int64
-	}{
-		{segSize: int64(5 * 1024), blockSize: 1024, paddedSize: int64(5120)},
-		{segSize: int64(5 * 1023), blockSize: 1024, paddedSize: int64(5120)},
-	} {
-		result := calcPadded(tt.segSize, tt.blockSize)
-		assert.Equal(t, result, tt.paddedSize)
-	}
-}
-
-func (m *mockDownloader) DownloadShares(ctx context.Context, pointer *pb.Pointer, stripeIndex int,
-	pba *pb.OrderLimit) (shares map[int]share, nodes map[int]storj.NodeID, err error) {
-
-	nodes = make(map[int]*pb.Node, 30)
-
-	for i := 0; i < 30; i++ {
-		nodes[i] = teststorj.NodeIDFromString(strconv.Itoa(i))
-	}
-	return m.shares, nodes, nil
-}
-
-func makePointer(nodeAmt int) *pb.Pointer {
-	var rps []*pb.RemotePiece
-	for i := 0; i < nodeAmt; i++ {
-		rps = append(rps, &pb.RemotePiece{
-			PieceNum: int32(i),
-			NodeId:   teststorj.NodeIDFromString("test" + strconv.Itoa(i)),
-		})
-	}
-	pr := &pb.Pointer{
-		Type: pb.Pointer_REMOTE,
-		Remote: &pb.RemoteSegment{
-			Redundancy: &pb.RedundancyScheme{
-				Type:             pb.RedundancyScheme_RS,
-				MinReq:           20,
-				Total:            40,
-				RepairThreshold:  2,
-				SuccessThreshold: 3,
-				ErasureShareSize: 4,
-			},
-			PieceId:      "testId",
-			RemotePieces: rps,
-		},
-		SegmentSize: int64(1),
-	}
-	return pr
-}
-
-func randData(amount int) []byte {
-	buf := make([]byte, amount)
-	_, err := rand.Read(buf)
-	if err != nil {
-		panic(err)
-	}
-	return buf
 }

--- a/pkg/audit/verifier_test.go
+++ b/pkg/audit/verifier_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vivint/infectious"
 )
 
@@ -66,7 +66,7 @@ func TestFailingAudit(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, shares, correctedShares)
+	require.Equal(t, shares, correctedShares)
 }
 
 func TestNotEnoughShares(t *testing.T) {
@@ -101,5 +101,5 @@ func TestNotEnoughShares(t *testing.T) {
 		}
 	}
 	_, _, err = auditShares(ctx, 20, 40, auditPkgShares)
-	assert.Contains(t, err.Error(), "infectious: must specify at least the number of required shares")
+	require.Contains(t, err.Error(), "infectious: must specify at least the number of required shares")
 }


### PR DESCRIPTION
What: The `Verifier` type of the `pkg/audit` had a test which was totally ignored
due to a +build tag.

Why: Ignoring test using a `+build` is confusing because it isn't clear that
the test is fully ignored and the test doesn't get compiled anymore so
all the breaking changes in the implementation don't warm to update the
test.

This changes remove the +build tag and resuscitate the tests which
haven't required that much changes, the rest of them have been deleted.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
