### PR TITLE
Delete pending audit entries from containment DB when files get deleted

### DIFF
--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -396,7 +396,10 @@ func (endpoint *Endpoint) DeleteSegment(ctx context.Context, req *pb.SegmentDele
 		}
 
 		for _, piece := range pointer.GetRemote().GetRemotePieces() {
-			endpoint.containment.Delete(ctx, piece.NodeId)
+			_, err := endpoint.containment.Delete(ctx, piece.NodeId)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, err.Error())
+			}
 		}
 
 		bucketID := createBucketID(keyInfo.ProjectID, req.Bucket)

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -357,6 +357,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config *Config, ve
 			peer.Metainfo.Service,
 			peer.Orders.Service,
 			peer.Overlay.Service,
+			peer.DB.Containment(),
 			peer.DB.Console().APIKeys(),
 			peer.DB.StoragenodeAccounting(),
 			peer.DB.ProjectAccounting(),


### PR DESCRIPTION
What: Make sure pendingAudit entries associated with deleted segments are also deleted from ContainmentDB

Why: So that we don't audit nodes on deleted segments

Jira task: https://storjlabs.atlassian.net/browse/V3-1763

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
