### PR TITLE
Make piecestore.Dial handle the connection completely.

### DIFF
--- a/internal/testplanet/uplink.go
+++ b/internal/testplanet/uplink.go
@@ -154,16 +154,8 @@ func (uplink *Uplink) DialMetainfo(ctx context.Context, destination Peer, apikey
 // DialPiecestore dials destination storagenode and returns a piecestore client.
 func (uplink *Uplink) DialPiecestore(ctx context.Context, destination Peer) (*piecestore.Client, error) {
 	node := destination.Local()
-
-	conn, err := uplink.Transport.DialNode(ctx, &node.Node)
-	if err != nil {
-		return nil, err
-	}
-
 	signer := signing.SignerFromFullIdentity(uplink.Transport.Identity())
-
-	// TODO(leak): unclear ownership semantics
-	return piecestore.NewClient(uplink.Log.Named("uplink>piecestore"), signer, conn, piecestore.DefaultConfig), nil
+	return piecestore.Dial(ctx, uplink.Transport, &node.Node, uplink.Log.Named("uplink>piecestore"), signer, piecestore.DefaultConfig)
 }
 
 // Upload data to specific satellite

--- a/pkg/storage/ec/client.go
+++ b/pkg/storage/ec/client.go
@@ -36,7 +36,7 @@ type Client interface {
 	WithForceErrorDetection(force bool) Client
 }
 
-type psClientHelper func(context.Context, *pb.Node) (*piecestore.Client, error)
+type dialPiecestoreFunc func(context.Context, *pb.Node) (*piecestore.Client, error)
 
 type ecClient struct {
 	transport           transport.Client
@@ -57,18 +57,10 @@ func (ec *ecClient) WithForceErrorDetection(force bool) Client {
 	return ec
 }
 
-func (ec *ecClient) newPSClient(ctx context.Context, n *pb.Node) (*piecestore.Client, error) {
-	conn, err := ec.transport.DialNode(ctx, n)
-	if err != nil {
-		return nil, err
-	}
-	// TODO(leak): unclear ownership semantics
-	return piecestore.NewClient(
-		zap.L().Named(n.Id.String()),
-		signing.SignerFromFullIdentity(ec.transport.Identity()),
-		conn,
-		piecestore.DefaultConfig,
-	), nil
+func (ec *ecClient) dialPiecestore(ctx context.Context, n *pb.Node) (*piecestore.Client, error) {
+	logger := zap.L().Named(n.Id.String())
+	signer := signing.SignerFromFullIdentity(ec.transport.Identity())
+	return piecestore.Dial(ctx, ec.transport, n, logger, signer, piecestore.DefaultConfig)
 }
 
 func (ec *ecClient) Put(ctx context.Context, limits []*pb.AddressedOrderLimit, rs eestream.RedundancyStrategy, data io.Reader, expiration time.Time) (successfulNodes []*pb.Node, successfulHashes []*pb.PieceHash, err error) {
@@ -300,7 +292,7 @@ func (ec *ecClient) putPiece(ctx, parent context.Context, limit *pb.AddressedOrd
 
 	storageNodeID := limit.GetLimit().StorageNodeId
 	pieceID := limit.GetLimit().PieceId
-	ps, err := ec.newPSClient(ctx, &pb.Node{
+	ps, err := ec.dialPiecestore(ctx, &pb.Node{
 		Id:      storageNodeID,
 		Address: limit.GetStorageNodeAddress(),
 	})
@@ -368,9 +360,9 @@ func (ec *ecClient) Get(ctx context.Context, limits []*pb.AddressedOrderLimit, e
 		}
 
 		rrs[i] = &lazyPieceRanger{
-			newPSClientHelper: ec.newPSClient,
-			limit:             addressedLimit,
-			size:              pieceSize,
+			dialPiecestore: ec.dialPiecestore,
+			limit:          addressedLimit,
+			size:           pieceSize,
 		}
 	}
 
@@ -394,7 +386,7 @@ func (ec *ecClient) Delete(ctx context.Context, limits []*pb.AddressedOrderLimit
 
 		go func(addressedLimit *pb.AddressedOrderLimit) {
 			limit := addressedLimit.GetLimit()
-			ps, err := ec.newPSClient(ctx, &pb.Node{
+			ps, err := ec.dialPiecestore(ctx, &pb.Node{
 				Id:      limit.StorageNodeId,
 				Address: addressedLimit.GetStorageNodeAddress(),
 			})
@@ -463,9 +455,9 @@ func calcPadded(size int64, blockSize int) int64 {
 }
 
 type lazyPieceRanger struct {
-	newPSClientHelper psClientHelper
-	limit             *pb.AddressedOrderLimit
-	size              int64
+	dialPiecestore dialPiecestoreFunc
+	limit          *pb.AddressedOrderLimit
+	size           int64
 }
 
 // Size implements Ranger.Size
@@ -476,7 +468,7 @@ func (lr *lazyPieceRanger) Size() int64 {
 // Range implements Ranger.Range to be lazily connected
 func (lr *lazyPieceRanger) Range(ctx context.Context, offset, length int64) (_ io.ReadCloser, err error) {
 	defer mon.Task()(&ctx)(&err)
-	ps, err := lr.newPSClientHelper(ctx, &pb.Node{
+	ps, err := lr.dialPiecestore(ctx, &pb.Node{
 		Id:      lr.limit.GetLimit().StorageNodeId,
 		Address: lr.limit.GetStorageNodeAddress(),
 	})

--- a/uplink/piecestore/client.go
+++ b/uplink/piecestore/client.go
@@ -14,6 +14,7 @@ import (
 	"storj.io/storj/internal/memory"
 	"storj.io/storj/pkg/auth/signing"
 	"storj.io/storj/pkg/pb"
+	"storj.io/storj/pkg/transport"
 )
 
 // Error is the default error class for piecestore client.
@@ -41,21 +42,25 @@ var DefaultConfig = Config{
 type Client struct {
 	log    *zap.Logger
 	signer signing.Signer
-	conn   *grpc.ClientConn
 	client pb.PiecestoreClient
+	conn   *grpc.ClientConn
 	config Config
 }
 
-// NewClient creates a new piecestore client from a grpc client connection.
-func NewClient(log *zap.Logger, signer signing.Signer, conn *grpc.ClientConn, config Config) *Client {
+// Dial dials the target piecestore endpoint.
+func Dial(ctx context.Context, transport transport.Client, target *pb.Node, log *zap.Logger, signer signing.Signer, config Config) (*Client, error) {
+	conn, err := transport.DialNode(ctx, target)
+	if err != nil {
+		return nil, Error.Wrap(err)
+	}
+
 	return &Client{
 		log:    log,
 		signer: signer,
-		// TODO(leak): unclear ownership semantics
-		conn:   conn,
 		client: pb.NewPiecestoreClient(conn),
+		conn:   conn,
 		config: config,
-	}
+	}, nil
 }
 
 // Delete uses delete order limit to delete a piece on piece store.


### PR DESCRIPTION
What: Connection was passed into piecestore.NewClient, however it was internally closing the connection. The expected behavior usually is that the caller is responsible for closing things. Rename the method to `Dial` and dial the connection internally, such that the behavior is clearer.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
