### PR TITLE
discovery: remove graveyard

### DIFF
--- a/internal/testplanet/planet.go
+++ b/internal/testplanet/planet.go
@@ -458,7 +458,6 @@ func (planet *Planet) newSatellites(count int) ([]*satellite.Peer, error) {
 				},
 			},
 			Discovery: discovery.Config{
-				GraveyardInterval: 1 * time.Second,
 				DiscoveryInterval: 1 * time.Second,
 				RefreshInterval:   1 * time.Second,
 				RefreshLimit:      100,

--- a/pkg/datarepair/datarepair_test.go
+++ b/pkg/datarepair/datarepair_test.go
@@ -31,7 +31,6 @@ func TestDataRepair(t *testing.T) {
 		// stop discovery service so that we do not get a race condition when we delete nodes from overlay cache
 		satellite.Discovery.Service.Discovery.Stop()
 		satellite.Discovery.Service.Refresh.Stop()
-		satellite.Discovery.Service.Graveyard.Stop()
 
 		satellite.Repair.Checker.Loop.Pause()
 		satellite.Repair.Repairer.Loop.Pause()

--- a/pkg/discovery/service_test.go
+++ b/pkg/discovery/service_test.go
@@ -27,7 +27,7 @@ func TestCache_Refresh(t *testing.T) {
 	})
 }
 
-func TestCache_Graveyard(t *testing.T) {
+func TestCache_Discovery(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 1, UplinkCount: 0,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
@@ -38,7 +38,6 @@ func TestCache_Graveyard(t *testing.T) {
 		satellite.Kademlia.Service.RefreshBuckets.Pause()
 
 		satellite.Discovery.Service.Refresh.Pause()
-		satellite.Discovery.Service.Graveyard.Pause()
 		satellite.Discovery.Service.Discovery.Pause()
 
 		overlay := satellite.Overlay.Service
@@ -51,7 +50,7 @@ func TestCache_Graveyard(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, overlay.IsOnline(node))
 
-		satellite.Discovery.Service.Graveyard.TriggerWait()
+		satellite.Discovery.Service.Discovery.TriggerWait()
 
 		found, err := overlay.Get(ctx, offlineID)
 		assert.NoError(t, err)

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -327,17 +327,6 @@ func (k *Kademlia) lookup(ctx context.Context, nodeID storj.NodeID, isBootstrap 
 	return *target, nil
 }
 
-// Seen returns all nodes that this kademlia instance has successfully communicated with
-func (k *Kademlia) Seen() []*pb.Node {
-	nodes := []*pb.Node{}
-	k.routingTable.mutex.Lock()
-	for _, v := range k.routingTable.seen {
-		nodes = append(nodes, pb.CopyNode(v))
-	}
-	k.routingTable.mutex.Unlock()
-	return nodes
-}
-
 // GetNodesWithinKBucket returns all the routing nodes in the specified k-bucket
 func (k *Kademlia) GetNodesWithinKBucket(bID bucketID) ([]*pb.Node, error) {
 	return k.routingTable.getUnmarshaledNodesFromBucket(bID)

--- a/pkg/kademlia/lookup_test.go
+++ b/pkg/kademlia/lookup_test.go
@@ -27,7 +27,10 @@ func TestLookupNodes(t *testing.T) {
 	k := planet.Satellites[0].Kademlia.Service
 	k.WaitForBootstrap() // redundant, but leaving here to be clear
 
-	seen := k.Seen()
+	seen, err := k.DumpNodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	assert.NotEqual(t, len(seen), 0)
 	assert.NotNil(t, seen)
 

--- a/pkg/kademlia/routing_helpers_test.go
+++ b/pkg/kademlia/routing_helpers_test.go
@@ -45,7 +45,6 @@ func newTestRoutingTable(local *overlay.NodeDossier, opts routingTableOpts) (*Ro
 
 		mutex:            &sync.Mutex{},
 		rcMutex:          &sync.Mutex{},
-		seen:             make(map[storj.NodeID]*pb.Node),
 		replacementCache: make(map[bucketID][]*pb.Node),
 
 		bucketSize:   opts.bucketSize,

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -61,9 +61,6 @@ defaults: "release"
 # the interval at which the satellite attempts to find new nodes via random node ID lookups
 # discovery.discovery-interval: 1s
 
-# the interval at which the the graveyard tries to resurrect nodes
-# discovery.graveyard-interval: 30s
-
 # the interval at which the cache refreshes itself in seconds
 # discovery.refresh-interval: 1s
 


### PR DESCRIPTION
What: remove the node graveyard and the kad seen map.

Why: the node graveyard is taking significant resources trying to ping dead nodes, which will almost certainly time out. the graveyard wasn't part of the whitepaper or spec anyway, and the other refresh and discovery processes will help find recovered nodes already (all the tests should continue to pass). the kad seen map is unnecessary entirely.

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
