### PR TITLE
fix `C.time_t` error

### DIFF
--- a/lib/uplinkc/convert.go
+++ b/lib/uplinkc/convert.go
@@ -13,7 +13,7 @@ import (
 func newBucketInfo(bucket *storj.Bucket) C.BucketInfo {
 	return C.BucketInfo{
 		name:         C.CString(bucket.Name),
-		created:      C.time_t(bucket.Created.Unix()),
+		created:      C.int64_t(bucket.Created.Unix()),
 		path_cipher:  C.uint8_t(bucket.PathCipher),
 		segment_size: C.uint64_t(bucket.SegmentsSize),
 

--- a/lib/uplinkc/uplink_definitions.h
+++ b/lib/uplinkc/uplink_definitions.h
@@ -9,8 +9,6 @@ typedef struct Uplink   { long _handle; } UplinkRef;
 typedef struct Project  { long _handle; } ProjectRef;
 typedef struct Bucket   { long _handle; } BucketRef;
 
-typedef int64_t time;
-
 typedef struct UplinkConfig {
     struct {
         struct {


### PR DESCRIPTION
What: Fix this error on osx when doing things like `go install`:
```
lib/uplinkc/convert.go:16:17: could not determine kind of name for C.time_t
```

Why:

Thanks for submitting a PR!

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Could the PR be broken into smaller PRs?
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
