### PR TITLE
pkg/kademlia: Fix bug using ref of var range loop

### DIFF
--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -293,7 +293,8 @@ func (k *Kademlia) lookup(ctx context.Context, nodeID storj.NodeID, isBootstrap 
 	var nodes []*pb.Node
 	if isBootstrap {
 		for _, bn := range k.bootstrapNodes {
-			nodes = append(nodes, &bn) // nolint: scopelint
+			bn := bn
+			nodes = append(nodes, &bn)
 		}
 	} else {
 		var err error


### PR DESCRIPTION
Fix a bug related with shadowing the assigned variable to the range loop
due to the reference is used rather than the value.

It was ignore by the _scopelint_ linter due to it was mistakenly marked as `nolin:`

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
