### PR TITLE
Stop pinging disqualified nodes

### DIFF
--- a/pkg/discovery/service.go
+++ b/pkg/discovery/service.go
@@ -94,8 +94,6 @@ func (discovery *Discovery) Run(ctx context.Context) (err error) {
 }
 
 // refresh updates the cache db with the current DHT.
-// We currently do not penalize nodes that are unresponsive,
-// but should in the future.
 func (discovery *Discovery) refresh(ctx context.Context) (err error) {
 	defer mon.Task()(&ctx)(&err)
 
@@ -114,6 +112,11 @@ func (discovery *Discovery) refresh(ctx context.Context) (err error) {
 	for _, node := range list {
 		if ctx.Err() != nil {
 			return ctx.Err()
+		}
+
+		if node.Disqualified != nil {
+			discovery.log.Debug("skip disqualified node", zap.Stringer("ID", node.Id))
+			continue
 		}
 
 		ping, err := discovery.kad.Ping(ctx, node.Node)


### PR DESCRIPTION
What: 

The discovery refresh service won't ping disqualified nodes.

Why:

Satellites are not interested in maintaining up-to-date info and stats for disqualified nodes. So it can save the resources for pinging them too.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
