### PR TITLE
cmd/uplink/cmd: don't create benchmark data on init

### DIFF
--- a/Jenkinsfile.gerrit
+++ b/Jenkinsfile.gerrit
@@ -2,7 +2,7 @@ pipeline {
     agent {
         dockerfile {
             filename 'Dockerfile.jenkins'
-            args '-u root:root --cap-add SYS_PTRACE -v "/tmp/gomod":/go/pkg/mod'
+            args '-u root:root --stop-timeout 1200 --cap-add SYS_PTRACE -v "/tmp/gomod":/go/pkg/mod'
             label 'gerrit'
         }
     }

--- a/Jenkinsfile.public
+++ b/Jenkinsfile.public
@@ -2,7 +2,7 @@ pipeline {
     agent {
         dockerfile {
             filename 'Dockerfile.jenkins'
-            args '-u root:root --cap-add SYS_PTRACE -v "/tmp/gomod":/go/pkg/mod'
+            args '-u root:root --stop-timeout 1200 --cap-add SYS_PTRACE -v "/tmp/gomod":/go/pkg/mod'
             label 'main'
         }
     }

--- a/internal/testrand/rand.go
+++ b/internal/testrand/rand.go
@@ -5,6 +5,7 @@
 package testrand
 
 import (
+	cryptorand "crypto/rand"
 	"io"
 	"math/rand"
 
@@ -28,15 +29,8 @@ func Int63n(n int64) int64 {
 
 // Read reads pseudo-random data into data.
 func Read(data []byte) {
-	const newSourceThreshold = 64
-	if len(data) < newSourceThreshold {
-		_, _ = rand.Read(data)
-		return
-	}
-
-	src := rand.NewSource(rand.Int63())
-	r := rand.New(src)
-	_, _ = r.Read(data)
+	// using cryptorand here because it plays nicer with `-race`
+	_, _ = cryptorand.Read(data)
 }
 
 // Bytes generates size amount of random data.
@@ -53,7 +47,7 @@ func BytesInt(size int) []byte {
 
 // Reader creates a new random data reader.
 func Reader() io.Reader {
-	return rand.New(rand.NewSource(rand.Int63()))
+	return cryptorand.Reader
 }
 
 // NodeID creates a random node id.

--- a/internal/testrand/rand.go
+++ b/internal/testrand/rand.go
@@ -5,7 +5,6 @@
 package testrand
 
 import (
-	cryptorand "crypto/rand"
 	"io"
 	"math/rand"
 
@@ -29,8 +28,15 @@ func Int63n(n int64) int64 {
 
 // Read reads pseudo-random data into data.
 func Read(data []byte) {
-	// using cryptorand here because it plays nicer with `-race`
-	_, _ = cryptorand.Read(data)
+	const newSourceThreshold = 64
+	if len(data) < newSourceThreshold {
+		_, _ = rand.Read(data)
+		return
+	}
+
+	src := rand.NewSource(rand.Int63())
+	r := rand.New(src)
+	_, _ = r.Read(data)
 }
 
 // Bytes generates size amount of random data.
@@ -47,7 +53,7 @@ func BytesInt(size int) []byte {
 
 // Reader creates a new random data reader.
 func Reader() io.Reader {
-	return cryptorand.Reader
+	return rand.New(rand.NewSource(rand.Int63()))
 }
 
 // NodeID creates a random node id.

--- a/pkg/kademlia/peer_discovery.go
+++ b/pkg/kademlia/peer_discovery.go
@@ -96,6 +96,11 @@ func (lookup *peerDiscovery) Run(ctx context.Context) (_ []*pb.Node, err error) 
 						)
 					}
 				} else {
+					if next.Id == lookup.target {
+						lookup.cond.L.Lock()
+						allDone = true
+						lookup.cond.L.Unlock()
+					}
 					lookup.queue.QuerySuccess(next, neighbors...)
 				}
 


### PR DESCRIPTION
What: previously during start of the test it was creating random data

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
