### PR TITLE
internal/testplanet: add missing consoleserver.Config

### DIFF
--- a/internal/testplanet/dir.go
+++ b/internal/testplanet/dir.go
@@ -16,5 +16,5 @@ func init() {
 		return
 	}
 
-	developmentRoot = strings.TrimSuffix(filename, "/cmd/storj-sim/dir.go")
+	developmentRoot = strings.TrimSuffix(filename, "/internal/testplanet/dir.go")
 }

--- a/internal/testplanet/dir.go
+++ b/internal/testplanet/dir.go
@@ -1,0 +1,20 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information
+
+package testplanet
+
+import (
+	"runtime"
+	"strings"
+)
+
+var developmentRoot string
+
+func init() {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return
+	}
+
+	developmentRoot = strings.TrimSuffix(filename, "/cmd/storj-sim/dir.go")
+}

--- a/internal/testplanet/planet.go
+++ b/internal/testplanet/planet.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -54,6 +53,7 @@ import (
 	"storj.io/storj/satellite/vouchers"
 	"storj.io/storj/storagenode"
 	"storj.io/storj/storagenode/collector"
+	"storj.io/storj/storagenode/console/consoleserver"
 	"storj.io/storj/storagenode/monitor"
 	"storj.io/storj/storagenode/orders"
 	"storj.io/storj/storagenode/piecestore"
@@ -511,14 +511,17 @@ func (planet *Planet) newSatellites(count int) ([]*satellite.Peer, error) {
 				SMTPServerAddress: "smtp.mail.test:587",
 				From:              "Labs <storj@mail.test>",
 				AuthType:          "simulate",
+				TemplatePath:      filepath.Join(developmentRoot, "web/satellite/static/emails"),
 			},
 			Console: consoleweb.Config{
 				Address:         "127.0.0.1:0",
+				StaticDir:       filepath.Join(developmentRoot, "web/satellite"),
 				PasswordCost:    console.TestPasswordCost,
 				AuthTokenSecret: "my-suppa-secret-key",
 			},
 			Marketing: marketingweb.Config{
-				Address: "127.0.0.1:0",
+				Address:   "127.0.0.1:0",
+				StaticDir: filepath.Join(developmentRoot, "web/marketing"),
 			},
 			Vouchers: vouchers.Config{
 				Expiration: 30,
@@ -528,18 +531,6 @@ func (planet *Planet) newSatellites(count int) ([]*satellite.Peer, error) {
 		if planet.config.Reconfigure.Satellite != nil {
 			planet.config.Reconfigure.Satellite(log, i, &config)
 		}
-
-		// TODO: find source file, to set static path
-		_, filename, _, ok := runtime.Caller(0)
-		if !ok {
-			return xs, errs.New("no caller information")
-		}
-		storjRoot := strings.TrimSuffix(filename, "/internal/testplanet/planet.go")
-
-		// TODO: for development only
-		config.Marketing.StaticDir = filepath.Join(storjRoot, "web/marketing")
-		config.Console.StaticDir = filepath.Join(storjRoot, "web/satellite")
-		config.Mail.TemplatePath = filepath.Join(storjRoot, "web/satellite/static/emails")
 
 		verInfo := planet.NewVersionInfo()
 
@@ -632,6 +623,10 @@ func (planet *Planet) newStorageNodes(count int, whitelistedSatelliteIDs []strin
 			},
 			Collector: collector.Config{
 				Interval: time.Minute,
+			},
+			Console: consoleserver.Config{
+				Address:   "127.0.0.1:0",
+				StaticDir: filepath.Join(developmentRoot, "web/operator/"),
 			},
 			Storage2: piecestore.Config{
 				Sender: orders.SenderConfig{


### PR DESCRIPTION
What: testplanet was missing config for address which was trying to open public ports.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
