### PR TITLE
lib/uplink: expose restrict on api keys

### DIFF
--- a/cmd/uplink/cmd/share.go
+++ b/cmd/uplink/cmd/share.go
@@ -79,11 +79,7 @@ func shareMain(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	// TODO(jeff): we have to have the server side of things expecting macaroons
-	// before we can change libuplink to use macaroons because of all the tests.
-	// For now, just use the raw macaroon library.
-
-	key, err := macaroon.ParseAPIKey(cfg.Client.APIKey)
+	key, err := libuplink.ParseAPIKey(cfg.Client.APIKey)
 	if err != nil {
 		return err
 	}

--- a/lib/uplink/apikey.go
+++ b/lib/uplink/apikey.go
@@ -3,17 +3,34 @@
 
 package uplink
 
+import (
+	"storj.io/storj/pkg/macaroon"
+)
+
 // APIKey represents an access credential to certain resources
 type APIKey struct {
-	key string
+	key *macaroon.APIKey
 }
 
 // Serialize serializes the API key to a string
 func (a APIKey) Serialize() string {
-	return a.key
+	return a.key.Serialize()
 }
 
 // ParseAPIKey parses an API key
 func ParseAPIKey(val string) (APIKey, error) {
-	return APIKey{key: val}, nil
+	k, err := macaroon.ParseAPIKey(val)
+	if err != nil {
+		return APIKey{}, err
+	}
+	return APIKey{key: k}, nil
+}
+
+// Restrict generates a new APIKey with the provided Caveat attached.
+func (a APIKey) Restrict(caveat macaroon.Caveat) (APIKey, error) {
+	k, err := a.key.Restrict(caveat)
+	if err != nil {
+		return APIKey{}, err
+	}
+	return APIKey{key: k}, nil
 }


### PR DESCRIPTION
The APIKey Restrict method should be in lib/uplink so people can find it

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
