### PR TITLE
fix bug for setting flag only values in process setup

### DIFF
--- a/pkg/process/exec_conf_test.go
+++ b/pkg/process/exec_conf_test.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package process
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spf13/cobra"
+)
+
+func setenv(key, value string) func() {
+	old := os.Getenv(key)
+	os.Setenv(key, value)
+	return func() { os.Setenv(key, old) }
+}
+
+func TestExec_PropagatesSettings(t *testing.T) {
+	// Set up a command that does nothing.
+	cmd := &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error { return nil }}
+
+	// Define a config struct and some flags.
+	var config struct {
+		X int `default:"0"`
+	}
+	Bind(cmd, &config)
+	y := cmd.Flags().Int("y", 0, "y flag (command)")
+	z := flag.Int("z", 0, "z flag (stdlib)")
+
+	// Set some environment variables for viper.
+	defer setenv("STORJ_X", "1")()
+	defer setenv("STORJ_Y", "2")()
+	defer setenv("STORJ_Z", "3")()
+
+	// Run the command through the exec call.
+	Exec(cmd)
+
+	// Check that the variables are now bound.
+	require.Equal(t, 1, config.X)
+	require.Equal(t, 2, *y)
+	require.Equal(t, 3, *z)
+}

--- a/pkg/process/exec_conf_test.go
+++ b/pkg/process/exec_conf_test.go
@@ -15,8 +15,8 @@ import (
 
 func setenv(key, value string) func() {
 	old := os.Getenv(key)
-	os.Setenv(key, value)
-	return func() { os.Setenv(key, old) }
+	_ = os.Setenv(key, value)
+	return func() { _ = os.Setenv(key, old) }
 }
 
 func TestExec_PropagatesSettings(t *testing.T) {


### PR DESCRIPTION
What: fixes a bug introduced by #2068

Why:

when the code was changed to directly load values into the config
structs, it was missed that some configuration is only defined
through flags, but can be loaded from config files still.

so, we need to propogate the settings to the flag only values.


## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
