### PR TITLE
internal/testplanet: enable TestUplinksParallel

### DIFF
--- a/internal/testplanet/uplink_test.go
+++ b/internal/testplanet/uplink_test.go
@@ -31,9 +31,7 @@ import (
 )
 
 func TestUplinksParallel(t *testing.T) {
-	t.Skip("flaky")
-
-	const uplinkCount = 3
+	const uplinkCount = 2
 	const parallelCount = 2
 
 	testplanet.Run(t, testplanet.Config{


### PR DESCRIPTION
What: Reenable TestUplinksParallel hoping it won't cause "transport is closing" flakiness again with the improved timeouts.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
