### PR TITLE
Set correct default erasure share size for libuplink

### DIFF
--- a/lib/uplink/project.go
+++ b/lib/uplink/project.go
@@ -83,7 +83,7 @@ func (cfg *BucketConfig) setDefaults() {
 		cfg.Volatile.RedundancyScheme.TotalShares = 130
 	}
 	if cfg.Volatile.RedundancyScheme.ShareSize == 0 {
-		cfg.Volatile.RedundancyScheme.ShareSize = (1 * memory.KiB).Int32()
+		cfg.Volatile.RedundancyScheme.ShareSize = 256 * memory.B.Int32()
 	}
 	if cfg.EncryptionParameters.BlockSize == 0 {
 		cfg.EncryptionParameters.BlockSize = cfg.Volatile.RedundancyScheme.ShareSize * int32(cfg.Volatile.RedundancyScheme.RequiredShares)


### PR DESCRIPTION
What: Sets the default erasure share size in libuplink to 256 bytes.

Why: The value was 1 KiB, which was out of sync with default uplink settings, and the validation config on the satellites. This way bucket created with libuplink had invalid redundancy configuration and all uploads were rejected by the satellite with `provided redundancy scheme parameters not allowed`.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
