### PR TITLE
satellite/console: rename credits field to creditInCent

### DIFF
--- a/satellite/console/consoleweb/consoleql/usercredit.go
+++ b/satellite/console/consoleweb/consoleql/usercredit.go
@@ -10,10 +10,10 @@ import (
 const (
 	// CreditUsageType is a graphql type for user credit
 	CreditUsageType = "creditUsage"
-	// FieldAvailableCredit is a field name for available credit
-	FieldAvailableCredit = "availableCredit"
-	// FieldUsedCredit is a field name for used credit
-	FieldUsedCredit = "usedCredit"
+	// FieldAvailableCreditInCent is a field name for available credit
+	FieldAvailableCreditInCent = "availableCreditInCent"
+	// FieldUsedCreditInCent is a field name for used credit
+	FieldUsedCreditInCent = "usedCreditInCent"
 	// FieldReferred is a field name for total referred number
 	FieldReferred = "referred"
 )
@@ -22,10 +22,10 @@ func graphqlCreditUsage() *graphql.Object {
 	return graphql.NewObject(graphql.ObjectConfig{
 		Name: CreditUsageType,
 		Fields: graphql.Fields{
-			FieldAvailableCredit: &graphql.Field{
+			FieldAvailableCreditInCent: &graphql.Field{
 				Type: graphql.Int,
 			},
-			FieldUsedCredit: &graphql.Field{
+			FieldUsedCreditInCent: &graphql.Field{
 				Type: graphql.Int,
 			},
 			FieldReferred: &graphql.Field{

--- a/satellite/console/usercredits.go
+++ b/satellite/console/usercredits.go
@@ -31,7 +31,7 @@ type UserCredit struct {
 
 // UserCreditUsage holds information about credit usage information
 type UserCreditUsage struct {
-	Referred         int64
-	AvailableCredits int64
-	UsedCredits      int64
+	Referred              int64
+	AvailableCreditInCent int64
+	UsedCreditInCent      int64
 }

--- a/satellite/satellitedb/usercredits.go
+++ b/satellite/satellitedb/usercredits.go
@@ -36,18 +36,18 @@ func (c *usercredits) GetCreditUsage(ctx context.Context, userID uuid.UUID, expi
 	for usageRows.Next() {
 
 		var (
-			usedCredit      sql.NullInt64
-			availableCredit sql.NullInt64
-			referred        sql.NullInt64
+			usedCreditInCent      sql.NullInt64
+			availableCreditInCent sql.NullInt64
+			referred              sql.NullInt64
 		)
-		err = usageRows.Scan(&usedCredit, &availableCredit, &referred)
+		err = usageRows.Scan(&usedCreditInCent, &availableCreditInCent, &referred)
 		if err != nil {
 			return nil, errs.Wrap(err)
 		}
 
-		usage.UsedCredits += usedCredit.Int64
+		usage.UsedCreditInCent += usedCreditInCent.Int64
 		usage.Referred += referred.Int64
-		usage.AvailableCredits += availableCredit.Int64
+		usage.AvailableCreditInCent += availableCreditInCent.Int64
 	}
 
 	return &usage, nil

--- a/satellite/satellitedb/usercredits_test.go
+++ b/satellite/satellitedb/usercredits_test.go
@@ -85,9 +85,9 @@ func TestUsercredits(t *testing.T) {
 				expected: result{
 					remainingCharge: 20,
 					usage: console.UserCreditUsage{
-						AvailableCredits: 0,
-						UsedCredits:      100,
-						Referred:         0,
+						AvailableCreditInCent: 0,
+						UsedCreditInCent:      100,
+						Referred:              0,
 					},
 					hasErr: false,
 				},
@@ -105,9 +105,9 @@ func TestUsercredits(t *testing.T) {
 				expected: result{
 					remainingCharge: 60,
 					usage: console.UserCreditUsage{
-						AvailableCredits: 0,
-						UsedCredits:      100,
-						Referred:         0,
+						AvailableCreditInCent: 0,
+						UsedCreditInCent:      100,
+						Referred:              0,
 					},
 					hasErr: true,
 				},
@@ -125,9 +125,9 @@ func TestUsercredits(t *testing.T) {
 				expected: result{
 					remainingCharge: 0,
 					usage: console.UserCreditUsage{
-						AvailableCredits: 20,
-						UsedCredits:      180,
-						Referred:         0,
+						AvailableCreditInCent: 20,
+						UsedCreditInCent:      180,
+						Referred:              0,
 					},
 					hasErr: false,
 				},

--- a/web/satellite/src/api/usage.ts
+++ b/web/satellite/src/api/usage.ts
@@ -102,8 +102,8 @@ export async function fetchCreditUsage(): Promise<RequestResponse<CreditUsage>> 
         isSuccess: false,
         data: {
             referred: 0,
-            usedCredits: 0,
-            availableCredits: 0,
+            usedCreditInCent: 0,
+            availableCreditInCent: 0,
         }
     };
 
@@ -113,8 +113,8 @@ export async function fetchCreditUsage(): Promise<RequestResponse<CreditUsage>> 
                 query {
                     creditUsage {
                         referred,
-                        usedCredit,
-                        availableCredit,
+                        usedCreditInCent,
+                        availableCreditInCent,
                     }
                 }`
             ),
@@ -131,4 +131,4 @@ export async function fetchCreditUsage(): Promise<RequestResponse<CreditUsage>> 
     }
 
     return result;
-}
+};

--- a/web/satellite/src/components/referral/ReferralStats.vue
+++ b/web/satellite/src/components/referral/ReferralStats.vue
@@ -75,7 +75,12 @@ import { CREDIT_USAGE_ACTIONS, NOTIFICATION_ACTIONS } from '@/utils/constants/ac
             return name.length > 0 ? `${name}, ${text}` : text; 
         },
         usage() {
-            return this.$store.state.creditUsageModule.creditUsage;
+            let { creditUsage } = this.$store.state.creditUsageModule;
+            return {
+                referred: creditUsage.referred,
+                availableCredits: creditUsage.availableCreditInCent * 100,
+                usedCredits: creditUsage.usedCreditInCent * 100
+            };
         }
     }
 })

--- a/web/satellite/src/store/modules/usage.ts
+++ b/web/satellite/src/store/modules/usage.ts
@@ -124,11 +124,11 @@ export const bucketUsageModule = {
 
 export const creditUsageModule = {
     state: {
-        creditUsage: { referred: 0, usedCredits: 0, availableCredits: 0 } as CreditUsage
+        creditUsage: { referred: 0, usedCreditInCent: 0, availableCreditInCent: 0 } as CreditUsage
     },
     mutations: {
-        [CREDIT_USAGE_ACTIONS.FETCH](state: any, creditUsage: CreditUsage) {
-            state.creditUsage = creditUsage;
+        [CREDIT_USAGE_ACTIONS.FETCH](state: any, creditUsageInCent: CreditUsage) {
+            state.creditUsageInCent = creditUsageInCent;
         }
     },
     actions: {

--- a/web/satellite/src/types/usage.d.ts
+++ b/web/satellite/src/types/usage.d.ts
@@ -41,6 +41,6 @@ declare type BucketUsageCursor = {
 
 declare type CreditUsage = {
     referred: number,
-    usedCredits: number,
-    availableCredits: number,
+    usedCreditInCent: number,
+    availableCreditInCent: number,
 };

--- a/web/satellite/src/utils/constants/actionNames.ts
+++ b/web/satellite/src/utils/constants/actionNames.ts
@@ -82,4 +82,4 @@ export const BUCKET_USAGE_ACTIONS = {
 
 export const CREDIT_USAGE_ACTIONS = {
     FETCH: 'fetchCreditUsage',
-}
+};


### PR DESCRIPTION
What: 
Since we are using `cent` as the unit for our money field. I want to expose this through the name of fields to satellite GUI code as well

Why:
Prevent misleading usage of unit for credits

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
