### PR TITLE
kademlia/routing: add contexts to more places so monkit works

### DIFF
--- a/pkg/dht/dht.go
+++ b/pkg/dht/dht.go
@@ -28,13 +28,13 @@ type RoutingTable interface {
 	Local() overlay.NodeDossier
 	K() int
 	CacheSize() int
-	GetBucketIds() (storage.Keys, error)
-	FindNear(id storj.NodeID, limit int) ([]*pb.Node, error)
-	ConnectionSuccess(node *pb.Node) error
-	ConnectionFailed(node *pb.Node) error
+	GetBucketIds(context.Context) (storage.Keys, error)
+	FindNear(ctx context.Context, id storj.NodeID, limit int) ([]*pb.Node, error)
+	ConnectionSuccess(ctx context.Context, node *pb.Node) error
+	ConnectionFailed(ctx context.Context, node *pb.Node) error
 	// these are for refreshing
-	SetBucketTimestamp(id []byte, now time.Time) error
-	GetBucketTimestamp(id []byte) (time.Time, error)
+	SetBucketTimestamp(ctx context.Context, id []byte, now time.Time) error
+	GetBucketTimestamp(ctx context.Context, id []byte) (time.Time, error)
 
 	Close() error
 }

--- a/pkg/kademlia/endpoint.go
+++ b/pkg/kademlia/endpoint.go
@@ -42,7 +42,7 @@ func (endpoint *Endpoint) Query(ctx context.Context, req *pb.QueryRequest) (_ *p
 		endpoint.pingback(ctx, req.Sender)
 	}
 
-	nodes, err := endpoint.routingTable.FindNear(req.Target.Id, int(req.Limit))
+	nodes, err := endpoint.routingTable.FindNear(ctx, req.Target.Id, int(req.Limit))
 	if err != nil {
 		return &pb.QueryResponse{}, EndpointError.New("could not find near endpoint: %v", err)
 	}
@@ -57,12 +57,12 @@ func (endpoint *Endpoint) pingback(ctx context.Context, target *pb.Node) {
 	_, err = endpoint.service.Ping(ctx, *target)
 	if err != nil {
 		endpoint.log.Debug("connection to node failed", zap.Error(err), zap.String("nodeID", target.Id.String()))
-		err = endpoint.routingTable.ConnectionFailed(target)
+		err = endpoint.routingTable.ConnectionFailed(ctx, target)
 		if err != nil {
 			endpoint.log.Error("could not respond to connection failed", zap.Error(err))
 		}
 	} else {
-		err = endpoint.routingTable.ConnectionSuccess(target)
+		err = endpoint.routingTable.ConnectionSuccess(ctx, target)
 		if err != nil {
 			endpoint.log.Error("could not respond to connection success", zap.Error(err))
 		} else {

--- a/pkg/kademlia/inspector.go
+++ b/pkg/kademlia/inspector.go
@@ -43,7 +43,7 @@ func (srv *Inspector) CountNodes(ctx context.Context, req *pb.CountNodesRequest)
 // GetBuckets returns all kademlia buckets for current kademlia instance
 func (srv *Inspector) GetBuckets(ctx context.Context, req *pb.GetBucketsRequest) (_ *pb.GetBucketsResponse, err error) {
 	defer mon.Task()(&ctx)(&err)
-	b, err := srv.dht.GetBucketIds()
+	b, err := srv.dht.GetBucketIds(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (srv *Inspector) NodeInfo(ctx context.Context, req *pb.NodeInfoRequest) (_ 
 // GetBucketList returns the list of buckets with their routing nodes and their cached nodes
 func (srv *Inspector) GetBucketList(ctx context.Context, req *pb.GetBucketListRequest) (_ *pb.GetBucketListResponse, err error) {
 	defer mon.Task()(&ctx)(&err)
-	bucketIds, err := srv.dht.GetBucketIds()
+	bucketIds, err := srv.dht.GetBucketIds(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (srv *Inspector) GetBucketList(ctx context.Context, req *pb.GetBucketListRe
 
 	for i, b := range bucketIds {
 		bucketID := keyToBucketID(b)
-		routingNodes, err := srv.dht.GetNodesWithinKBucket(bucketID)
+		routingNodes, err := srv.dht.GetNodesWithinKBucket(ctx, bucketID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kademlia/kademlia_test.go
+++ b/pkg/kademlia/kademlia_test.go
@@ -66,7 +66,7 @@ func TestNewKademlia(t *testing.T) {
 	}
 
 	for i, v := range cases {
-		kad, err := newKademlia(zaptest.NewLogger(t), pb.NodeType_STORAGE, v.bn, v.addr, pb.NodeOperator{}, v.id, ctx.Dir(strconv.Itoa(i)), defaultAlpha)
+		kad, err := newKademlia(ctx, zaptest.NewLogger(t), pb.NodeType_STORAGE, v.bn, v.addr, pb.NodeOperator{}, v.id, ctx.Dir(strconv.Itoa(i)), defaultAlpha)
 		require.NoError(t, err)
 		assert.Equal(t, v.expectedErr, err)
 		assert.Equal(t, kad.bootstrapNodes, v.bn)
@@ -93,7 +93,7 @@ func TestPeerDiscovery(t *testing.T) {
 	operator := pb.NodeOperator{
 		Wallet: "OperatorWallet",
 	}
-	k, err := newKademlia(zaptest.NewLogger(t), pb.NodeType_STORAGE, bootstrapNodes, testAddress, operator, testID, ctx.Dir("test"), defaultAlpha)
+	k, err := newKademlia(ctx, zaptest.NewLogger(t), pb.NodeType_STORAGE, bootstrapNodes, testAddress, operator, testID, ctx.Dir("test"), defaultAlpha)
 	require.NoError(t, err)
 	rt := k.routingTable
 	assert.Equal(t, rt.Local().Operator.Wallet, "OperatorWallet")
@@ -161,7 +161,7 @@ func testNode(ctx *testcontext.Context, name string, t *testing.T, bn []pb.Node)
 	// new kademlia
 
 	logger := zaptest.NewLogger(t)
-	k, err := newKademlia(logger, pb.NodeType_STORAGE, bn, lis.Addr().String(), pb.NodeOperator{}, fid, ctx.Dir(name), defaultAlpha)
+	k, err := newKademlia(ctx, logger, pb.NodeType_STORAGE, bn, lis.Addr().String(), pb.NodeOperator{}, fid, ctx.Dir(name), defaultAlpha)
 	require.NoError(t, err)
 
 	s := NewEndpoint(logger, k, k.routingTable)
@@ -200,18 +200,18 @@ func TestRefresh(t *testing.T) {
 	rt := k.routingTable
 	now := time.Now().UTC()
 	bID := firstBucketID //always exists
-	err := rt.SetBucketTimestamp(bID[:], now.Add(-2*time.Hour))
+	err := rt.SetBucketTimestamp(ctx, bID[:], now.Add(-2*time.Hour))
 	require.NoError(t, err)
 	//refresh should  call FindNode, updating the time
 	err = k.refresh(ctx, time.Minute)
 	require.NoError(t, err)
-	ts1, err := rt.GetBucketTimestamp(bID[:])
+	ts1, err := rt.GetBucketTimestamp(ctx, bID[:])
 	require.NoError(t, err)
 	assert.True(t, now.Add(-5*time.Minute).Before(ts1))
 	//refresh should not call FindNode, leaving the previous time
 	err = k.refresh(ctx, time.Minute)
 	require.NoError(t, err)
-	ts2, err := rt.GetBucketTimestamp(bID[:])
+	ts2, err := rt.GetBucketTimestamp(ctx, bID[:])
 	require.NoError(t, err)
 	assert.True(t, ts1.Equal(ts2))
 	s.GracefulStop()
@@ -243,7 +243,7 @@ func TestFindNear(t *testing.T) {
 	})
 
 	bootstrap := []pb.Node{{Id: fid2.ID, Address: &pb.NodeAddress{Address: lis.Addr().String()}}}
-	k, err := newKademlia(zaptest.NewLogger(t), pb.NodeType_STORAGE, bootstrap,
+	k, err := newKademlia(ctx, zaptest.NewLogger(t), pb.NodeType_STORAGE, bootstrap,
 		lis.Addr().String(), pb.NodeOperator{}, fid, ctx.Dir("kademlia"), defaultAlpha)
 	require.NoError(t, err)
 	defer ctx.Check(k.Close)
@@ -254,7 +254,7 @@ func TestFindNear(t *testing.T) {
 		nodeID := teststorj.NodeIDFromString(id)
 		n := &pb.Node{Id: nodeID}
 		nodes = append(nodes, n)
-		err = k.routingTable.ConnectionSuccess(n)
+		err = k.routingTable.ConnectionSuccess(ctx, n)
 		require.NoError(t, err)
 		return *n
 	}
@@ -408,7 +408,7 @@ func (mn *mockNodesServer) RequestInfo(ctx context.Context, req *pb.InfoRequest)
 }
 
 // newKademlia returns a newly configured Kademlia instance
-func newKademlia(log *zap.Logger, nodeType pb.NodeType, bootstrapNodes []pb.Node, address string, operator pb.NodeOperator, identity *identity.FullIdentity, path string, alpha int) (*Kademlia, error) {
+func newKademlia(ctx context.Context, log *zap.Logger, nodeType pb.NodeType, bootstrapNodes []pb.Node, address string, operator pb.NodeOperator, identity *identity.FullIdentity, path string, alpha int) (*Kademlia, error) {
 	self := &overlay.NodeDossier{
 		Node: pb.Node{
 			Id:      identity.ID,

--- a/pkg/kademlia/replacement_cache_test.go
+++ b/pkg/kademlia/replacement_cache_test.go
@@ -17,7 +17,7 @@ import (
 func TestAddToReplacementCache(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
-	rt := createRoutingTable(storj.NodeID{244, 255})
+	rt := createRoutingTable(ctx, storj.NodeID{244, 255})
 	defer ctx.Check(rt.Close)
 
 	kadBucketID := bucketID{255, 255}
@@ -40,7 +40,7 @@ func TestAddToReplacementCache(t *testing.T) {
 func TestRemoveFromReplacementCache(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
-	rt := createRoutingTableWith(storj.NodeID{244, 255}, routingTableOpts{cacheSize: 3})
+	rt := createRoutingTableWith(ctx, storj.NodeID{244, 255}, routingTableOpts{cacheSize: 3})
 	defer ctx.Check(rt.Close)
 
 	kadBucketID2 := bucketID{127, 255}

--- a/pkg/kademlia/routing.go
+++ b/pkg/kademlia/routing.go
@@ -68,7 +68,7 @@ type RoutingTable struct {
 }
 
 // NewRoutingTable returns a newly configured instance of a RoutingTable
-func NewRoutingTable(logger *zap.Logger, localNode *overlay.NodeDossier, kdb, ndb storage.KeyValueStore, config *RoutingTableConfig) (*RoutingTable, error) {
+func NewRoutingTable(logger *zap.Logger, localNode *overlay.NodeDossier, kdb, ndb storage.KeyValueStore, config *RoutingTableConfig) (_ *RoutingTable, err error) {
 	if config == nil || config.BucketSize == 0 || config.ReplacementCacheSize == 0 {
 		// TODO: handle this more nicely
 		config = &RoutingTableConfig{
@@ -91,7 +91,7 @@ func NewRoutingTable(logger *zap.Logger, localNode *overlay.NodeDossier, kdb, nd
 		bucketSize:   config.BucketSize,
 		rcBucketSize: config.ReplacementCacheSize,
 	}
-	ok, err := rt.addNode(&localNode.Node)
+	ok, err := rt.addNode(context.TODO(), &localNode.Node)
 	if !ok || err != nil {
 		return nil, RoutingErr.New("could not add localNode to routing table: %s", err)
 	}
@@ -131,8 +131,7 @@ func (rt *RoutingTable) CacheSize() int {
 
 // GetNodes retrieves nodes within the same kbucket as the given node id
 // Note: id doesn't need to be stored at time of search
-func (rt *RoutingTable) GetNodes(id storj.NodeID) ([]*pb.Node, bool) {
-	ctx := context.TODO()
+func (rt *RoutingTable) GetNodes(ctx context.Context, id storj.NodeID) ([]*pb.Node, bool) {
 	defer mon.Task()(&ctx)(nil)
 	bID, err := rt.getKBucketID(ctx, id)
 	if err != nil {
@@ -141,7 +140,7 @@ func (rt *RoutingTable) GetNodes(id storj.NodeID) ([]*pb.Node, bool) {
 	if bID == (bucketID{}) {
 		return nil, false
 	}
-	unmarshaledNodes, err := rt.getUnmarshaledNodesFromBucket(bID)
+	unmarshaledNodes, err := rt.getUnmarshaledNodesFromBucket(ctx, bID)
 	if err != nil {
 		return nil, false
 	}
@@ -149,8 +148,7 @@ func (rt *RoutingTable) GetNodes(id storj.NodeID) ([]*pb.Node, bool) {
 }
 
 // GetBucketIds returns a storage.Keys type of bucket ID's in the Kademlia instance
-func (rt *RoutingTable) GetBucketIds() (_ storage.Keys, err error) {
-	ctx := context.TODO()
+func (rt *RoutingTable) GetBucketIds(ctx context.Context) (_ storage.Keys, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	kbuckets, err := rt.kadBucketDB.List(ctx, nil, 0)
@@ -161,8 +159,7 @@ func (rt *RoutingTable) GetBucketIds() (_ storage.Keys, err error) {
 }
 
 // DumpNodes iterates through all nodes in the nodeBucketDB and marshals them to &pb.Nodes, then returns them
-func (rt *RoutingTable) DumpNodes() (_ []*pb.Node, err error) {
-	ctx := context.TODO()
+func (rt *RoutingTable) DumpNodes(ctx context.Context) (_ []*pb.Node, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	var nodes []*pb.Node
@@ -187,8 +184,7 @@ func (rt *RoutingTable) DumpNodes() (_ []*pb.Node, err error) {
 
 // FindNear returns the node corresponding to the provided nodeID
 // returns all Nodes (excluding self) closest via XOR to the provided nodeID up to the provided limit
-func (rt *RoutingTable) FindNear(target storj.NodeID, limit int) (_ []*pb.Node, err error) {
-	ctx := context.TODO()
+func (rt *RoutingTable) FindNear(ctx context.Context, target storj.NodeID, limit int) (_ []*pb.Node, err error) {
 	defer mon.Task()(&ctx)(&err)
 	closestNodes := make([]*pb.Node, 0, limit+1)
 	err = rt.iterateNodes(ctx, storj.NodeID{}, func(ctx context.Context, newID storj.NodeID, protoNode []byte) error {
@@ -217,8 +213,7 @@ func (rt *RoutingTable) FindNear(target storj.NodeID, limit int) (_ []*pb.Node, 
 
 // ConnectionSuccess updates or adds a node to the routing table when
 // a successful connection is made to the node on the network
-func (rt *RoutingTable) ConnectionSuccess(node *pb.Node) (err error) {
-	ctx := context.TODO()
+func (rt *RoutingTable) ConnectionSuccess(ctx context.Context, node *pb.Node) (err error) {
 	defer mon.Task()(&ctx)(&err)
 	// valid to connect to node without ID but don't store connection
 	if node.Id == (storj.NodeID{}) {
@@ -230,13 +225,13 @@ func (rt *RoutingTable) ConnectionSuccess(node *pb.Node) (err error) {
 		return RoutingErr.New("could not get node %s", err)
 	}
 	if v != nil {
-		err = rt.updateNode(node)
+		err = rt.updateNode(ctx, node)
 		if err != nil {
 			return RoutingErr.New("could not update node %s", err)
 		}
 		return nil
 	}
-	_, err = rt.addNode(node)
+	_, err = rt.addNode(ctx, node)
 	if err != nil {
 		return RoutingErr.New("could not add node %s", err)
 	}
@@ -246,10 +241,9 @@ func (rt *RoutingTable) ConnectionSuccess(node *pb.Node) (err error) {
 
 // ConnectionFailed removes a node from the routing table when
 // a connection fails for the node on the network
-func (rt *RoutingTable) ConnectionFailed(node *pb.Node) (err error) {
-	ctx := context.TODO()
+func (rt *RoutingTable) ConnectionFailed(ctx context.Context, node *pb.Node) (err error) {
 	defer mon.Task()(&ctx)(&err)
-	err = rt.removeNode(node)
+	err = rt.removeNode(ctx, node)
 	if err != nil {
 		return RoutingErr.New("could not remove node %s", err)
 	}
@@ -257,8 +251,7 @@ func (rt *RoutingTable) ConnectionFailed(node *pb.Node) (err error) {
 }
 
 // SetBucketTimestamp records the time of the last node lookup for a bucket
-func (rt *RoutingTable) SetBucketTimestamp(bIDBytes []byte, now time.Time) (err error) {
-	ctx := context.TODO()
+func (rt *RoutingTable) SetBucketTimestamp(ctx context.Context, bIDBytes []byte, now time.Time) (err error) {
 	defer mon.Task()(&ctx)(&err)
 	rt.mutex.Lock()
 	defer rt.mutex.Unlock()
@@ -270,8 +263,7 @@ func (rt *RoutingTable) SetBucketTimestamp(bIDBytes []byte, now time.Time) (err 
 }
 
 // GetBucketTimestamp retrieves time of the last node lookup for a bucket
-func (rt *RoutingTable) GetBucketTimestamp(bIDBytes []byte) (_ time.Time, err error) {
-	ctx := context.TODO()
+func (rt *RoutingTable) GetBucketTimestamp(ctx context.Context, bIDBytes []byte) (_ time.Time, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	t, err := rt.kadBucketDB.Get(ctx, bIDBytes)
@@ -307,7 +299,7 @@ func (rt *RoutingTable) iterateNodes(ctx context.Context, start storj.NodeID, f 
 
 // ConnFailure implements the Transport failure function
 func (rt *RoutingTable) ConnFailure(ctx context.Context, node *pb.Node, err error) {
-	err2 := rt.ConnectionFailed(node)
+	err2 := rt.ConnectionFailed(ctx, node)
 	if err2 != nil {
 		zap.L().Debug(fmt.Sprintf("error with ConnFailure hook  %+v : %+v", err, err2))
 	}
@@ -315,7 +307,7 @@ func (rt *RoutingTable) ConnFailure(ctx context.Context, node *pb.Node, err erro
 
 // ConnSuccess implements the Transport success function
 func (rt *RoutingTable) ConnSuccess(ctx context.Context, node *pb.Node) {
-	err := rt.ConnectionSuccess(node)
+	err := rt.ConnectionSuccess(ctx, node)
 	if err != nil {
 		zap.L().Debug("connection success error:", zap.Error(err))
 	}

--- a/pkg/kademlia/routing_test.go
+++ b/pkg/kademlia/routing_test.go
@@ -5,6 +5,7 @@ package kademlia
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -25,7 +26,7 @@ func TestLocal(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
 
-	rt := createRoutingTable(teststorj.NodeIDFromString("AA"))
+	rt := createRoutingTable(ctx, teststorj.NodeIDFromString("AA"))
 	defer ctx.Check(rt.Close)
 	assert.Equal(t, rt.Local().Id.Bytes()[:2], []byte("AA"))
 }
@@ -34,7 +35,7 @@ func TestK(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
 
-	rt := createRoutingTable(teststorj.NodeIDFromString("AA"))
+	rt := createRoutingTable(ctx, teststorj.NodeIDFromString("AA"))
 	defer ctx.Check(rt.Close)
 	k := rt.K()
 	assert.Equal(t, rt.bucketSize, k)
@@ -45,7 +46,7 @@ func TestCacheSize(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
 
-	rt := createRoutingTable(teststorj.NodeIDFromString("AA"))
+	rt := createRoutingTable(ctx, teststorj.NodeIDFromString("AA"))
 	defer ctx.Check(rt.Close)
 	expected := rt.rcBucketSize
 	result := rt.CacheSize()
@@ -56,11 +57,11 @@ func TestGetBucket(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
 
-	rt := createRoutingTable(teststorj.NodeIDFromString("AA"))
+	rt := createRoutingTable(ctx, teststorj.NodeIDFromString("AA"))
 	defer ctx.Check(rt.Close)
 	node := teststorj.MockNode("AA")
 	node2 := teststorj.MockNode("BB")
-	ok, err := rt.addNode(node2)
+	ok, err := rt.addNode(ctx, node2)
 	assert.True(t, ok)
 	assert.NoError(t, err)
 
@@ -79,7 +80,7 @@ func TestGetBucket(t *testing.T) {
 		},
 	}
 	for i, v := range cases {
-		b, e := rt.GetNodes(node2.Id)
+		b, e := rt.GetNodes(ctx, node2.Id)
 		for j, w := range v.expected {
 			if !assert.True(t, bytes.Equal(w.Id.Bytes(), b[j].Id.Bytes())) {
 				t.Logf("case %v failed expected: ", i)
@@ -97,14 +98,15 @@ func RandomNode() pb.Node {
 	return node
 }
 func TestKademliaFindNear(t *testing.T) {
+	ctx := context.Background()
 	testFunc := func(t *testing.T, testNodeCount, limit int) {
 		selfNode := RandomNode()
-		rt := createRoutingTable(selfNode.Id)
+		rt := createRoutingTable(ctx, selfNode.Id)
 
 		expectedIDs := make([]storj.NodeID, 0)
 		for x := 0; x < testNodeCount; x++ {
 			n := RandomNode()
-			ok, err := rt.addNode(&n)
+			ok, err := rt.addNode(ctx, &n)
 			require.NoError(t, err)
 			if ok { // buckets were full
 				expectedIDs = append(expectedIDs, n.Id)
@@ -118,7 +120,7 @@ func TestKademliaFindNear(t *testing.T) {
 		targetNode.Id[storj.NodeIDSize-1] ^= 1 //flip lowest bit
 		sortByXOR(expectedIDs, targetNode.Id)
 
-		results, err := rt.FindNear(targetNode.Id, limit)
+		results, err := rt.FindNear(ctx, targetNode.Id, limit)
 		require.NoError(t, err)
 		counts := []int{len(expectedIDs), limit}
 		sort.Ints(counts)
@@ -142,7 +144,7 @@ func TestConnectionSuccess(t *testing.T) {
 	defer ctx.Cleanup()
 
 	id := teststorj.NodeIDFromString("AA")
-	rt := createRoutingTable(id)
+	rt := createRoutingTable(ctx, id)
 	defer ctx.Check(rt.Close)
 	id2 := teststorj.NodeIDFromString("BB")
 	address1 := &pb.NodeAddress{Address: "a"}
@@ -169,7 +171,7 @@ func TestConnectionSuccess(t *testing.T) {
 	for _, c := range cases {
 		testCase := c
 		t.Run(testCase.testID, func(t *testing.T) {
-			err := rt.ConnectionSuccess(testCase.node)
+			err := rt.ConnectionSuccess(ctx, testCase.node)
 			assert.NoError(t, err)
 			v, err := rt.nodeBucketDB.Get(ctx, testCase.id.Bytes())
 			assert.NoError(t, err)
@@ -186,9 +188,9 @@ func TestConnectionFailed(t *testing.T) {
 
 	id := teststorj.NodeIDFromString("AA")
 	node := &pb.Node{Id: id}
-	rt := createRoutingTable(id)
+	rt := createRoutingTable(ctx, id)
 	defer ctx.Check(rt.Close)
-	err := rt.ConnectionFailed(node)
+	err := rt.ConnectionFailed(ctx, node)
 	assert.NoError(t, err)
 	v, err := rt.nodeBucketDB.Get(ctx, id.Bytes())
 	assert.Error(t, err)
@@ -200,19 +202,19 @@ func TestSetBucketTimestamp(t *testing.T) {
 	defer ctx.Cleanup()
 
 	id := teststorj.NodeIDFromString("AA")
-	rt := createRoutingTable(id)
+	rt := createRoutingTable(ctx, id)
 	defer ctx.Check(rt.Close)
 	now := time.Now().UTC()
 
 	err := rt.createOrUpdateKBucket(ctx, keyToBucketID(id.Bytes()), now)
 	assert.NoError(t, err)
-	ti, err := rt.GetBucketTimestamp(id.Bytes())
+	ti, err := rt.GetBucketTimestamp(ctx, id.Bytes())
 	assert.Equal(t, now, ti)
 	assert.NoError(t, err)
 	now = time.Now().UTC()
-	err = rt.SetBucketTimestamp(id.Bytes(), now)
+	err = rt.SetBucketTimestamp(ctx, id.Bytes(), now)
 	assert.NoError(t, err)
-	ti, err = rt.GetBucketTimestamp(id.Bytes())
+	ti, err = rt.GetBucketTimestamp(ctx, id.Bytes())
 	assert.Equal(t, now, ti)
 	assert.NoError(t, err)
 }
@@ -222,12 +224,12 @@ func TestGetBucketTimestamp(t *testing.T) {
 	defer ctx.Cleanup()
 
 	id := teststorj.NodeIDFromString("AA")
-	rt := createRoutingTable(id)
+	rt := createRoutingTable(ctx, id)
 	defer ctx.Check(rt.Close)
 	now := time.Now().UTC()
 	err := rt.createOrUpdateKBucket(ctx, keyToBucketID(id.Bytes()), now)
 	assert.NoError(t, err)
-	ti, err := rt.GetBucketTimestamp(id.Bytes())
+	ti, err := rt.GetBucketTimestamp(ctx, id.Bytes())
 	assert.Equal(t, now, ti)
 	assert.NoError(t, err)
 }

--- a/pkg/kademlia/testrouting/testrouting.go
+++ b/pkg/kademlia/testrouting/testrouting.go
@@ -9,13 +9,13 @@ import (
 	"sync"
 	"time"
 
+	monkit "gopkg.in/spacemonkeygo/monkit.v2"
+
 	"storj.io/storj/pkg/dht"
 	"storj.io/storj/pkg/overlay"
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/storage"
-
-	monkit "gopkg.in/spacemonkeygo/monkit.v2"
 )
 
 var (

--- a/pkg/kademlia/testrouting/testrouting.go
+++ b/pkg/kademlia/testrouting/testrouting.go
@@ -4,6 +4,7 @@
 package testrouting
 
 import (
+	"context"
 	"sort"
 	"sync"
 	"time"
@@ -13,6 +14,12 @@ import (
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/storage"
+
+	monkit "gopkg.in/spacemonkeygo/monkit.v2"
+)
+
+var (
+	mon = monkit.Package()
 )
 
 type nodeData struct {
@@ -63,7 +70,8 @@ func (t *Table) CacheSize() int { return t.cacheSize }
 
 // ConnectionSuccess should be called whenever a node is successfully connected
 // to. It will add or update the node's entry in the routing table.
-func (t *Table) ConnectionSuccess(node *pb.Node) error {
+func (t *Table) ConnectionSuccess(ctx context.Context, node *pb.Node) (err error) {
+	defer mon.Task()(&ctx)(&err)
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -100,7 +108,8 @@ func (t *Table) ConnectionSuccess(node *pb.Node) error {
 // ConnectionFailed should be called whenever a node can't be contacted.
 // If a node fails more than allowedFailures times, it will be removed from
 // the routing table. The failure count is reset every successful connection.
-func (t *Table) ConnectionFailed(node *pb.Node) error {
+func (t *Table) ConnectionFailed(ctx context.Context, node *pb.Node) (err error) {
+	defer mon.Task()(&ctx)(&err)
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -122,7 +131,8 @@ func (t *Table) ConnectionFailed(node *pb.Node) error {
 
 // FindNear will return up to limit nodes in the routing table ordered by
 // kademlia xor distance from the given id.
-func (t *Table) FindNear(id storj.NodeID, limit int) ([]*pb.Node, error) {
+func (t *Table) FindNear(ctx context.Context, id storj.NodeID, limit int) (_ []*pb.Node, err error) {
+	defer mon.Task()(&ctx)(&err)
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -180,17 +190,17 @@ func (t *Table) GetNodes(id storj.NodeID) (nodes []*pb.Node, ok bool) {
 }
 
 // GetBucketIds returns a storage.Keys type of bucket ID's in the Kademlia instance
-func (t *Table) GetBucketIds() (storage.Keys, error) {
+func (t *Table) GetBucketIds(context.Context) (storage.Keys, error) {
 	panic("TODO")
 }
 
 // SetBucketTimestamp records the time of the last node lookup for a bucket
-func (t *Table) SetBucketTimestamp(id []byte, now time.Time) error {
+func (t *Table) SetBucketTimestamp(context.Context, []byte, time.Time) error {
 	panic("TODO")
 }
 
 // GetBucketTimestamp retrieves time of the last node lookup for a bucket
-func (t *Table) GetBucketTimestamp(id []byte) (time.Time, error) {
+func (t *Table) GetBucketTimestamp(context.Context, []byte) (time.Time, error) {
 	panic("TODO")
 }
 

--- a/pkg/kademlia/testrouting/utils.go
+++ b/pkg/kademlia/testrouting/utils.go
@@ -3,9 +3,7 @@
 
 package testrouting
 
-import (
-	"storj.io/storj/pkg/storj"
-)
+import "storj.io/storj/pkg/storj"
 
 type nodeDataDistanceSorter struct {
 	self  storj.NodeID


### PR DESCRIPTION
This makes monkit.Task trees look properly filled out, where routing calls now have correct ancestor information due to the context passing

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
