### PR TITLE
process/metrics: have metrics suffix default to dev/release status

### DIFF
--- a/pkg/cfgstruct/bind.go
+++ b/pkg/cfgstruct/bind.go
@@ -287,25 +287,31 @@ func SetupFlag(log *zap.Logger, cmd *cobra.Command, dest *string, name, value, u
 	}
 }
 
+// DefaultsType returns the type of defaults (release/dev) this binary should use
+func DefaultsType() string {
+	// define a flag so that the flag parsing system will be happy.
+	defaults := strings.ToLower(FindDefaultsParam())
+	if defaults != "" {
+		return defaults
+	}
+	if version.Build.Release {
+		return "release"
+	}
+	return "dev"
+}
+
 // DefaultsFlag sets up the defaults=dev/release flag options, which is needed
 // before `flag.Parse` has been called
 func DefaultsFlag(cmd *cobra.Command) BindOpt {
 	// define a flag so that the flag parsing system will be happy.
-	defaults := "dev"
-	if version.Build.Release {
-		defaults = "release"
-	}
+	defaults := DefaultsType()
+
 	// we're actually going to ignore this flag entirely and parse the commandline
 	// arguments early instead
 	_ = cmd.PersistentFlags().String("defaults", defaults,
 		"determines which set of configuration defaults to use. can either be 'dev' or 'release'")
 
-	foundDefaults := strings.ToLower(FindDefaultsParam())
-	if foundDefaults == "" {
-		foundDefaults = defaults
-	}
-
-	switch foundDefaults {
+	switch defaults {
 	case "dev":
 		return UseDevDefaults()
 	case "release":

--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/spacemonkeygo/monkit.v2/environment"
 
 	"storj.io/storj/internal/version"
+	"storj.io/storj/pkg/cfgstruct"
 	"storj.io/storj/pkg/identity"
 	"storj.io/storj/pkg/telemetry"
 )
@@ -24,7 +25,7 @@ var (
 	metricInterval  = flag.Duration("metrics.interval", telemetry.DefaultInterval, "how frequently to send up telemetry")
 	metricCollector = flag.String("metrics.addr", "collectora.storj.io:9000", "address to send telemetry to")
 	metricApp       = flag.String("metrics.app", filepath.Base(os.Args[0]), "application name for telemetry identification")
-	metricAppSuffix = flag.String("metrics.app-suffix", "-dev", "application suffix")
+	metricAppSuffix = flag.String("metrics.app-suffix", "-"+cfgstruct.DefaultsType(), "application suffix")
 )
 
 // InitMetrics initializes telemetry reporting. Makes a telemetry.Client and calls

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -167,7 +167,7 @@ kademlia.operator.wallet: ""
 # metrics.app: "satellite"
 
 # application suffix
-# metrics.app-suffix: "-dev"
+# metrics.app-suffix: "-release"
 
 # how frequently to send up telemetry
 # metrics.interval: 1m0s


### PR DESCRIPTION
What: this will make it so release binaries default to whatever-release instead of whatever-dev in metrics collection

Why: So we can monitor release binaries with default configuration without getting drowned out by dev binaries

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
