### PR TITLE
storagenodedb: use datetime functions in sqlite queries

### DIFF
--- a/storagenode/collector/service_test.go
+++ b/storagenode/collector/service_test.go
@@ -99,8 +99,6 @@ func TestCollector(t *testing.T) {
 
 		require.Equal(t, 0, serialsPresent)
 
-		serialsPresent = 0
-
 		// imagine we are 10 days in the future
 		for _, storageNode := range planet.StorageNodes {
 			pieceinfos := storageNode.DB.PieceInfo()
@@ -123,5 +121,7 @@ func TestCollector(t *testing.T) {
 
 			collections++
 		}
+
+		require.Equal(t, 0, serialsPresent)
 	})
 }

--- a/storagenode/pieces/db_test.go
+++ b/storagenode/pieces/db_test.go
@@ -86,13 +86,17 @@ func TestPieceInfo(t *testing.T) {
 			})
 		require.NoError(t, err)
 
+		// use different timezones
+		location := time.FixedZone("XYZ", int((8 * time.Hour).Seconds()))
+		now2 := now.In(location)
+
 		info2 := &pieces.Info{
 			SatelliteID: satellite2.ID,
 
 			PieceID:         pieceid0,
 			PieceSize:       123,
-			PieceCreation:   now,
-			PieceExpiration: now,
+			PieceCreation:   now2,
+			PieceExpiration: now2,
 
 			UplinkPieceHash: piecehash2,
 		}

--- a/storagenode/piecestore/serials_test.go
+++ b/storagenode/piecestore/serials_test.go
@@ -49,11 +49,13 @@ func TestUsedSerials(t *testing.T) {
 			Expiration   time.Time
 		}
 
+		// use different timezones
+		location := time.FixedZone("XYZ", int((8 * time.Hour).Seconds()))
 		serialNumbers := []Serial{
 			{node0.ID, serial1, now.Add(time.Minute)},
 			{node0.ID, serial2, now.Add(4 * time.Minute)},
-			{node0.ID, serial3, now.Add(8 * time.Minute)},
-			{node1.ID, serial1, now.Add(time.Minute)},
+			{node0.ID, serial3, now.In(location).Add(8 * time.Minute)},
+			{node1.ID, serial1, now.In(location).Add(time.Minute)},
 			{node1.ID, serial2, now.Add(4 * time.Minute)},
 			{node1.ID, serial3, now.Add(8 * time.Minute)},
 		}

--- a/storagenode/piecestore/serials_test.go
+++ b/storagenode/piecestore/serials_test.go
@@ -51,6 +51,7 @@ func TestUsedSerials(t *testing.T) {
 
 		// use different timezones
 		location := time.FixedZone("XYZ", int((8 * time.Hour).Seconds()))
+
 		serialNumbers := []Serial{
 			{node0.ID, serial1, now.Add(time.Minute)},
 			{node0.ID, serial2, now.Add(4 * time.Minute)},

--- a/storagenode/storagenodedb/bandwidthdb.go
+++ b/storagenode/storagenodedb/bandwidthdb.go
@@ -88,7 +88,7 @@ func (db *bandwidthdb) Summary(ctx context.Context, from, to time.Time) (_ *band
 	rows, err := db.db.Query(`
 		SELECT action, sum(amount)
 		FROM bandwidth_usage
-		WHERE ? <= created_at AND created_at <= ?
+		WHERE datetime(?) <= datetime(created_at) AND datetime(created_at) <= datetime(?)
 		GROUP BY action`, from, to)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -120,7 +120,7 @@ func (db *bandwidthdb) SummaryBySatellite(ctx context.Context, from, to time.Tim
 	rows, err := db.db.Query(`
 		SELECT satellite_id, action, sum(amount)
 		FROM bandwidth_usage
-		WHERE ? <= created_at AND created_at <= ?
+		WHERE datetime(?) <= datetime(created_at) AND datetime(created_at) <= datetime(?)
 		GROUP BY satellite_id, action`, from, to)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/storagenode/storagenodedb/pieceinfo.go
+++ b/storagenode/storagenodedb/pieceinfo.go
@@ -134,7 +134,7 @@ func (db *pieceinfo) GetExpired(ctx context.Context, expiredAt time.Time, limit 
 	rows, err := db.db.QueryContext(ctx, db.Rebind(`
 		SELECT satellite_id, piece_id, piece_size
 		FROM pieceinfo
-		WHERE piece_expiration < ? AND ((deletion_failed_at IS NULL) OR deletion_failed_at <> ?)
+		WHERE datetime(piece_expiration) < datetime(?) AND ((deletion_failed_at IS NULL) OR datetime(deletion_failed_at) <> datetime(?))
 		ORDER BY satellite_id
 		LIMIT ?
 	`), expiredAt, expiredAt, limit)

--- a/storagenode/storagenodedb/usedserials.go
+++ b/storagenode/storagenodedb/usedserials.go
@@ -39,7 +39,7 @@ func (db *usedSerials) Add(ctx context.Context, satelliteID storj.NodeID, serial
 func (db *usedSerials) DeleteExpired(ctx context.Context, now time.Time) (err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	_, err = db.db.Exec(`DELETE FROM used_serial WHERE expiration < ?`, now)
+	_, err = db.db.Exec(`DELETE FROM used_serial WHERE datetime(expiration) < datetime(?)`, now)
 	return ErrInfo.Wrap(err)
 }
 


### PR DESCRIPTION
this way comparison happens on the actual time rather than the
string representation of the time which may change depending on
the time zone.

What: Wraps timestamp columns with `datetime()` in queries 

Why: So that sqlite does the right comparison

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact: Minimal?

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
