### PR TITLE
enable utccheck in all tests by default

### DIFF
--- a/storagenode/storagenodedb/utcdb.go
+++ b/storagenode/storagenodedb/utcdb.go
@@ -6,13 +6,21 @@ package storagenodedb
 import (
 	"context"
 	"database/sql"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/zeebo/errs"
 )
 
-// utcChecks controls if the time zone checks are enabled.
-var utcChecks = false
+// utcChecks controls if the time zone checks are enabled. They are by default
+// enabled only during tests.
+var utcChecks = len(os.Args) > 0 && strings.HasSuffix(os.Args[0], ".test")
+
+// EnableUTCChecks turns on tracking for timestamps being passed to the database being in
+// the UTC location. They cannot be turned off once turned on, and should be turned on
+// before any database calls are made.
+func EnableUTCChecks() { utcChecks = true }
 
 // utcDB wraps a sql.DB and checks all of the arguments to queries to ensure they are in UTC.
 type utcDB struct {

--- a/storagenode/storagenodedb/utcdb_test.go
+++ b/storagenode/storagenodedb/utcdb_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func init() { utcChecks = true }
-
 func TestUTCDB(t *testing.T) {
 	notUTC := time.FixedZone("not utc", -1)
 	db := utcDB{sql.OpenDB(emptyConnector{})}


### PR DESCRIPTION
What: see pr title

Why: so that we have better coverage of passing utc timestamps

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
