### PR TITLE
Use absolute size for unit calculation to account for negative numbers

### DIFF
--- a/internal/memory/size.go
+++ b/internal/memory/size.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"math"
 )
 
 // base 2 and base 10 sizes

--- a/internal/memory/size.go
+++ b/internal/memory/size.go
@@ -102,21 +102,21 @@ func countZeros(num, base int64) (count int) {
 // Base2String converts size to a string using base-2 prefixes
 func (size Size) Base2String() string {
 	if size == 0 {
-		return "0"
+		return "0 B"
 	}
 
 	switch {
-	case size >= EiB*2/3:
+	case Abs(size) >= EiB*2/3:
 		return fmt.Sprintf("%.1f EiB", size.EiB())
-	case size >= PiB*2/3:
+	case Abs(size) >= PiB*2/3:
 		return fmt.Sprintf("%.1f PiB", size.PiB())
-	case size >= TiB*2/3:
+	case Abs(size) >= TiB*2/3:
 		return fmt.Sprintf("%.1f TiB", size.TiB())
-	case size >= GiB*2/3:
+	case Abs(size) >= GiB*2/3:
 		return fmt.Sprintf("%.1f GiB", size.GiB())
-	case size >= MiB*2/3:
+	case Abs(size) >= MiB*2/3:
 		return fmt.Sprintf("%.1f MiB", size.MiB())
-	case size >= KiB*2/3:
+	case Abs(size) >= KiB*2/3:
 		return fmt.Sprintf("%.1f KiB", size.KiB())
 	}
 
@@ -126,21 +126,21 @@ func (size Size) Base2String() string {
 // Base10String converts size to a string using base-10 prefixes
 func (size Size) Base10String() string {
 	if size == 0 {
-		return "0"
+		return "0 B"
 	}
 
 	switch {
-	case size >= EB*2/3:
+	case Abs(size) >= EB*2/3:
 		return fmt.Sprintf("%.1f EB", size.EB())
-	case size >= PB*2/3:
+	case Abs(size) >= PB*2/3:
 		return fmt.Sprintf("%.1f PB", size.PB())
-	case size >= TB*2/3:
+	case Abs(size) >= TB*2/3:
 		return fmt.Sprintf("%.1f TB", size.TB())
-	case size >= GB*2/3:
+	case Abs(size) >= GB*2/3:
 		return fmt.Sprintf("%.1f GB", size.GB())
-	case size >= MB*2/3:
+	case Abs(size) >= MB*2/3:
 		return fmt.Sprintf("%.1f MB", size.MB())
-	case size >= KB*2/3:
+	case Abs(size) >= KB*2/3:
 		return fmt.Sprintf("%.1f KB", size.KB())
 	}
 

--- a/internal/memory/size.go
+++ b/internal/memory/size.go
@@ -107,17 +107,17 @@ func (size Size) Base2String() string {
 	}
 
 	switch {
-	case math.Abs(size) >= EiB*2/3:
+	case math.Abs(size.Float64()) >= EiB.Float64()*2/3:
 		return fmt.Sprintf("%.1f EiB", size.EiB())
-	case math.Abs(size) >= PiB*2/3:
+	case math.Abs(size.Float64()) >= PiB.Float64()*2/3:
 		return fmt.Sprintf("%.1f PiB", size.PiB())
-	case math.Abs(size) >= TiB*2/3:
+	case math.Abs(size.Float64()) >= TiB.Float64()*2/3:
 		return fmt.Sprintf("%.1f TiB", size.TiB())
-	case math.Abs(size) >= GiB*2/3:
+	case math.Abs(size.Float64()) >= GiB.Float64()*2/3:
 		return fmt.Sprintf("%.1f GiB", size.GiB())
-	case math.Abs(size) >= MiB*2/3:
+	case math.Abs(size.Float64()) >= MiB.Float64()*2/3:
 		return fmt.Sprintf("%.1f MiB", size.MiB())
-	case math.Abs(size) >= KiB*2/3:
+	case math.Abs(size.Float64()) >= KiB.Float64()*2/3:
 		return fmt.Sprintf("%.1f KiB", size.KiB())
 	}
 
@@ -131,17 +131,17 @@ func (size Size) Base10String() string {
 	}
 
 	switch {
-	case math.Abs(size) >= EB*2/3:
+	case math.Abs(size.Float64()) >= EB.Float64()*2/3:
 		return fmt.Sprintf("%.1f EB", size.EB())
-	case math.Abs(size) >= PB*2/3:
+	case math.Abs(size.Float64()) >= PB.Float64()*2/3:
 		return fmt.Sprintf("%.1f PB", size.PB())
-	case math.Abs(size) >= TB*2/3:
+	case math.Abs(size.Float64()) >= TB.Float64()*2/3:
 		return fmt.Sprintf("%.1f TB", size.TB())
-	case math.Abs(size) >= GB*2/3:
+	case math.Abs(size.Float64()) >= GB.Float64()*2/3:
 		return fmt.Sprintf("%.1f GB", size.GB())
-	case math.Abs(size) >= MB*2/3:
+	case math.Abs(size.Float64()) >= MB.Float64()*2/3:
 		return fmt.Sprintf("%.1f MB", size.MB())
-	case math.Abs(size) >= KB*2/3:
+	case math.Abs(size.Float64()) >= KB.Float64()*2/3:
 		return fmt.Sprintf("%.1f KB", size.KB())
 	}
 

--- a/internal/memory/size.go
+++ b/internal/memory/size.go
@@ -107,17 +107,17 @@ func (size Size) Base2String() string {
 	}
 
 	switch {
-	case Abs(size) >= EiB*2/3:
+	case math.Abs(size) >= EiB*2/3:
 		return fmt.Sprintf("%.1f EiB", size.EiB())
-	case Abs(size) >= PiB*2/3:
+	case math.Abs(size) >= PiB*2/3:
 		return fmt.Sprintf("%.1f PiB", size.PiB())
-	case Abs(size) >= TiB*2/3:
+	case math.Abs(size) >= TiB*2/3:
 		return fmt.Sprintf("%.1f TiB", size.TiB())
-	case Abs(size) >= GiB*2/3:
+	case math.Abs(size) >= GiB*2/3:
 		return fmt.Sprintf("%.1f GiB", size.GiB())
-	case Abs(size) >= MiB*2/3:
+	case math.Abs(size) >= MiB*2/3:
 		return fmt.Sprintf("%.1f MiB", size.MiB())
-	case Abs(size) >= KiB*2/3:
+	case math.Abs(size) >= KiB*2/3:
 		return fmt.Sprintf("%.1f KiB", size.KiB())
 	}
 
@@ -131,17 +131,17 @@ func (size Size) Base10String() string {
 	}
 
 	switch {
-	case Abs(size) >= EB*2/3:
+	case math.Abs(size) >= EB*2/3:
 		return fmt.Sprintf("%.1f EB", size.EB())
-	case Abs(size) >= PB*2/3:
+	case math.Abs(size) >= PB*2/3:
 		return fmt.Sprintf("%.1f PB", size.PB())
-	case Abs(size) >= TB*2/3:
+	case math.Abs(size) >= TB*2/3:
 		return fmt.Sprintf("%.1f TB", size.TB())
-	case Abs(size) >= GB*2/3:
+	case math.Abs(size) >= GB*2/3:
 		return fmt.Sprintf("%.1f GB", size.GB())
-	case Abs(size) >= MB*2/3:
+	case math.Abs(size) >= MB*2/3:
 		return fmt.Sprintf("%.1f MB", size.MB())
-	case Abs(size) >= KB*2/3:
+	case math.Abs(size) >= KB*2/3:
 		return fmt.Sprintf("%.1f KB", size.KB())
 	}
 

--- a/internal/memory/size.go
+++ b/internal/memory/size.go
@@ -6,9 +6,9 @@ package memory
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
-	"math"
 )
 
 // base 2 and base 10 sizes

--- a/internal/memory/size_test.go
+++ b/internal/memory/size_test.go
@@ -43,7 +43,7 @@ func TestBase2Size(t *testing.T) {
 		{500, "500 B"},
 		{5, "5 B"},
 		{1, "1 B"},
-		{0, "0"},
+		{0, "0 B"},
 	}
 
 	for i, test := range tests {
@@ -81,7 +81,7 @@ func TestBase10Size(t *testing.T) {
 		{500, "500 B"},
 		{5, "5 B"},
 		{1, "1 B"},
-		{0, "0"},
+		{0, "0 B"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
What: 
Currently code checks whether size is larger than the threshold set for the unit used. Because negative numbers are always smaller, they are always displayed in bytes. Using absolute numbers when comparing ensures negative numbers are displayed in the appropriate unit. To be consistent when "0" is returned it should say "0 B" as well.

Why:
This issue causes strange negative numbers to appear on the storagenode dashboard when used space goes slightly over the available space on full nodes. And might appear in other places as well.
This change will display negative sizes numbers in a compact format, similar to positive ones.

This is a fix for minor issue #2055 

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
