### PR TITLE
removed fields

### DIFF
--- a/pkg/overlay/benchmark_test.go
+++ b/pkg/overlay/benchmark_test.go
@@ -55,11 +55,9 @@ func BenchmarkOverlay(b *testing.B) {
 
 		b.Run("KnownUnreliableOrOffline", func(b *testing.B) {
 			criteria := &overlay.NodeCriteria{
-				AuditCount:         0,
-				AuditSuccessRatio:  0.5,
-				OnlineWindow:       1000 * time.Hour,
-				UptimeCount:        0,
-				UptimeSuccessRatio: 0.5,
+				AuditCount:   0,
+				OnlineWindow: 1000 * time.Hour,
+				UptimeCount:  0,
 			}
 			for i := 0; i < b.N; i++ {
 				badNodes, err := overlaydb.KnownUnreliableOrOffline(ctx, criteria, check)

--- a/pkg/overlay/cache.go
+++ b/pkg/overlay/cache.go
@@ -74,17 +74,15 @@ type FindStorageNodesRequest struct {
 
 // NodeCriteria are the requirements for selecting nodes
 type NodeCriteria struct {
-	FreeBandwidth      int64
-	FreeDisk           int64
-	AuditCount         int64
-	AuditSuccessRatio  float64
-	UptimeCount        int64
-	UptimeSuccessRatio float64
-	ExcludedNodes      []storj.NodeID
-	ExcludedIPs        []string
-	MinimumVersion     string // semver or empty
-	OnlineWindow       time.Duration
-	DistinctIP         bool
+	FreeBandwidth  int64
+	FreeDisk       int64
+	AuditCount     int64
+	UptimeCount    int64
+	ExcludedNodes  []storj.NodeID
+	ExcludedIPs    []string
+	MinimumVersion string // semver or empty
+	OnlineWindow   time.Duration
+	DistinctIP     bool
 }
 
 // UpdateRequest is used to update a node status.
@@ -197,14 +195,13 @@ func (cache *Cache) FindStorageNodesWithPreferences(ctx context.Context, req Fin
 	var newNodes []*pb.Node
 	if newNodeCount > 0 {
 		newNodes, err = cache.db.SelectNewStorageNodes(ctx, newNodeCount, &NodeCriteria{
-			FreeBandwidth:     req.FreeBandwidth,
-			FreeDisk:          req.FreeDisk,
-			AuditCount:        preferences.AuditCount,
-			AuditSuccessRatio: preferences.AuditSuccessRatio,
-			ExcludedNodes:     excludedNodes,
-			MinimumVersion:    preferences.MinimumVersion,
-			OnlineWindow:      preferences.OnlineWindow,
-			DistinctIP:        preferences.DistinctIP,
+			FreeBandwidth:  req.FreeBandwidth,
+			FreeDisk:       req.FreeDisk,
+			AuditCount:     preferences.AuditCount,
+			ExcludedNodes:  excludedNodes,
+			MinimumVersion: preferences.MinimumVersion,
+			OnlineWindow:   preferences.OnlineWindow,
+			DistinctIP:     preferences.DistinctIP,
 		})
 		if err != nil {
 			return nil, err
@@ -221,17 +218,15 @@ func (cache *Cache) FindStorageNodesWithPreferences(ctx context.Context, req Fin
 	}
 
 	criteria := NodeCriteria{
-		FreeBandwidth:      req.FreeBandwidth,
-		FreeDisk:           req.FreeDisk,
-		AuditCount:         preferences.AuditCount,
-		AuditSuccessRatio:  preferences.AuditSuccessRatio,
-		UptimeCount:        preferences.UptimeCount,
-		UptimeSuccessRatio: preferences.UptimeRatio,
-		ExcludedNodes:      excludedNodes,
-		ExcludedIPs:        excludedIPs,
-		MinimumVersion:     preferences.MinimumVersion,
-		OnlineWindow:       preferences.OnlineWindow,
-		DistinctIP:         preferences.DistinctIP,
+		FreeBandwidth:  req.FreeBandwidth,
+		FreeDisk:       req.FreeDisk,
+		AuditCount:     preferences.AuditCount,
+		UptimeCount:    preferences.UptimeCount,
+		ExcludedNodes:  excludedNodes,
+		ExcludedIPs:    excludedIPs,
+		MinimumVersion: preferences.MinimumVersion,
+		OnlineWindow:   preferences.OnlineWindow,
+		DistinctIP:     preferences.DistinctIP,
 	}
 	reputableNodes, err := cache.db.SelectStorageNodes(ctx, reputableNodeCount-len(newNodes), &criteria)
 	if err != nil {
@@ -252,11 +247,9 @@ func (cache *Cache) FindStorageNodesWithPreferences(ctx context.Context, req Fin
 func (cache *Cache) KnownUnreliableOrOffline(ctx context.Context, nodeIds storj.NodeIDList) (badNodes storj.NodeIDList, err error) {
 	defer mon.Task()(&ctx)(&err)
 	criteria := &NodeCriteria{
-		AuditCount:         cache.preferences.AuditCount,
-		AuditSuccessRatio:  cache.preferences.AuditSuccessRatio,
-		OnlineWindow:       cache.preferences.OnlineWindow,
-		UptimeCount:        cache.preferences.UptimeCount,
-		UptimeSuccessRatio: cache.preferences.UptimeRatio,
+		AuditCount:   cache.preferences.AuditCount,
+		OnlineWindow: cache.preferences.OnlineWindow,
+		UptimeCount:  cache.preferences.UptimeCount,
 	}
 	return cache.db.KnownUnreliableOrOffline(ctx, criteria, nodeIds)
 }
@@ -294,10 +287,8 @@ func (cache *Cache) Create(ctx context.Context, nodeID storj.NodeID, initial *No
 func (cache *Cache) IsVetted(ctx context.Context, nodeID storj.NodeID) (reputable bool, err error) {
 	defer mon.Task()(&ctx)(&err)
 	criteria := &NodeCriteria{
-		AuditCount:         cache.preferences.AuditCount,
-		AuditSuccessRatio:  cache.preferences.AuditSuccessRatio,
-		UptimeCount:        cache.preferences.UptimeCount,
-		UptimeSuccessRatio: cache.preferences.UptimeRatio,
+		AuditCount:  cache.preferences.AuditCount,
+		UptimeCount: cache.preferences.UptimeCount,
 	}
 	reputable, err = cache.db.IsVetted(ctx, nodeID, criteria)
 	if err != nil {

--- a/pkg/overlay/statdb_test.go
+++ b/pkg/overlay/statdb_test.go
@@ -119,11 +119,7 @@ func testDatabase(ctx context.Context, t *testing.T, cache overlay.DB) {
 			storj.NodeID{3}, storj.NodeID{4},
 			storj.NodeID{5}, storj.NodeID{6},
 		}
-		criteria := &overlay.NodeCriteria{
-			AuditSuccessRatio:  0.5,
-			UptimeSuccessRatio: 0.5,
-			OnlineWindow:       time.Hour,
-		}
+		criteria := &overlay.NodeCriteria{OnlineWindow: time.Hour}
 
 		invalid, err := cache.KnownUnreliableOrOffline(ctx, criteria, nodeIds)
 		require.NoError(t, err)


### PR DESCRIPTION
What: 
Remove Ratios from NodeCriteria
Simplified some inner select SQLs
Added missing Uptime criteria to one SQL statement.

Why:
NodeCriteria previously cared about AuditSuccessRatio and UptimeSuccessRatio. These need to go away away as part of the reputation refactor w/ alpha and betas.
Found some small things to clean up along the way.