### PR TITLE
Always use difficulty larger than 8 for identites

### DIFF
--- a/internal/testidentity/identity.go
+++ b/internal/testidentity/identity.go
@@ -36,7 +36,7 @@ func NewTestIdentity(ctx context.Context) (*identity.FullIdentity, error) {
 func NewTestCA(ctx context.Context) (*identity.FullCertificateAuthority, error) {
 	return identity.NewCA(ctx, identity.NewCAOptions{
 		VersionNumber: storj.LatestIDVersion().Number,
-		Difficulty:    8,
+		Difficulty:    9,
 		Concurrency:   4,
 	})
 }

--- a/lib/uplink/uplink.go
+++ b/lib/uplink/uplink.go
@@ -99,7 +99,7 @@ func NewUplink(ctx context.Context, cfg *Config) (_ *Uplink, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	ident, err := identity.NewFullIdentity(ctx, identity.NewCAOptions{
-		Difficulty:  0,
+		Difficulty:  9,
 		Concurrency: 1,
 	})
 	if err != nil {


### PR DESCRIPTION
What: Set difficulty for libuplink and testplanet larger than 8

Why: We use last byte in the node id to store the version number, so the difficulty must be larger than 8.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
