### PR TITLE
ensure uplink is sending correct size with PieceHash

### DIFF
--- a/storagenode/piecestore/endpoint.go
+++ b/storagenode/piecestore/endpoint.go
@@ -282,6 +282,10 @@ func (endpoint *Endpoint) Upload(stream pb.Piecestore_UploadServer) (err error) 
 			if err := endpoint.VerifyPieceHash(ctx, limit, message.Done, expectedHash); err != nil {
 				return err // TODO: report grpc status internal server error
 			}
+			if message.Done.PieceSize != pieceWriter.Size() {
+				return ErrProtocol.New("Size of finished piece does not match size declared by uplink! %d != %d",
+					message.Done.GetPieceSize(), pieceWriter.Size())
+			}
 
 			if err := pieceWriter.Commit(ctx); err != nil {
 				return ErrInternal.Wrap(err) // TODO: report grpc status internal server error

--- a/uplink/piecestore/upload.go
+++ b/uplink/piecestore/upload.go
@@ -181,8 +181,10 @@ func (client *Upload) Commit(ctx context.Context) (_ *pb.PieceHash, err error) {
 
 	// sign the hash for storage node
 	uplinkHash, err := signing.SignUplinkPieceHash(ctx, client.privateKey, &pb.PieceHash{
-		PieceId: client.limit.PieceId,
-		Hash:    client.hash.Sum(nil),
+		PieceId:   client.limit.PieceId,
+		PieceSize: client.offset,
+		Hash:      client.hash.Sum(nil),
+		Timestamp: client.limit.OrderCreation,
 	})
 	if err != nil {
 		// failed to sign, let's close the sending side, no need to wait for a response


### PR DESCRIPTION
What: 

ensure uplink is sending correct size with PieceHash

Why:

If we verify that the size matches reality, we can then expect to use the actual piece _file_ size to store the piece size as given in the signed `PieceHash` from the uplink. Otherwise, the uplink might send a garbage size value, leaving the storagenode with no good way to verify the uplink signature on the PieceHash at a later date, unless we explicitly track what the uplink *sent* as the piece size, which seems like just a waste of bytes and a potential source of confusion when we have multiple sources of truth.

This was motivated by ongoing work to move pieceinfo data into piece files and out of the sqlite database.

Also fix the code in `uplink/piecestore/` so that it sends a valid size, because it was being rude and sending `0`.

Please describe the tests:

 Existing tests cover this behavior ok (I know because after I added the extra check in storagenode code, many tests started failing until I also fixed the uplink code)
 
Please describe the performance impact:

  insignificant

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
