### PR TITLE
storagenode: use minimum time in the order for expiration

### DIFF
--- a/internal/testplanet/storagenode.go
+++ b/internal/testplanet/storagenode.go
@@ -115,7 +115,7 @@ func (planet *Planet) newStorageNodes(count int, whitelistedSatellites storj.Nod
 			Storage2: piecestore.Config{
 				ExpirationGracePeriod: 0,
 				MaxConcurrentRequests: 100,
-				OrderLimitGracePeriod: time.Hour * 24,
+				OrderLimitGracePeriod: time.Hour,
 				Sender: orders.SenderConfig{
 					Interval: time.Hour,
 					Timeout:  time.Hour,

--- a/storagenode/collector/service_test.go
+++ b/storagenode/collector/service_test.go
@@ -49,7 +49,7 @@ func TestCollector(t *testing.T) {
 		collections := 0
 		serialsPresent := 0
 
-		// imagine we are 16 days in the future
+		// imagine we are 30 minutes in the future
 		for _, storageNode := range planet.StorageNodes {
 			pieceinfos := storageNode.DB.PieceInfo()
 			usedSerials := storageNode.DB.UsedSerials()
@@ -63,13 +63,8 @@ func TestCollector(t *testing.T) {
 			}
 
 			// collect all the data
-			err = storageNode.Collector.Collect(ctx, time.Now().Add(16*24*time.Hour))
+			err = storageNode.Collector.Collect(ctx, time.Now().Add(30*time.Minute))
 			require.NoError(t, err)
-
-			// verify that we deleted everything
-			used, err = pieceinfos.SpaceUsed(ctx)
-			require.NoError(t, err)
-			require.Equal(t, int64(0), used)
 
 			// ensure we haven't deleted used serials
 			err = usedSerials.IterateAll(ctx, func(_ storj.NodeID, _ storj.SerialNumber, _ time.Time) {
@@ -85,12 +80,12 @@ func TestCollector(t *testing.T) {
 
 		serialsPresent = 0
 
-		// imagine we are 48 days in the future
+		// imagine we are 2 hours in the future
 		for _, storageNode := range planet.StorageNodes {
 			usedSerials := storageNode.DB.UsedSerials()
 
 			// collect all the data
-			err = storageNode.Collector.Collect(ctx, time.Now().Add(48*24*time.Hour))
+			err = storageNode.Collector.Collect(ctx, time.Now().Add(2*time.Hour))
 			require.NoError(t, err)
 
 			// ensure we have deleted used serials
@@ -103,5 +98,30 @@ func TestCollector(t *testing.T) {
 		}
 
 		require.Equal(t, 0, serialsPresent)
+
+		serialsPresent = 0
+
+		// imagine we are 10 days in the future
+		for _, storageNode := range planet.StorageNodes {
+			pieceinfos := storageNode.DB.PieceInfo()
+			usedSerials := storageNode.DB.UsedSerials()
+
+			// collect all the data
+			err = storageNode.Collector.Collect(ctx, time.Now().Add(10*24*time.Hour))
+			require.NoError(t, err)
+
+			// verify that we deleted everything
+			used, err := pieceinfos.SpaceUsed(ctx)
+			require.NoError(t, err)
+			require.Equal(t, int64(0), used)
+
+			// ensure we have deleted used serials
+			err = usedSerials.IterateAll(ctx, func(id storj.NodeID, serial storj.SerialNumber, expiration time.Time) {
+				serialsPresent++
+			})
+			require.NoError(t, err)
+
+			collections++
+		}
 	})
 }


### PR DESCRIPTION
What: Use the smaller of the two expiration times in the piecestore for the order limits 

Why: So that the database is much smaller.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact: Should help with database load.

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
