### PR TITLE
Fix the gateway image build process

### DIFF
--- a/cmd/gateway/Dockerfile
+++ b/cmd/gateway/Dockerfile
@@ -1,16 +1,14 @@
-ARG CGO_ENABLED=1
-ARG REPOSITORY=../storj.io/storj
-ARG PACKAGE=storj.io/storj/cmd/gateway
-FROM storjlabs/golang as build-env
-
-# final stage
-FROM alpine
-ENV CONF_PATH=/root/.local/share/storj/gateway \
-    API_KEY= \
-    SATELLITE_ADDR=
+ARG DOCKER_ARCH
+FROM ${DOCKER_ARCH:-amd64}/alpine
+ARG TAG
+ARG GOARCH
+ENV GOARCH ${GOARCH}
 EXPOSE 7777
 WORKDIR /app
 VOLUME /root/.local/share/storj/gateway
-COPY --from=build-env /app /app/gateway
+COPY release/${TAG}/gateway_linux_${GOARCH:-amd64} /app/gateway
 COPY cmd/gateway/entrypoint /entrypoint
 ENTRYPOINT ["/entrypoint"]
+ENV CONF_PATH=/root/.local/share/storj/gateway \
+    API_KEY= \
+    SATELLITE_ADDR=


### PR DESCRIPTION
Stop building the binaries inside the image and instead build them outside once then just package them in a container image.