### PR TITLE
adding expiration date check on satellite's CreateSegment

### DIFF
--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -135,9 +135,8 @@ func (endpoint *Endpoint) CreateSegmentOld(ctx context.Context, req *pb.SegmentW
 			return nil, status.Errorf(codes.InvalidArgument, err.Error())
 		}
 
-		err = validateExpiration(ctx, exp)
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, err.Error())
+		if !exp.After(time.Now()) {
+			return nil, errs.New("Invalid expiration time")
 		}
 	}
 
@@ -623,25 +622,6 @@ func bytesToUUID(data []byte) (uuid.UUID, error) {
 	}
 
 	return id, nil
-}
-
-// validateExpiration checks the validity of the expiration timer
-func validateExpiration(ctx context.Context, expiration time.Time) (err error) {
-	defer mon.Task()(&ctx)(&err)
-
-	if expiration.IsZero() {
-		return nil
-	}
-
-	now := time.Now()
-	diff := now.Sub(expiration)
-
-	// +ve value indicates past time than current
-	// -ve value indicates future time than current
-	if diff.Seconds() < 0 {
-		return nil
-	}
-	return errs.New("Invalid expiration time")
 }
 
 // ProjectInfo returns allowed ProjectInfo for the provided API key

--- a/satellite/metainfo/metainfo_test.go
+++ b/satellite/metainfo/metainfo_test.go
@@ -469,6 +469,10 @@ func TestExpirationTimeSegment(t *testing.T) {
 			expirationDate time.Time
 			errFlag        bool
 		}{
+			{ // expiration time not set
+				time.Time{},
+				false,
+			},
 			{ // 10 days into future
 				time.Now().AddDate(0, 0, 10),
 				false,

--- a/satellite/metainfo/metainfo_test.go
+++ b/satellite/metainfo/metainfo_test.go
@@ -454,6 +454,45 @@ func TestCreateSegment(t *testing.T) {
 	})
 }
 
+func TestExpirationTimeSegment(t *testing.T) {
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1, StorageNodeCount: 6, UplinkCount: 1,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		apiKey := planet.Uplinks[0].APIKey[planet.Satellites[0].ID()]
+
+		metainfo, err := planet.Uplinks[0].DialMetainfo(ctx, planet.Satellites[0], apiKey)
+		require.NoError(t, err)
+		defer ctx.Check(metainfo.Close)
+		pointer := createTestPointer(t)
+
+		for _, r := range []struct {
+			expirationDate time.Time
+			errFlag        bool
+		}{
+			{ // 10 days into future
+				time.Now().AddDate(0, 0, 10),
+				false,
+			},
+			{ // current time
+				time.Now(),
+				true,
+			},
+			{ // 10 days into past
+				time.Now().AddDate(0, 0, -10),
+				true,
+			},
+		} {
+
+			_, _, err := metainfo.CreateSegment(ctx, "my-bucket-name", "file/path", -1, pointer.Remote.Redundancy, memory.MiB.Int64(), r.expirationDate)
+			if err != nil {
+				assert.True(t, r.errFlag)
+			} else {
+				assert.False(t, r.errFlag)
+			}
+		}
+	})
+}
+
 func TestDoubleCommitSegment(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 6, UplinkCount: 1,


### PR DESCRIPTION
What:
Bug fix
https://storjlabs.atlassian.net/browse/V3-2001

Why:
Root cause:
The expiration time when set, was checked at the user’s uplink or libuplink end. If the user changes the code to accept it, the satellite should also check the validity of the time before segments are created. Per the problem stated and upon looking at the satellite’s metainfo createsegment() I see satellite accepts ANY expiration date. The root cause is the satellite should filter invalid expiration times before it goes any further. Changing just the error is not the root cause.
Please describe the tests:

Test 1:
TestExpirationTimeSegment()
Test 2:
Please describe the performance impact:
## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
