### PR TITLE
mobile: add a way to get an encryption access at some path root

### DIFF
--- a/mobile/apikey.go
+++ b/mobile/apikey.go
@@ -63,7 +63,7 @@ func (a *APIKey) IsZero() bool {
 func ParseAPIKey(val string) (*APIKey, error) {
 	k, err := libuplink.ParseAPIKey(val)
 	if err != nil {
-		return &APIKey{}, safeError(err)
+		return nil, safeError(err)
 	}
 	return &APIKey{lib: &k}, nil
 }
@@ -97,7 +97,7 @@ func (a APIKey) Restrict(caveat *Caveat) (*APIKey, error) {
 
 	k, err := a.lib.Restrict(libCaveat)
 	if err != nil {
-		return &APIKey{}, safeError(err)
+		return nil, safeError(err)
 	}
 	return &APIKey{lib: &k}, nil
 }

--- a/mobile/apikey.go
+++ b/mobile/apikey.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package mobile
+
+import (
+	"time"
+
+	libuplink "storj.io/storj/lib/uplink"
+	"storj.io/storj/pkg/macaroon"
+)
+
+// Caveat TODO
+type Caveat struct {
+	DisallowReads   bool
+	DisallowWrites  bool
+	DisallowLists   bool
+	DisallowDeletes bool
+	AllowedPaths    []*CaveatPath
+	// if set, the validity time window
+	NotAfter  int64
+	NotBefore int64
+	// nonce is set to some random bytes so that you can make arbitrarily
+	// many restricted macaroons with the same (or no) restrictions.
+	Nonce []byte
+}
+
+// CaveatPath If any entries exist, require all access to happen in at least
+// one of them.
+type CaveatPath struct {
+	Bucket              []byte
+	EncryptedPathPrefix []byte
+}
+
+// NewCaveat TODO
+func NewCaveat() *Caveat {
+	return &Caveat{
+		AllowedPaths: make([]*CaveatPath, 0),
+	}
+}
+
+// AddCaveatPath TODO
+func (caveat Caveat) AddCaveatPath(path *CaveatPath) {
+	caveat.AllowedPaths = append(caveat.AllowedPaths, path)
+}
+
+// APIKey represents an access credential to certain resources
+type APIKey struct {
+	lib *libuplink.APIKey
+}
+
+// Serialize serializes the API key to a string
+func (a APIKey) Serialize() string {
+	return a.lib.Serialize()
+}
+
+// IsZero returns if the api key is an uninitialized value
+func (a *APIKey) IsZero() bool {
+	return a.IsZero()
+}
+
+// ParseAPIKey parses an API key
+func ParseAPIKey(val string) (*APIKey, error) {
+	k, err := libuplink.ParseAPIKey(val)
+	if err != nil {
+		return &APIKey{}, err
+	}
+	return &APIKey{lib: &k}, nil
+}
+
+// Restrict generates a new APIKey with the provided Caveat attached.
+func (a APIKey) Restrict(caveat *Caveat) (*APIKey, error) {
+	paths := make([]*macaroon.Caveat_Path, 0)
+	for _, path := range caveat.AllowedPaths {
+		paths = append(paths, &macaroon.Caveat_Path{
+			Bucket:              path.Bucket,
+			EncryptedPathPrefix: path.EncryptedPathPrefix,
+		})
+	}
+	libCaveat := macaroon.Caveat{
+		DisallowReads:   caveat.DisallowReads,
+		DisallowWrites:  caveat.DisallowWrites,
+		DisallowLists:   caveat.DisallowLists,
+		DisallowDeletes: caveat.DisallowDeletes,
+		AllowedPaths:    paths,
+		Nonce:           caveat.Nonce,
+	}
+
+	if caveat.NotAfter != 0 {
+		notAfter := time.Unix(caveat.NotAfter, 0)
+		libCaveat.NotAfter = &notAfter
+	}
+	if caveat.NotBefore != 0 {
+		notBefore := time.Unix(caveat.NotBefore, 0)
+		libCaveat.NotBefore = &notBefore
+	}
+
+	k, err := a.lib.Restrict(libCaveat)
+	if err != nil {
+		return &APIKey{}, err
+	}
+	return &APIKey{lib: &k}, nil
+}

--- a/mobile/apikey.go
+++ b/mobile/apikey.go
@@ -63,7 +63,7 @@ func (a *APIKey) IsZero() bool {
 func ParseAPIKey(val string) (*APIKey, error) {
 	k, err := libuplink.ParseAPIKey(val)
 	if err != nil {
-		return &APIKey{}, err
+		return &APIKey{}, safeError(err)
 	}
 	return &APIKey{lib: &k}, nil
 }
@@ -97,7 +97,7 @@ func (a APIKey) Restrict(caveat *Caveat) (*APIKey, error) {
 
 	k, err := a.lib.Restrict(libCaveat)
 	if err != nil {
-		return &APIKey{}, err
+		return &APIKey{}, safeError(err)
 	}
 	return &APIKey{lib: &k}, nil
 }

--- a/mobile/encryption.go
+++ b/mobile/encryption.go
@@ -5,6 +5,7 @@ package mobile
 
 import (
 	libuplink "storj.io/storj/lib/uplink"
+	"storj.io/storj/pkg/paths"
 	"storj.io/storj/pkg/storj"
 )
 
@@ -16,6 +17,20 @@ type EncryptionAccess struct {
 // NewEncryptionAccess constructs an empty encryption context.
 func NewEncryptionAccess() *EncryptionAccess {
 	return &EncryptionAccess{lib: libuplink.NewEncryptionAccess()}
+}
+
+// NewEncryptionAccessWithRoot constructs an encryption access with a key rooted at the provided path inside of a bucket.
+func NewEncryptionAccessWithRoot(bucket, unencryptedPath, encryptedPath string, keyData []byte) (*EncryptionAccess, error) {
+	key, err := storj.NewKey(keyData)
+	if err != nil {
+		return nil, safeError(err)
+	}
+	encAccess := libuplink.NewEncryptionAccess()
+	err = encAccess.Store().Add(bucket, paths.NewUnencrypted(unencryptedPath), paths.NewEncrypted(encryptedPath), *key)
+	if err != nil {
+		return nil, safeError(err)
+	}
+	return &EncryptionAccess{lib: encAccess}, nil
 }
 
 // SetDefaultKey sets the default key to use when no matching keys are found


### PR DESCRIPTION
this exposes a way to have keys deeper than the bucket root

What: Adds a new EncryptionAccess constructor that takes paths

Why: To allow keys to exist deeper than at the bucket level

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
