### PR TITLE
jenkins: Stop docker container after 18m

### DIFF
--- a/Dockerfile.jenkins
+++ b/Dockerfile.jenkins
@@ -1,5 +1,7 @@
 FROM golang:1.12
 
+# Postgres
+
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
 
@@ -14,6 +16,8 @@ RUN rm /etc/postgresql/11/main/pg_hba.conf; \
 
 RUN echo 'max_connections = 1000' >> /etc/postgresql/11/main/conf.d/connectionlimits.conf
 
+# Tooling
+
 COPY ./scripts/install-awscli.sh /tmp/install-awscli.sh
 RUN bash /tmp/install-awscli.sh
 ENV PATH "$PATH:/root/bin"
@@ -21,16 +25,20 @@ ENV PATH "$PATH:/root/bin"
 RUN curl -L https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip -o /tmp/protoc.zip
 RUN unzip /tmp/protoc.zip -d "$HOME"/protoc
 
+# Linters
+
 RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ${GOPATH}/bin v1.17.1
 RUN go get github.com/ckaznocha/protoc-gen-lint
 RUN go get github.com/nilslice/protolock/cmd/protolock
-RUN go get github.com/mfridman/tparse
 RUN go get github.com/josephspurrier/goversioninfo
+RUN go get github.com/loov/leakcheck
 
+# Output formatters
+
+RUN go get github.com/mfridman/tparse
 RUN go get github.com/axw/gocov/gocov
 RUN go get github.com/AlekSi/gocov-xml
 
-RUN go get -v -u github.com/loov/leakcheck
-
-CMD ["go", "version"]
+# Set our entrypoint to close after 18 minutes, and forcefully close at 20 minutes.
+# This is to prevent Jenkins collecting cats.
 ENTRYPOINT ["timeout", "-k20m", "18m"]

--- a/Dockerfile.jenkins
+++ b/Dockerfile.jenkins
@@ -32,4 +32,5 @@ RUN go get github.com/AlekSi/gocov-xml
 
 RUN go get -v -u github.com/loov/leakcheck
 
-RUN go version
+CMD ["go", "version"]
+ENTRYPOINT ["timeout", "-k20m", "18m"]

--- a/Jenkinsfile.gerrit
+++ b/Jenkinsfile.gerrit
@@ -2,7 +2,7 @@ pipeline {
     agent {
         dockerfile {
             filename 'Dockerfile.jenkins'
-            args '-u root:root --stop-timeout 1200 --cap-add SYS_PTRACE -v "/tmp/gomod":/go/pkg/mod'
+            args '-u root:root --cap-add SYS_PTRACE -v "/tmp/gomod":/go/pkg/mod'
             label 'gerrit'
         }
     }
@@ -21,7 +21,7 @@ pipeline {
             steps {
                 checkout scm
 
-                sh 'mkdir .build'
+                sh 'mkdir -p .build'
 
                 // make a backup of the mod file in case, for later linting
                 sh 'cp go.mod .build/go.mod.orig'

--- a/Jenkinsfile.gerrit
+++ b/Jenkinsfile.gerrit
@@ -11,10 +11,10 @@ pipeline {
     }
     stages {
         stage('Start') {
-          steps {
-            gerritReview message: 'Building'
-            sh 'python ./scripts/gerrit-cla.py'
-          }
+            steps {
+                gerritReview message: 'Building'
+                sh 'python ./scripts/gerrit-cla.py'
+            }
         }
 
         stage('Build') {

--- a/Jenkinsfile.public
+++ b/Jenkinsfile.public
@@ -2,7 +2,7 @@ pipeline {
     agent {
         dockerfile {
             filename 'Dockerfile.jenkins'
-            args '-u root:root --stop-timeout 1200 --cap-add SYS_PTRACE -v "/tmp/gomod":/go/pkg/mod'
+            args '-u root:root --cap-add SYS_PTRACE -v "/tmp/gomod":/go/pkg/mod'
             label 'main'
         }
     }
@@ -14,7 +14,7 @@ pipeline {
             steps {
                 checkout scm
 
-                sh 'mkdir .build'
+                sh 'mkdir -p .build'
 
                 // make a backup of the mod file in case, for later linting
                 sh 'cp go.mod .build/go.mod.orig'

--- a/pkg/kademlia/peer_discovery.go
+++ b/pkg/kademlia/peer_discovery.go
@@ -96,11 +96,6 @@ func (lookup *peerDiscovery) Run(ctx context.Context) (_ []*pb.Node, err error) 
 						)
 					}
 				} else {
-					if next.Id == lookup.target {
-						lookup.cond.L.Lock()
-						allDone = true
-						lookup.cond.L.Unlock()
-					}
 					lookup.queue.QuerySuccess(next, neighbors...)
 				}
 


### PR DESCRIPTION
What: Previously docker containers were left running for some reason. Add an explicit timeout to the container itself to ensure it gets shutdown.

Note the limit for Jenkins is still 10min, but if it doesn't properly cleanup after 10min, it will fallback to stopping the main process at 18min and killing at 20min.

Also removes some test code from kademlia.

Why:

Please describe the tests:
 - Test 1: manually tested the `timeout -k20m 18m` part.
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
