### PR TITLE
Use release build of uplink for container image

### DIFF
--- a/cmd/uplink/Dockerfile
+++ b/cmd/uplink/Dockerfile
@@ -1,16 +1,14 @@
-ARG CGO_ENABLED=1
-ARG REPOSITORY=../storj.io/storj
-ARG PACKAGE=storj.io/storj/cmd/uplink
-FROM storjlabs/golang as build-env
+ARG DOCKER_ARCH
+FROM ${DOCKER_ARCH:-amd64}/alpine
+ARG TAG
+ARG GOARCH
+ENV GOARCH ${GOARCH}
 
-# final stage
-FROM alpine
 ENV CONF_PATH=/root/.local/storj/uplink \
     API_KEY= \
     SATELLITE_ADDR=
-EXPOSE 7777
 WORKDIR /app
 VOLUME /root/.local/storj/uplink
-COPY --from=build-env /app /app/uplink
+COPY release/${TAG}/uplink_linux_${GOARCH:-amd64} /app/uplink
 COPY cmd/uplink/entrypoint /entrypoint
 ENTRYPOINT ["/entrypoint"]


### PR DESCRIPTION
We were building the uplink again for the container image. We should just copy in the release binary we've already built, like the other container images.