### PR TITLE
Add os.Env for 'defaults' flag

### DIFF
--- a/pkg/cfgstruct/bind.go
+++ b/pkg/cfgstruct/bind.go
@@ -264,6 +264,9 @@ func FindIdentityDirParam() string {
 
 // FindDefaultsParam returns '--defaults' param from os.Args (if it exists)
 func FindDefaultsParam() string {
+	if os.Getenv("STORJ_DEFAULTS") != "" {
+		return os.Getenv("STORJ_DEFAULTS")
+	}
 	return FindFlagEarly("defaults")
 }
 


### PR DESCRIPTION
What: Add support for environment variable for `--defaults` flag

Why: Now each `uplink` command needs to set `--defaults=release` for every command

Please describe the tests:
 - Test 1: none
 - Test 2: none
 
Please describe the performance impact: none

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
