### PR TITLE
monitor macaroon parse/serialization perf

### DIFF
--- a/pkg/macaroon/serialize.go
+++ b/pkg/macaroon/serialize.go
@@ -4,6 +4,7 @@
 package macaroon
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 )
@@ -25,6 +26,8 @@ type packet struct {
 
 // Serialize converts macaroon to binary format
 func (m *Macaroon) Serialize() (data []byte) {
+	ctx := context.TODO()
+	defer mon.Task()(&ctx)(nil)
 	// Start data from version int
 	data = append(data, 2)
 
@@ -72,7 +75,9 @@ func appendVarint(data []byte, x int) []byte {
 }
 
 // ParseMacaroon converts binary to macaroon
-func ParseMacaroon(data []byte) (*Macaroon, error) {
+func ParseMacaroon(data []byte) (_ *Macaroon, err error) {
+	ctx := context.TODO()
+	defer mon.Task()(&ctx)(&err)
 	// skip version
 	data = data[1:]
 	// Parse Location


### PR DESCRIPTION
What: monitor macaroon parsing/serialization

Why: validateAuth can take almost a second, but none of the other monitored subcalls take that long?
![image](https://user-images.githubusercontent.com/109603/58981729-2e19e480-8790-11e9-9416-a7999cc9bc19.png)


## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
