### PR TITLE
satellite/gc: Fix data race accessing Service.lastSendTime

### DIFF
--- a/satellite/gc/gc_test.go
+++ b/satellite/gc/gc_test.go
@@ -126,16 +126,18 @@ func TestService_NewPieceTracker_and_Send(t *testing.T) {
 	wg.Add(2)
 
 	go func() {
-		service.NewPieceTracker()
+		_ = service.NewPieceTracker()
 		wg.Done()
 	}()
 
+	var err error
 	go func() {
-		service.Send(context.Background(), &gc.PieceTracker{}, func() {})
+		err = service.Send(context.Background(), &gc.PieceTracker{}, func() {})
 		wg.Done()
 	}()
 
 	wg.Wait()
+	require.NoError(t, err)
 }
 
 func getPointer(ctx *testcontext.Context, t *testing.T, satellite *satellite.Peer, upl *testplanet.Uplink, bucket, path string) (lastSegPath string, pointer *pb.Pointer) {


### PR DESCRIPTION
What: Fix the data race with accessing to the `Service.lastSendTime` for the branch `green/gc-queue` (__NOTE__ this branch is not intended to be merged to __MASTER__ it's going to be merged into branch under an open PR)

Why: Because we may avoid to get those errors in production when the service runs concurrently.

Please describe the tests: Add a test case which showed up the data race when calling the `Service.Send` and `Service.NewPieceTracker` concurrently.
 
Please describe the performance impact: Probably slower than without controlling the access, but there is no choice without having a full refactoring and even with that, it isn't clear if it won't need such lock and it will perform better.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
