### PR TITLE
Fix TestGetSignee flakiness

### DIFF
--- a/internal/errs2/ignore.go
+++ b/internal/errs2/ignore.go
@@ -11,15 +11,19 @@ import (
 	"google.golang.org/grpc"
 )
 
-// IgnoreCanceled returns nil, when the operation was about canceling.
-func IgnoreCanceled(err error) error {
-	if errs.IsFunc(err, func(err error) bool {
+// IsCanceled returns true, when the error is a cancellation.
+func IsCanceled(err error) bool {
+	return errs.IsFunc(err, func(err error) bool {
 		return err == context.Canceled ||
 			err == grpc.ErrServerStopped ||
 			err == http.ErrServerClosed
-	}) {
+	})
+}
+
+// IgnoreCanceled returns nil, when the operation was about canceling.
+func IgnoreCanceled(err error) error {
+	if IsCanceled(err) {
 		return nil
 	}
-
 	return err
 }

--- a/pkg/kademlia/kademlia.go
+++ b/pkg/kademlia/kademlia.go
@@ -288,7 +288,7 @@ func (k *Kademlia) FindNode(ctx context.Context, nodeID storj.NodeID) (_ pb.Node
 		return pb.Node{}, err
 	}
 	if len(results) < 1 {
-		return pb.Node{}, NodeNotFound.New("")
+		return pb.Node{}, NodeNotFound.Wrap(err)
 	}
 	return *results[0], nil
 }
@@ -305,6 +305,7 @@ func (k *Kademlia) lookup(ctx context.Context, nodeID storj.NodeID) (_ []*pb.Nod
 	if err != nil {
 		return nil, err
 	}
+
 	self := k.routingTable.Local().Node
 	lookup := newPeerDiscovery(k.log, k.dialer, nodeID, nodes, k.routingTable.K(), k.alpha, &self)
 	results, err := lookup.Run(ctx)

--- a/pkg/kademlia/peer_discovery.go
+++ b/pkg/kademlia/peer_discovery.go
@@ -5,7 +5,6 @@ package kademlia
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync"
 

--- a/pkg/kademlia/peer_discovery.go
+++ b/pkg/kademlia/peer_discovery.go
@@ -5,6 +5,7 @@ package kademlia
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 
@@ -110,11 +111,7 @@ func (lookup *peerDiscovery) Run(ctx context.Context) (_ []*pb.Node, err error) 
 
 	wg.Wait()
 
-	err = ctx.Err()
-	if err == context.Canceled {
-		err = nil
-	}
-	return lookup.queue.ClosestQueried(), err
+	return lookup.queue.ClosestQueried(), ctx.Err()
 }
 
 func isDone(ctx context.Context) bool {

--- a/storagenode/piecestore/verification.go
+++ b/storagenode/piecestore/verification.go
@@ -135,7 +135,7 @@ func (endpoint *Endpoint) VerifyOrderLimitSignature(ctx context.Context, limit *
 
 	signee, err := endpoint.trust.GetSignee(ctx, limit.SatelliteId)
 	if err != nil {
-		if err == context.Canceled {
+		if errs2.IsCanceled(err) {
 			return err
 		}
 		return ErrVerifyUntrusted.New("unable to get signee: %v", err) // TODO: report grpc status bad message

--- a/storagenode/piecestore/verification.go
+++ b/storagenode/piecestore/verification.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/zeebo/errs"
 
+	"storj.io/storj/internal/errs2"
 	"storj.io/storj/pkg/auth/signing"
 	"storj.io/storj/pkg/identity"
 	"storj.io/storj/pkg/pb"

--- a/storagenode/trust/service.go
+++ b/storagenode/trust/service.go
@@ -133,9 +133,6 @@ func (pool *Pool) GetSignee(ctx context.Context, id storj.NodeID) (_ signing.Sig
 	if info.identity == nil {
 		identity, err := pool.kademlia.FetchPeerIdentity(ctx, id)
 		if err != nil {
-			if err == context.Canceled {
-				return nil, err
-			}
 			return nil, Error.Wrap(err)
 		}
 		info.identity = identity

--- a/storagenode/trust/service_test.go
+++ b/storagenode/trust/service_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/zeebo/errs"
 	"golang.org/x/sync/errgroup"
 
 	"storj.io/storj/internal/errs2"

--- a/storagenode/trust/service_test.go
+++ b/storagenode/trust/service_test.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zeebo/errs"
 	"golang.org/x/sync/errgroup"
 
+	"storj.io/storj/internal/errs2"
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testplanet"
 )
@@ -37,7 +39,7 @@ func TestGetSignee(t *testing.T) {
 	var group errgroup.Group
 	group.Go(func() error {
 		_, err := trust.GetSignee(canceledContext, planet.Satellites[0].ID())
-		if err == context.Canceled {
+		if errs2.IsCanceled(err) {
 			return nil
 		}
 		// if the other goroutine races us,

--- a/storagenode/vouchers/verification.go
+++ b/storagenode/vouchers/verification.go
@@ -43,7 +43,7 @@ func (service *Service) VerifyVoucher(ctx context.Context, satellite storj.NodeI
 
 	signee, err := service.trust.GetSignee(ctx, voucher.SatelliteId)
 	if err != nil {
-		if err != context.Canceled {
+		if errs2.IsCanceled(err) {
 			return err
 		}
 		return ErrVerify.New("unable to get signee: %v", err) // TODO: report grpc status bad message

--- a/storagenode/vouchers/verification.go
+++ b/storagenode/vouchers/verification.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/zeebo/errs"
 
+	"storj.io/storj/internal/errs2"
 	"storj.io/storj/pkg/auth/signing"
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/storj"


### PR DESCRIPTION
What: `context.Canceled` was not being propagated from peer discovery to `GetSignee`.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
