### PR TITLE
add functions for password/root key derivation

### DIFF
--- a/pkg/encryption/password.go
+++ b/pkg/encryption/password.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package encryption
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"runtime"
+
+	"github.com/zeebo/errs"
+	"golang.org/x/crypto/argon2"
+
+	"storj.io/storj/pkg/storj"
+)
+
+func sha256hmac(key, data []byte) ([]byte, error) {
+	h := hmac.New(sha256.New, key)
+	if _, err := h.Write(data); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}
+
+// DeriveRootKey derives a root key for some path using the salt for the bucket and
+// a password from the user. See the password key derivation design doc.
+func DeriveRootKey(password, salt []byte, path storj.Path) (*storj.Key, error) {
+	mixedSalt, err := sha256hmac(password, salt)
+	if err != nil {
+		return nil, err
+	}
+
+	pathSalt, err := sha256hmac(mixedSalt, []byte(path))
+	if err != nil {
+		return nil, err
+	}
+
+	// use a time of 1, 64MB of ram, and all of the cores.
+	keyData := argon2.IDKey(password, pathSalt, 1, 64<<10, uint8(runtime.GOMAXPROCS(-1)), 32)
+	if len(keyData) != len(storj.Key{}) {
+		return nil, errs.New("invalid output from argon2id")
+	}
+
+	var key storj.Key
+	copy(key[:], keyData)
+	return &key, nil
+}
+
+// DeriveDefaultPassword combines a salt from the project with a user password to create
+// a default password used for DeriveRootKey in the case that a single secret should be
+// used to derive all of the bucket level secrets. See the password key derivation design
+// doc.
+func DeriveDefaultPassword(password, salt []byte) ([]byte, error) {
+	mixedSalt, err := sha256hmac(password, salt)
+	if err != nil {
+		return nil, err
+	}
+
+	// use a time of 1, 64MB of ram, and all of the cores.
+	return argon2.IDKey(password, mixedSalt, 1, 64<<10, uint8(runtime.GOMAXPROCS(-1)), 32), nil
+}

--- a/pkg/encryption/password_test.go
+++ b/pkg/encryption/password_test.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package encryption
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeriveRootKey(t *testing.T) {
+	// ensure that we can derive with no errors
+	_, err := DeriveRootKey([]byte("password"), []byte("salt"), "")
+	assert.NoError(t, err)
+	_, err = DeriveRootKey([]byte("password"), []byte("salt"), "any/path")
+	assert.NoError(t, err)
+}
+
+func TestDeriveDefaultPassword(t *testing.T) {
+	// ensure that we can derive with no errors
+	_, err := DeriveDefaultPassword([]byte("password"), []byte("salt"))
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This commit adds two functions that implement the algorithms
described in the password key derivation design document. They
will be used during setup to derive bucket level root keys or
default passwords to use when buckets do not have their own
independent key.

The code is not yet used, so there is no testing or performance impact.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
