### PR TITLE
[v3-1952 test 6] Disqualification is a one way ticket. Storage Node can't get around it.

### DIFF
--- a/pkg/audit/disqualification_test.go
+++ b/pkg/audit/disqualification_test.go
@@ -196,7 +196,7 @@ func TestDisqualifiedNodesGetNoUpload(t *testing.T) {
 	})
 }
 
-func TestDisqualifiedNodesRemainsDisqualified(t *testing.T) {
+func TestDisqualifiedNodeRemainsDisqualified(t *testing.T) {
 
 	// - mark a node as disqualified
 	// - give it high uptime and audit rate
@@ -213,7 +213,7 @@ func TestDisqualifiedNodesRemainsDisqualified(t *testing.T) {
 		disqualifiedNode := planet.StorageNodes[0]
 		disqualifyNode(t, ctx, satellite, disqualifiedNode.ID())
 
-		_, err = satellite.DB.OverlayCache().UpdateUptime(ctx, disqualifiedNode.ID(), true, 1, 1, 1)
+		_, err = satellite.DB.OverlayCache().UpdateUptime(ctx, disqualifiedNode.ID(), true, 0, 1, 0)
 		require.NoError(t, err)
 
 		assert.True(t, isDisqualified(t, ctx, satellite, disqualifiedNode.ID()))
@@ -222,12 +222,12 @@ func TestDisqualifiedNodesRemainsDisqualified(t *testing.T) {
 			NodeID:       disqualifiedNode.ID(),
 			IsUp:         true,
 			AuditSuccess: true,
-			AuditLambda:  1,
+			AuditLambda:  0, // forget about history
 			AuditWeight:  1,
-			AuditDQ:      1,
-			UptimeLambda: 1,
+			AuditDQ:      0, // make sure new reputation scores are larger than the DQ thresholds
+			UptimeLambda: 0, // forget about history
 			UptimeWeight: 1,
-			UptimeDQ:     1,
+			UptimeDQ:     0, // make sure new reputation scores are larger than the DQ thresholds
 		})
 		require.NoError(t, err)
 

--- a/web/satellite/src/components/referral/ReferralStats.vue
+++ b/web/satellite/src/components/referral/ReferralStats.vue
@@ -66,7 +66,7 @@ import { CREDIT_USAGE_ACTIONS, NOTIFICATION_ACTIONS } from '@/utils/constants/ac
         }
     },
     mounted() {
-        this.fetch();
+        (this as any).fetch();
     },
     computed: {
         title() {


### PR DESCRIPTION
What: Take the disqualified storage node and give it a high uptime and audit rate. 

Why: To check that disqualification is permanent

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
