### PR TITLE
audit verifier should try a fresh Kad lookup for a node before marking it as offline

### DIFF
--- a/pkg/audit/service.go
+++ b/pkg/audit/service.go
@@ -13,6 +13,7 @@ import (
 	"storj.io/storj/internal/memory"
 	"storj.io/storj/internal/sync2"
 	"storj.io/storj/pkg/identity"
+	"storj.io/storj/pkg/kademlia"
 	"storj.io/storj/pkg/overlay"
 	"storj.io/storj/pkg/transport"
 	"storj.io/storj/satellite/metainfo"
@@ -42,13 +43,13 @@ type Service struct {
 
 // NewService instantiates a Service with access to a Cursor and Verifier
 func NewService(log *zap.Logger, config Config, metainfo *metainfo.Service,
-	orders *orders.Service, transport transport.Client, overlay *overlay.Cache,
+	orders *orders.Service, transport transport.Client, overlay *overlay.Cache, k *kademlia.Kademlia,
 	containment Containment, identity *identity.FullIdentity) (service *Service, err error) {
 	return &Service{
 		log: log,
 
 		Cursor:   NewCursor(metainfo),
-		Verifier: NewVerifier(log.Named("audit:verifier"), transport, overlay, orders, identity, config.MinBytesPerSecond),
+		Verifier: NewVerifier(log.Named("audit:verifier"), transport, overlay, k, orders, identity, config.MinBytesPerSecond),
 		Reporter: NewReporter(overlay, containment, config.MaxRetriesStatDB),
 
 		Loop: *sync2.NewCycle(config.Interval),

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -410,6 +410,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config *Config, ve
 			peer.Orders.Service,
 			peer.Transport,
 			peer.Overlay.Service,
+			peer.Kademlia.Service,
 			peer.DB.Containment(),
 			peer.Identity,
 		)


### PR DESCRIPTION
What: 
If a node appears offline, the audit service should attempt a new Kad lookup instead of immediately marking the node as offline.

Why:
Currently, if the audit verifier attempts to download a piece from a storage node, it will mark the node as offline if it appears to be offline. Instead, it should do a fresh Kad lookup and try to reach the node again. The whitepaper says:
>In the case of a node being offline, the audit failure may be due to the address in the node discovery cache being stale, so another, fresh Kademlia lookup will be attempted.

Only after this has been attempted, should the node be marked as offline.


Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
