### PR TITLE
satellite/gc: Fix data race with last piece counts map

### DIFF
--- a/satellite/gc/piecetracker.go
+++ b/satellite/gc/piecetracker.go
@@ -40,7 +40,9 @@ type PieceTracker struct {
 	initialPieces      int64
 	falsePositiveRate  float64
 	retainInfos        map[storj.NodeID]*RetainInfo
-	pieceCounts        map[storj.NodeID]int
+
+	// This map MUST ONLY BE USED as readonly
+	pieceCounts map[storj.NodeID]int
 }
 
 // Add adds a pieceID to the relevant node's RetainInfo


### PR DESCRIPTION
What: Fix a data race in the current garbage collector open PR (look at the branch where this PR should be merged which is **NOT MASTER**)
Why: Because otherwise we may have a data race in production

Please describe the tests: Unfortunately none. I wrote a test which showed the data race however once it was fixed the test was sometimes crashing because it was finished before an internal goroutine used by the implementation ended, causing a panic error. We decided not to spend much time in trying to have a test which could detect the data race but it was not flaky at the same time.
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
