### PR TITLE
Set MinDownloadTimeout to 5s in testplanet

### DIFF
--- a/internal/testplanet/satellite.go
+++ b/internal/testplanet/satellite.go
@@ -158,9 +158,10 @@ func (planet *Planet) newSatellites(count int) ([]*satellite.Peer, error) {
 				MaxBufferMem: 4 * memory.MiB,
 			},
 			Audit: audit.Config{
-				MaxRetriesStatDB:  0,
-				Interval:          30 * time.Second,
-				MinBytesPerSecond: 1 * memory.KB,
+				MaxRetriesStatDB:   0,
+				Interval:           30 * time.Second,
+				MinBytesPerSecond:  1 * memory.KB,
+				MinDownloadTimeout: 5 * time.Second,
 			},
 			Tally: tally.Config{
 				Interval: 30 * time.Second,


### PR DESCRIPTION
What: Set `MinDownloadTime` audit config to 5s in testplanet.

Why: It was `0` until now, so the calculated timeout applied, which was too low (few ms) and some test may fail due to this.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
