### PR TITLE
Audit tests cleanup

### DIFF
--- a/pkg/audit/reporter_test.go
+++ b/pkg/audit/reporter_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	"storj.io/storj/internal/memory"
 	"storj.io/storj/internal/testcontext"
@@ -39,8 +38,9 @@ func TestReportPendingAudits(t *testing.T) {
 		report := audit.Report{PendingAudits: []*audit.PendingAudit{&pending}}
 		overlay := planet.Satellites[0].Overlay.Service
 		containment := planet.Satellites[0].DB.Containment()
+		log := planet.Satellites[0].Log.Named("reporter")
 
-		reporter := audit.NewReporter(zap.L(), overlay, containment, 1, 3)
+		reporter := audit.NewReporter(log, overlay, containment, 1, 3)
 		failed, err := reporter.RecordAudits(ctx, &report)
 		require.NoError(t, err)
 		assert.Zero(t, failed)
@@ -67,9 +67,10 @@ func TestRecordAuditsAtLeastOnce(t *testing.T) {
 		report := audit.Report{Successes: []storj.NodeID{nodeID}}
 		overlay := planet.Satellites[0].Overlay.Service
 		containment := planet.Satellites[0].DB.Containment()
+		log := planet.Satellites[0].Log.Named("reporter")
 
 		// set maxRetries to 0
-		reporter := audit.NewReporter(zap.L(), overlay, containment, 0, 3)
+		reporter := audit.NewReporter(log, overlay, containment, 0, 3)
 
 		// expect RecordAudits to try recording at least once
 		failed, err := reporter.RecordAudits(ctx, &report)

--- a/pkg/audit/reporter_test.go
+++ b/pkg/audit/reporter_test.go
@@ -22,7 +22,8 @@ func TestReportPendingAudits(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 1, UplinkCount: 0,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		err := planet.Satellites[0].Audit.Service.Close()
+		audits := planet.Satellites[0].Audit.Service
+		err := audits.Close()
 		require.NoError(t, err)
 
 		nodeID := planet.StorageNodes[0].ID()

--- a/pkg/audit/reporter_test.go
+++ b/pkg/audit/reporter_test.go
@@ -21,8 +21,7 @@ func TestReportPendingAudits(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 1, UplinkCount: 0,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		audits := planet.Satellites[0].Audit.Service
-		err := audits.Close()
+		err := planet.Satellites[0].Audit.Service.Close()
 		require.NoError(t, err)
 
 		nodeID := planet.StorageNodes[0].ID()

--- a/pkg/audit/reverify_test.go
+++ b/pkg/audit/reverify_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestReverifySuccess(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
-		SatelliteCount: 1, StorageNodeCount: 6, UplinkCount: 1,
+		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 
 		// This is a bulky test but all it's doing is:
@@ -90,7 +90,7 @@ func TestReverifySuccess(t *testing.T) {
 
 func TestReverifyFailMissingShare(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
-		SatelliteCount: 1, StorageNodeCount: 6, UplinkCount: 1,
+		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 
 		// - uploads random data
@@ -164,7 +164,7 @@ func TestReverifyFailMissingShare(t *testing.T) {
 
 func TestReverifyFailBadData(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
-		SatelliteCount: 1, StorageNodeCount: 6, UplinkCount: 1,
+		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 
 		// - uploads random data
@@ -217,7 +217,7 @@ func TestReverifyFailBadData(t *testing.T) {
 
 func TestReverifyOffline(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
-		SatelliteCount: 1, StorageNodeCount: 6, UplinkCount: 1,
+		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 
 		// - uploads random data
@@ -273,7 +273,7 @@ func TestReverifyOffline(t *testing.T) {
 
 func TestReverifyOfflineDialTimeout(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
-		SatelliteCount: 1, StorageNodeCount: 6, UplinkCount: 1,
+		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 
 		// - uploads random data

--- a/pkg/audit/reverify_test.go
+++ b/pkg/audit/reverify_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	"storj.io/storj/internal/memory"
 	"storj.io/storj/internal/testcontext"
@@ -318,7 +317,8 @@ func TestReverifyOfflineDialTimeout(t *testing.T) {
 		// downloading from new nodes.
 		minBytesPerSecond := 100 * memory.KiB
 
-		verifier := audit.NewVerifier(zap.L(),
+		verifier := audit.NewVerifier(
+			planet.Satellites[0].Log.Named("verifier"),
 			planet.Satellites[0].Metainfo.Service,
 			slowClient,
 			planet.Satellites[0].Overlay.Service,

--- a/pkg/audit/reverify_test.go
+++ b/pkg/audit/reverify_test.go
@@ -39,7 +39,7 @@ func TestReverifySuccess(t *testing.T) {
 		require.NoError(t, err)
 
 		ul := planet.Uplinks[0]
-		testData := testrand.Bytes(memory.MiB)
+		testData := testrand.Bytes(8 * memory.KiB)
 
 		err = ul.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
 		require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestReverifyFailMissingShare(t *testing.T) {
 		require.NoError(t, err)
 
 		ul := planet.Uplinks[0]
-		testData := testrand.Bytes(memory.MiB)
+		testData := testrand.Bytes(8 * memory.KiB)
 
 		err = ul.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
 		require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestReverifyFailBadData(t *testing.T) {
 		require.NoError(t, err)
 
 		ul := planet.Uplinks[0]
-		testData := testrand.Bytes(memory.MiB)
+		testData := testrand.Bytes(8 * memory.KiB)
 
 		err = ul.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
 		require.NoError(t, err)
@@ -232,7 +232,7 @@ func TestReverifyOffline(t *testing.T) {
 		require.NoError(t, err)
 
 		ul := planet.Uplinks[0]
-		testData := testrand.Bytes(memory.MiB)
+		testData := testrand.Bytes(8 * memory.KiB)
 
 		err = ul.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
 		require.NoError(t, err)
@@ -288,7 +288,7 @@ func TestReverifyOfflineDialTimeout(t *testing.T) {
 		require.NoError(t, err)
 
 		ul := planet.Uplinks[0]
-		testData := testrand.Bytes(memory.MiB)
+		testData := testrand.Bytes(8 * memory.KiB)
 
 		err = ul.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
 		require.NoError(t, err)

--- a/pkg/audit/verifier_test.go
+++ b/pkg/audit/verifier_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zeebo/errs"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 
 	"storj.io/storj/internal/errs2"
@@ -215,7 +214,8 @@ func TestDownloadSharesDialTimeout(t *testing.T) {
 		// downloading from new nodes.
 		minBytesPerSecond := 100 * memory.KiB
 
-		verifier := audit.NewVerifier(zap.L(),
+		verifier := audit.NewVerifier(
+			planet.Satellites[0].Log.Named("verifier"),
 			planet.Satellites[0].Metainfo.Service,
 			slowClient,
 			planet.Satellites[0].Overlay.Service,
@@ -292,7 +292,8 @@ func TestDownloadSharesDownloadTimeout(t *testing.T) {
 		// downloading from new nodes.
 		minBytesPerSecond := 1 * memory.MiB
 
-		verifier := audit.NewVerifier(zap.L(),
+		verifier := audit.NewVerifier(
+			planet.Satellites[0].Log.Named("verifier"),
 			planet.Satellites[0].Metainfo.Service,
 			slowClient,
 			planet.Satellites[0].Overlay.Service,
@@ -448,7 +449,8 @@ func TestVerifierDialTimeout(t *testing.T) {
 		// downloading from new nodes.
 		minBytesPerSecond := 100 * memory.KiB
 
-		verifier := audit.NewVerifier(zap.L(),
+		verifier := audit.NewVerifier(
+			planet.Satellites[0].Log.Named("verifier"),
 			planet.Satellites[0].Metainfo.Service,
 			slowClient,
 			planet.Satellites[0].Overlay.Service,

--- a/pkg/audit/verifier_test.go
+++ b/pkg/audit/verifier_test.go
@@ -33,7 +33,8 @@ func TestDownloadSharesHappyPath(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		err := planet.Satellites[0].Audit.Service.Close()
+		audits := planet.Satellites[0].Audit.Service
+		err := audits.Close()
 		require.NoError(t, err)
 
 		uplink := planet.Uplinks[0]
@@ -47,25 +48,14 @@ func TestDownloadSharesHappyPath(t *testing.T) {
 
 		bucketID := []byte(storj.JoinPaths(projects[0].ID.String(), "testbucket"))
 
-		cursor := audit.NewCursor(planet.Satellites[0].Metainfo.Service)
-		stripe, _, err := cursor.NextStripe(ctx)
+		stripe, _, err := audits.Cursor.NextStripe(ctx)
 		require.NoError(t, err)
-
-		verifier := audit.NewVerifier(zap.L(),
-			planet.Satellites[0].Metainfo.Service,
-			planet.Satellites[0].Transport,
-			planet.Satellites[0].Overlay.Service,
-			planet.Satellites[0].DB.Containment(),
-			planet.Satellites[0].Orders.Service,
-			planet.Satellites[0].Identity,
-			128*memory.B,
-			5*time.Second)
 
 		shareSize := stripe.Segment.GetRemote().GetRedundancy().GetErasureShareSize()
 		limits, err := planet.Satellites[0].Orders.Service.CreateAuditOrderLimits(ctx, planet.Satellites[0].Identity.PeerIdentity(), bucketID, stripe.Segment, nil)
 		require.NoError(t, err)
 
-		shares, err := verifier.DownloadShares(ctx, limits, stripe.Index, shareSize)
+		shares, err := audits.Verifier.DownloadShares(ctx, limits, stripe.Index, shareSize)
 		require.NoError(t, err)
 
 		for _, share := range shares {
@@ -87,7 +77,8 @@ func TestDownloadSharesOfflineNode(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		err := planet.Satellites[0].Audit.Service.Close()
+		audits := planet.Satellites[0].Audit.Service
+		err := audits.Close()
 		require.NoError(t, err)
 
 		uplink := planet.Uplinks[0]
@@ -101,19 +92,8 @@ func TestDownloadSharesOfflineNode(t *testing.T) {
 
 		bucketID := []byte(storj.JoinPaths(projects[0].ID.String(), "testbucket"))
 
-		cursor := audit.NewCursor(planet.Satellites[0].Metainfo.Service)
-		stripe, _, err := cursor.NextStripe(ctx)
+		stripe, _, err := audits.Cursor.NextStripe(ctx)
 		require.NoError(t, err)
-
-		verifier := audit.NewVerifier(zap.L(),
-			planet.Satellites[0].Metainfo.Service,
-			planet.Satellites[0].Transport,
-			planet.Satellites[0].Overlay.Service,
-			planet.Satellites[0].DB.Containment(),
-			planet.Satellites[0].Orders.Service,
-			planet.Satellites[0].Identity,
-			128*memory.B,
-			5*time.Second)
 
 		shareSize := stripe.Segment.GetRemote().GetRedundancy().GetErasureShareSize()
 		limits, err := planet.Satellites[0].Orders.Service.CreateAuditOrderLimits(ctx, planet.Satellites[0].Identity.PeerIdentity(), bucketID, stripe.Segment, nil)
@@ -124,7 +104,7 @@ func TestDownloadSharesOfflineNode(t *testing.T) {
 		err = stopStorageNode(ctx, planet, stoppedNodeID)
 		require.NoError(t, err)
 
-		shares, err := verifier.DownloadShares(ctx, limits, stripe.Index, shareSize)
+		shares, err := audits.Verifier.DownloadShares(ctx, limits, stripe.Index, shareSize)
 		require.NoError(t, err)
 
 		for _, share := range shares {
@@ -149,7 +129,8 @@ func TestDownloadSharesMissingPiece(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		err := planet.Satellites[0].Audit.Service.Close()
+		audits := planet.Satellites[0].Audit.Service
+		err := audits.Close()
 		require.NoError(t, err)
 
 		uplink := planet.Uplinks[0]
@@ -163,29 +144,18 @@ func TestDownloadSharesMissingPiece(t *testing.T) {
 
 		bucketID := []byte(storj.JoinPaths(projects[0].ID.String(), "testbucket"))
 
-		cursor := audit.NewCursor(planet.Satellites[0].Metainfo.Service)
-		stripe, _, err := cursor.NextStripe(ctx)
+		stripe, _, err := audits.Cursor.NextStripe(ctx)
 		require.NoError(t, err)
 
 		// replace the piece id of the selected stripe with a new random one
 		// to simulate missing piece on the storage nodes
 		stripe.Segment.GetRemote().RootPieceId = storj.NewPieceID()
 
-		verifier := audit.NewVerifier(zap.L(),
-			planet.Satellites[0].Metainfo.Service,
-			planet.Satellites[0].Transport,
-			planet.Satellites[0].Overlay.Service,
-			planet.Satellites[0].DB.Containment(),
-			planet.Satellites[0].Orders.Service,
-			planet.Satellites[0].Identity,
-			128*memory.B,
-			5*time.Second)
-
 		shareSize := stripe.Segment.GetRemote().GetRedundancy().GetErasureShareSize()
 		limits, err := planet.Satellites[0].Orders.Service.CreateAuditOrderLimits(ctx, planet.Satellites[0].Identity.PeerIdentity(), bucketID, stripe.Segment, nil)
 		require.NoError(t, err)
 
-		shares, err := verifier.DownloadShares(ctx, limits, stripe.Index, shareSize)
+		shares, err := audits.Verifier.DownloadShares(ctx, limits, stripe.Index, shareSize)
 		require.NoError(t, err)
 
 		for _, share := range shares {
@@ -207,7 +177,8 @@ func TestDownloadSharesDialTimeout(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		err := planet.Satellites[0].Audit.Service.Close()
+		audits := planet.Satellites[0].Audit.Service
+		err := audits.Close()
 		require.NoError(t, err)
 
 		upl := planet.Uplinks[0]
@@ -221,8 +192,7 @@ func TestDownloadSharesDialTimeout(t *testing.T) {
 
 		bucketID := []byte(storj.JoinPaths(projects[0].ID.String(), "testbucket"))
 
-		cursor := audit.NewCursor(planet.Satellites[0].Metainfo.Service)
-		stripe, _, err := cursor.NextStripe(ctx)
+		stripe, _, err := audits.Cursor.NextStripe(ctx)
 		require.NoError(t, err)
 
 		network := &transport.SimulatedNetwork{
@@ -281,7 +251,8 @@ func TestDownloadSharesDownloadTimeout(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		err := planet.Satellites[0].Audit.Service.Close()
+		audits := planet.Satellites[0].Audit.Service
+		err := audits.Close()
 		require.NoError(t, err)
 
 		upl := planet.Uplinks[0]
@@ -302,8 +273,7 @@ func TestDownloadSharesDownloadTimeout(t *testing.T) {
 
 		bucketID := []byte(storj.JoinPaths(projects[0].ID.String(), "testbucket"))
 
-		cursor := audit.NewCursor(planet.Satellites[0].Metainfo.Service)
-		stripe, _, err := cursor.NextStripe(ctx)
+		stripe, _, err := audits.Cursor.NextStripe(ctx)
 		require.NoError(t, err)
 
 		// set stripe index to 0 to ensure we are auditing large enough stripe
@@ -350,7 +320,8 @@ func TestVerifierHappyPath(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		err := planet.Satellites[0].Audit.Service.Close()
+		audits := planet.Satellites[0].Audit.Service
+		err := audits.Close()
 		require.NoError(t, err)
 
 		ul := planet.Uplinks[0]
@@ -359,21 +330,10 @@ func TestVerifierHappyPath(t *testing.T) {
 		err = ul.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
 		require.NoError(t, err)
 
-		cursor := audit.NewCursor(planet.Satellites[0].Metainfo.Service)
-		stripe, _, err := cursor.NextStripe(ctx)
+		stripe, _, err := audits.Cursor.NextStripe(ctx)
 		require.NoError(t, err)
 
-		verifier := audit.NewVerifier(zap.L(),
-			planet.Satellites[0].Metainfo.Service,
-			planet.Satellites[0].Transport,
-			planet.Satellites[0].Overlay.Service,
-			planet.Satellites[0].DB.Containment(),
-			planet.Satellites[0].Orders.Service,
-			planet.Satellites[0].Identity,
-			128*memory.B,
-			5*time.Second)
-
-		report, err := verifier.Verify(ctx, stripe, nil)
+		report, err := audits.Verifier.Verify(ctx, stripe, nil)
 		require.NoError(t, err)
 
 		assert.Len(t, report.Successes, len(stripe.Segment.GetRemote().GetRemotePieces()))
@@ -388,7 +348,9 @@ func TestVerifierOfflineNode(t *testing.T) {
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 		planet.Satellites[0].Discovery.Service.Discovery.Pause()
-		err := planet.Satellites[0].Audit.Service.Close()
+
+		audits := planet.Satellites[0].Audit.Service
+		err := audits.Close()
 		require.NoError(t, err)
 
 		ul := planet.Uplinks[0]
@@ -397,26 +359,15 @@ func TestVerifierOfflineNode(t *testing.T) {
 		err = ul.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
 		require.NoError(t, err)
 
-		cursor := audit.NewCursor(planet.Satellites[0].Metainfo.Service)
-		stripe, _, err := cursor.NextStripe(ctx)
+		stripe, _, err := audits.Cursor.NextStripe(ctx)
 		require.NoError(t, err)
-
-		verifier := audit.NewVerifier(zap.L(),
-			planet.Satellites[0].Metainfo.Service,
-			planet.Satellites[0].Transport,
-			planet.Satellites[0].Overlay.Service,
-			planet.Satellites[0].DB.Containment(),
-			planet.Satellites[0].Orders.Service,
-			planet.Satellites[0].Identity,
-			128*memory.B,
-			5*time.Second)
 
 		// stop the first node in the pointer
 		stoppedNodeID := stripe.Segment.GetRemote().GetRemotePieces()[0].NodeId
 		err = stopStorageNode(ctx, planet, stoppedNodeID)
 		require.NoError(t, err)
 
-		report, err := verifier.Verify(ctx, stripe, nil)
+		report, err := audits.Verifier.Verify(ctx, stripe, nil)
 		require.NoError(t, err)
 
 		assert.Len(t, report.Successes, len(stripe.Segment.GetRemote().GetRemotePieces())-1)
@@ -430,7 +381,8 @@ func TestVerifierMissingPiece(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		err := planet.Satellites[0].Audit.Service.Close()
+		audits := planet.Satellites[0].Audit.Service
+		err := audits.Close()
 		require.NoError(t, err)
 
 		ul := planet.Uplinks[0]
@@ -439,19 +391,8 @@ func TestVerifierMissingPiece(t *testing.T) {
 		err = ul.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
 		require.NoError(t, err)
 
-		cursor := audit.NewCursor(planet.Satellites[0].Metainfo.Service)
-		stripe, _, err := cursor.NextStripe(ctx)
+		stripe, _, err := audits.Cursor.NextStripe(ctx)
 		require.NoError(t, err)
-
-		verifier := audit.NewVerifier(zap.L(),
-			planet.Satellites[0].Metainfo.Service,
-			planet.Satellites[0].Transport,
-			planet.Satellites[0].Overlay.Service,
-			planet.Satellites[0].DB.Containment(),
-			planet.Satellites[0].Orders.Service,
-			planet.Satellites[0].Identity,
-			128*memory.B,
-			5*time.Second)
 
 		// delete the piece from the first node
 		nodeID := stripe.Segment.GetRemote().GetRemotePieces()[0].NodeId
@@ -460,7 +401,7 @@ func TestVerifierMissingPiece(t *testing.T) {
 		err = node.Storage2.Store.Delete(ctx, planet.Satellites[0].ID(), pieceID)
 		require.NoError(t, err)
 
-		report, err := verifier.Verify(ctx, stripe, nil)
+		report, err := audits.Verifier.Verify(ctx, stripe, nil)
 		require.NoError(t, err)
 
 		assert.Len(t, report.Successes, len(stripe.Segment.GetRemote().GetRemotePieces())-1)
@@ -474,7 +415,8 @@ func TestVerifierDialTimeout(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		err := planet.Satellites[0].Audit.Service.Close()
+		audits := planet.Satellites[0].Audit.Service
+		err := audits.Close()
 		require.NoError(t, err)
 
 		ul := planet.Uplinks[0]
@@ -483,8 +425,7 @@ func TestVerifierDialTimeout(t *testing.T) {
 		err = ul.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
 		require.NoError(t, err)
 
-		cursor := audit.NewCursor(planet.Satellites[0].Metainfo.Service)
-		stripe, _, err := cursor.NextStripe(ctx)
+		stripe, _, err := audits.Cursor.NextStripe(ctx)
 		require.NoError(t, err)
 
 		network := &transport.SimulatedNetwork{
@@ -531,7 +472,8 @@ func TestVerifierDeletedSegment(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		err := planet.Satellites[0].Audit.Service.Close()
+		audits := planet.Satellites[0].Audit.Service
+		err := audits.Close()
 		require.NoError(t, err)
 
 		ul := planet.Uplinks[0]
@@ -540,25 +482,14 @@ func TestVerifierDeletedSegment(t *testing.T) {
 		err = ul.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
 		require.NoError(t, err)
 
-		cursor := audit.NewCursor(planet.Satellites[0].Metainfo.Service)
-		stripe, _, err := cursor.NextStripe(ctx)
+		stripe, _, err := audits.Cursor.NextStripe(ctx)
 		require.NoError(t, err)
-
-		verifier := audit.NewVerifier(zap.L(),
-			planet.Satellites[0].Metainfo.Service,
-			planet.Satellites[0].Transport,
-			planet.Satellites[0].Overlay.Service,
-			planet.Satellites[0].DB.Containment(),
-			planet.Satellites[0].Orders.Service,
-			planet.Satellites[0].Identity,
-			128*memory.B,
-			5*time.Second)
 
 		// delete the file
 		err = ul.Delete(ctx, planet.Satellites[0], "testbucket", "test/path")
 		require.NoError(t, err)
 
-		report, err := verifier.Verify(ctx, stripe, nil)
+		report, err := audits.Verifier.Verify(ctx, stripe, nil)
 		require.True(t, audit.ErrSegmentDeleted.Has(err))
 		assert.Empty(t, report)
 	})
@@ -568,7 +499,8 @@ func TestVerifierModifiedSegment(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		err := planet.Satellites[0].Audit.Service.Close()
+		audits := planet.Satellites[0].Audit.Service
+		err := audits.Close()
 		require.NoError(t, err)
 
 		ul := planet.Uplinks[0]
@@ -577,25 +509,14 @@ func TestVerifierModifiedSegment(t *testing.T) {
 		err = ul.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
 		require.NoError(t, err)
 
-		cursor := audit.NewCursor(planet.Satellites[0].Metainfo.Service)
-		stripe, _, err := cursor.NextStripe(ctx)
+		stripe, _, err := audits.Cursor.NextStripe(ctx)
 		require.NoError(t, err)
-
-		verifier := audit.NewVerifier(zap.L(),
-			planet.Satellites[0].Metainfo.Service,
-			planet.Satellites[0].Transport,
-			planet.Satellites[0].Overlay.Service,
-			planet.Satellites[0].DB.Containment(),
-			planet.Satellites[0].Orders.Service,
-			planet.Satellites[0].Identity,
-			128*memory.B,
-			5*time.Second)
 
 		// replace the file
 		err = ul.Upload(ctx, planet.Satellites[0], "testbucket", "test/path", testData)
 		require.NoError(t, err)
 
-		report, err := verifier.Verify(ctx, stripe, nil)
+		report, err := audits.Verifier.Verify(ctx, stripe, nil)
 		require.True(t, audit.ErrSegmentDeleted.Has(err))
 		assert.Empty(t, report)
 	})


### PR DESCRIPTION
What: A few things are cleaned up in audit tests:

- Existing Cursor and Verifier are reused from the satellite instead of always creating new ones. New Verifier is created only if necessary to pass a custom config in the constructor.
- Some test code used `zap.L()` instead of testplanet's logger.
- Some tests used 6 storage nodes where only 4 would be enough
- Some tests upload 1 MiB of test data where only 8 KiB would be enough


Why: Housekeeping, faster test execution and easier maintenance

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
