### PR TITLE
pkg/storage/segments: Abort repaired test unmet requirements

### DIFF
--- a/pkg/storage/segments/repairer_test.go
+++ b/pkg/storage/segments/repairer_test.go
@@ -64,11 +64,11 @@ func TestSegmentStoreRepair(t *testing.T) {
 		numStorageNodes := len(planet.StorageNodes)
 		redundancy := pointer.GetRemote().GetRedundancy()
 		remotePieces := pointer.GetRemote().GetRemotePieces()
-		minReq := redundancy.GetMinReq()
 		numPieces := len(remotePieces)
+		minReq := redundancy.GetMinReq()
 		toKill := numPieces - (int(minReq) + 1)
 		// we should have enough storage nodes to repair on
-		assert.True(t, (numStorageNodes-toKill) >= numPieces)
+		require.True(t, (numStorageNodes-toKill) >= numPieces)
 
 		// kill nodes and track lost pieces
 		var lostPieces []int32
@@ -96,10 +96,10 @@ func TestSegmentStoreRepair(t *testing.T) {
 		oc := satellite.Overlay.Service
 		ec := ecclient.NewClient(satellite.Transport, 0)
 		repairer := segments.NewSegmentRepairer(metainfo, os, oc, ec, satellite.Identity, time.Minute)
-		assert.NotNil(t, repairer)
+		require.NotNil(t, repairer)
 
 		err = repairer.Repair(ctx, path)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// kill one of the nodes kept alive to ensure repair worked
 		for _, node := range planet.StorageNodes {
@@ -114,12 +114,12 @@ func TestSegmentStoreRepair(t *testing.T) {
 
 		// we should be able to download data without any of the original nodes
 		newData, err := ul.Download(ctx, satellite, "testbucket", "test/path")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, newData, testData)
 
 		// updated pointer should not contain any of the killed nodes
 		pointer, err = metainfo.Get(ctx, path)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		remotePieces = pointer.GetRemote().GetRemotePieces()
 		for _, piece := range remotePieces {


### PR DESCRIPTION
What: 
Abort the repairer test when asserting results which are required later
on by the test for being able to continue.

Why:
Asserting the results for results which are required later on by the test can provoke test panics whose shows uglier and less understandable test failure messages. Also a failed test will ends earlier.

Please describe the tests: N/A
Please describe the performance impact: In case that the test fails, it will finish earlier, so there could be some gain on the total amount of time that the test run takes in such specific case.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
