### PR TITLE
storagenode/trust: implement fetching peer identity without kademlia and endpoint

### DIFF
--- a/internal/testplanet/storagenode.go
+++ b/internal/testplanet/storagenode.go
@@ -101,8 +101,6 @@ func (planet *Planet) newStorageNodes(count int, whitelistedSatellites storj.Nod
 				AllocatedDiskSpace:     1 * memory.GB,
 				AllocatedBandwidth:     memory.TB,
 				KBucketRefreshInterval: time.Hour,
-
-				SatelliteIDRestriction: true,
 				WhitelistedSatellites:  whitelistedSatellites,
 			},
 			Collector: collector.Config{

--- a/pkg/transport/fetchidentity.go
+++ b/pkg/transport/fetchidentity.go
@@ -23,7 +23,7 @@ type handshakeCapture struct {
 }
 
 // ClientHandshake does the authentication handshake specified by the corresponding
-// authentication protocol on rawConn for clients. It returns the authenticated
+// authentication protocol on conn for clients. It returns the authenticated
 // connection and the corresponding auth information about the connection.
 func (capture *handshakeCapture) ClientHandshake(ctx context.Context, s string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	conn, auth, err := capture.TransportCredentials.ClientHandshake(ctx, s, conn)

--- a/pkg/transport/fetchidentity.go
+++ b/pkg/transport/fetchidentity.go
@@ -18,7 +18,6 @@ import (
 )
 
 // handshakeCapture implements a credentials.TransportCredentials for capturing handshake information.
-// TODO: check whether this would be problematic with concurrency or should we thread the authinfo through context?
 type handshakeCapture struct {
 	credentials.TransportCredentials
 

--- a/pkg/transport/fetchidentity.go
+++ b/pkg/transport/fetchidentity.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package transport
+
+import (
+	"context"
+	"net"
+
+	"github.com/zeebo/errs"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	"storj.io/storj/pkg/identity"
+	"storj.io/storj/pkg/pb"
+	"storj.io/storj/pkg/peertls"
+)
+
+// TODO: check whether this would be problematic with concurrency or should we thread the authinfo through context?
+type handshakeCapture struct {
+	credentials.TransportCredentials
+	AuthInfo credentials.AuthInfo
+}
+
+// ClientHandshake does the authentication handshake specified by the corresponding
+// authentication protocol on rawConn for clients. It returns the authenticated
+// connection and the corresponding auth information about the connection.
+func (capture *handshakeCapture) ClientHandshake(ctx context.Context, s string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	conn, auth, err := capture.TransportCredentials.ClientHandshake(ctx, s, conn)
+	capture.AuthInfo = auth
+	return conn, auth, err
+}
+
+// ServerHandshake does the authentication handshake for servers. It returns
+// the authenticated connection and the corresponding auth information about
+// the connection.
+func (capture *handshakeCapture) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	conn, auth, err := capture.TransportCredentials.ServerHandshake(conn)
+	capture.AuthInfo = auth
+	return conn, auth, err
+}
+
+// FetchPeerIdentity dials the node and fetches the identity
+func (transport *Transport) FetchPeerIdentity(ctx context.Context, node *pb.Node, opts ...grpc.DialOption) (_ *identity.PeerIdentity, err error) {
+	defer mon.Task()(&ctx, "node: "+node.Id.String()[0:8])(&err)
+
+	if node.Address == nil || node.Address.Address == "" {
+		return nil, Error.New("no address")
+	}
+	tlsConfig := transport.tlsOpts.ClientTLSConfig(node.Id)
+
+	capture := &handshakeCapture{
+		TransportCredentials: credentials.NewTLS(tlsConfig),
+	}
+
+	options := append([]grpc.DialOption{
+		grpc.WithTransportCredentials(capture),
+		grpc.WithBlock(),
+		grpc.FailOnNonTempDialError(true),
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+			if err != nil {
+				return nil, err
+			}
+			return &timeoutConn{conn: conn, timeout: transport.timeouts.Request}, nil
+		}),
+	}, opts...)
+
+	timedCtx, cancel := context.WithTimeout(ctx, transport.timeouts.Dial)
+	defer cancel()
+
+	conn, err := grpc.DialContext(timedCtx, node.GetAddress().Address, options...)
+	if err != nil {
+		if err == context.Canceled {
+			return nil, err
+		}
+		transport.AlertFail(timedCtx, node, err)
+		return nil, Error.Wrap(err)
+	}
+	defer func() {
+		err = errs.Combine(err, conn.Close())
+	}()
+	transport.AlertSuccess(timedCtx, node)
+
+	switch info := capture.AuthInfo.(type) {
+	case credentials.TLSInfo:
+		chain := info.State.PeerCertificates
+		if len(chain)-1 < peertls.CAIndex {
+			return nil, Error.New("invalid certificate chain")
+		}
+
+		pi, err := identity.PeerIdentityFromChain(chain)
+		if err != nil {
+			return nil, err
+		}
+
+		return pi, nil
+	default:
+		return nil, Error.New("unknown capture info %T", capture.AuthInfo)
+	}
+}

--- a/pkg/transport/fetchidentity.go
+++ b/pkg/transport/fetchidentity.go
@@ -16,6 +16,7 @@ import (
 	"storj.io/storj/pkg/peertls"
 )
 
+// handshakeCapture implements a credentials.TransportCredentials for capturing handshake information.
 // TODO: check whether this would be problematic with concurrency or should we thread the authinfo through context?
 type handshakeCapture struct {
 	credentials.TransportCredentials

--- a/pkg/transport/slowtransport.go
+++ b/pkg/transport/slowtransport.go
@@ -47,6 +47,12 @@ func (client *slowTransport) DialAddress(ctx context.Context, address string, op
 	return client.client.DialAddress(ctx, address, append(client.network.DialOptions(), opts...)...)
 }
 
+// FetchPeerIdentity dials the node and fetches the identity.
+func (client *slowTransport) FetchPeerIdentity(ctx context.Context, node *pb.Node, opts ...grpc.DialOption) (_ *identity.PeerIdentity, err error) {
+	defer mon.Task()(&ctx)(&err)
+	return client.client.FetchPeerIdentity(ctx, node, append(client.network.DialOptions(), opts...)...)
+}
+
 // Identity for slowTransport
 func (client *slowTransport) Identity() *identity.FullIdentity {
 	return client.client.Identity()

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -26,6 +26,7 @@ type Observer interface {
 type Client interface {
 	DialNode(ctx context.Context, node *pb.Node, opts ...grpc.DialOption) (*grpc.ClientConn, error)
 	DialAddress(ctx context.Context, address string, opts ...grpc.DialOption) (*grpc.ClientConn, error)
+	FetchPeerIdentity(ctx context.Context, node *pb.Node, opts ...grpc.DialOption) (*identity.PeerIdentity, error)
 	Identity() *identity.FullIdentity
 	WithObservers(obs ...Observer) Client
 	AlertSuccess(ctx context.Context, node *pb.Node)

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -216,8 +216,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config, ver
 	}
 
 	{ // setup storage
-		trustAllSatellites := !config.Storage.SatelliteIDRestriction
-		peer.Storage2.Trust, err = trust.NewPool(peer.Kademlia.Service, trustAllSatellites, config.Storage.WhitelistedSatellites)
+		peer.Storage2.Trust, err = trust.NewPool(peer.Transport, config.Storage.WhitelistedSatellites)
 		if err != nil {
 			return nil, errs.Combine(err, peer.Close())
 		}

--- a/storagenode/piecestore/endpoint.go
+++ b/storagenode/piecestore/endpoint.go
@@ -48,7 +48,6 @@ var _ pb.PiecestoreServer = (*Endpoint)(nil)
 type OldConfig struct {
 	Path                   string         `help:"path to store data in" default:"$CONFDIR/storage"`
 	WhitelistedSatellites  storj.NodeURLs `help:"a comma-separated list of approved satellite node urls" devDefault:"" releaseDefault:"12EayRS2V1kEsWESU9QMRseFhdxYxKicsiFmxrsLZHeLUtdps3S@mars.tardigrade.io:7777,118UWpMCHzs6CvSgWd9BfFVjw5K9pZbJjkfZJexMtSkmKxvvAW@satellite.stefan-benten.de:7777,121RTSDpyNZVcEU84Ticf2L1ntiuUimbWgfATz21tuvgk3vzoA6@saturn.tardigrade.io:7777,12L9ZFwhzVpuEKMUNUqkaTLGzwY9G24tbiigLiXpmZWKwmcNDDs@jupiter.tardigrade.io:7777"`
-	SatelliteIDRestriction bool           `help:"if true, only allow data from approved satellites" devDefault:"false" releaseDefault:"true"`
 	AllocatedDiskSpace     memory.Size    `user:"true" help:"total allocated disk space in bytes" default:"1TB"`
 	AllocatedBandwidth     memory.Size    `user:"true" help:"total allocated bandwidth in bytes" default:"2TB"`
 	KBucketRefreshInterval time.Duration  `help:"how frequently Kademlia bucket should be refreshed with node stats" default:"1h0m0s"`

--- a/storagenode/piecestore/endpoint_test.go
+++ b/storagenode/piecestore/endpoint_test.go
@@ -528,7 +528,7 @@ func TestRetain(t *testing.T) {
 			storj.NodeURL{ID: satellite1.ID},
 		}
 
-		trusted, err := trust.NewPool(nil, false, whitelisted)
+		trusted, err := trust.NewPool(nil, whitelisted)
 		require.NoError(t, err)
 
 		uplink := testidentity.MustPregeneratedSignedIdentity(3, storj.LatestIDVersion())

--- a/storagenode/trust/service.go
+++ b/storagenode/trust/service.go
@@ -37,7 +37,7 @@ type satelliteInfoCache struct {
 	identity *identity.PeerIdentity
 }
 
-// NewPool creates a new trust pool using kademlia to find certificates and with the specified list of trusted satellites.
+// NewPool creates a new trust pool of the specified list of trusted satellites.
 func NewPool(transport transport.Client, trustedSatellites storj.NodeURLs) (*Pool, error) {
 	// TODO: preload all satellite peer identities
 

--- a/storagenode/trust/service.go
+++ b/storagenode/trust/service.go
@@ -5,7 +5,6 @@ package trust
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/zeebo/errs"
@@ -20,6 +19,7 @@ import (
 
 // Error is the default error class
 var Error = errs.Class("trust:")
+
 var mon = monkit.Package()
 
 // Pool implements different peer verifications.
@@ -63,7 +63,7 @@ func (pool *Pool) VerifySatelliteID(ctx context.Context, id storj.NodeID) (err e
 
 	_, ok := pool.trustedSatellites[id]
 	if !ok {
-		return fmt.Errorf("satellite %q is untrusted", id)
+		return Error.New("satellite %q is untrusted", id)
 	}
 	return nil
 }
@@ -79,7 +79,7 @@ func (pool *Pool) GetSignee(ctx context.Context, id storj.NodeID) (_ signing.Sig
 	pool.mu.RUnlock()
 
 	if !ok {
-		return nil, fmt.Errorf("signee %q is untrusted", id)
+		return nil, Error.New("signee %q is untrusted", id)
 	}
 
 	info.mu.Lock()

--- a/storagenode/trust/service.go
+++ b/storagenode/trust/service.go
@@ -13,8 +13,9 @@ import (
 
 	"storj.io/storj/pkg/auth/signing"
 	"storj.io/storj/pkg/identity"
-	"storj.io/storj/pkg/kademlia"
+	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/storj"
+	"storj.io/storj/pkg/transport"
 )
 
 // Error is the default error class
@@ -23,55 +24,39 @@ var mon = monkit.Package()
 
 // Pool implements different peer verifications.
 type Pool struct {
-	kademlia *kademlia.Kademlia
+	mu        sync.RWMutex
+	transport transport.Client
 
-	mu sync.RWMutex
-
-	trustAllSatellites bool
-	trustedSatellites  map[storj.NodeID]*satelliteInfoCache
+	trustedSatellites map[storj.NodeID]*satelliteInfoCache
 }
 
 // satelliteInfoCache caches identity information about a satellite
 type satelliteInfoCache struct {
 	mu       sync.Mutex
+	url      storj.NodeURL
 	identity *identity.PeerIdentity
-	nodeURL  storj.NodeURL
 }
 
 // NewPool creates a new trust pool using kademlia to find certificates and with the specified list of trusted satellites.
-func NewPool(kademlia *kademlia.Kademlia, trustAll bool, trustedSatellites storj.NodeURLs) (*Pool, error) {
-	if trustAll {
-		return &Pool{
-			kademlia: kademlia,
-
-			trustAllSatellites: true,
-			trustedSatellites:  map[storj.NodeID]*satelliteInfoCache{},
-		}, nil
-	}
-
+func NewPool(transport transport.Client, trustedSatellites storj.NodeURLs) (*Pool, error) {
 	// TODO: preload all satellite peer identities
 
 	// parse the comma separated list of approved satellite IDs into an array of storj.NodeIDs
 	trusted := make(map[storj.NodeID]*satelliteInfoCache)
 
 	for _, node := range trustedSatellites {
-		trusted[node.ID] = &satelliteInfoCache{nodeURL: node}
+		trusted[node.ID] = &satelliteInfoCache{url: node}
 	}
 
 	return &Pool{
-		kademlia: kademlia,
-
-		trustAllSatellites: false,
-		trustedSatellites:  trusted,
+		transport:         transport,
+		trustedSatellites: trusted,
 	}, nil
 }
 
 // VerifySatelliteID checks whether id corresponds to a trusted satellite.
 func (pool *Pool) VerifySatelliteID(ctx context.Context, id storj.NodeID) (err error) {
 	defer mon.Task()(&ctx)(&err)
-	if pool.trustAllSatellites {
-		return nil
-	}
 
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
@@ -93,29 +78,15 @@ func (pool *Pool) GetSignee(ctx context.Context, id storj.NodeID) (_ signing.Sig
 	info, ok := pool.trustedSatellites[id]
 	pool.mu.RUnlock()
 
-	if pool.trustAllSatellites {
-		// add a new entry
-		if !ok {
-			pool.mu.Lock()
-			// did another goroutine manage to make it first?
-			info, ok = pool.trustedSatellites[id]
-			if !ok {
-				info = &satelliteInfoCache{}
-				pool.trustedSatellites[id] = info
-			}
-			pool.mu.Unlock()
-		}
-	} else {
-		if !ok {
-			return nil, fmt.Errorf("signee %q is untrusted", id)
-		}
+	if !ok {
+		return nil, fmt.Errorf("signee %q is untrusted", id)
 	}
 
 	info.mu.Lock()
 	defer info.mu.Unlock()
 
 	if info.identity == nil {
-		identity, err := pool.kademlia.FetchPeerIdentity(ctx, id)
+		identity, err := pool.FetchPeerIdentity(ctx, info.url)
 		if err != nil {
 			return nil, Error.Wrap(err)
 		}
@@ -123,6 +94,18 @@ func (pool *Pool) GetSignee(ctx context.Context, id storj.NodeID) (_ signing.Sig
 	}
 
 	return signing.SigneeFromPeerIdentity(info.identity), nil
+}
+
+// FetchPeerIdentity dials the url and fetches the identity.
+func (pool *Pool) FetchPeerIdentity(ctx context.Context, url storj.NodeURL) (_ *identity.PeerIdentity, err error) {
+	identity, err := pool.transport.FetchPeerIdentity(ctx, &pb.Node{
+		Id: url.ID,
+		Address: &pb.NodeAddress{
+			Transport: pb.NodeTransport_TCP_TLS_GRPC,
+			Address:   url.Address,
+		},
+	})
+	return identity, Error.Wrap(err)
 }
 
 // GetSatellites returns a slice containing all trusted satellites
@@ -145,5 +128,5 @@ func (pool *Pool) GetAddress(ctx context.Context, id storj.NodeID) (_ string, er
 	if !ok {
 		return "", Error.New("ID %v not found in trusted list", id)
 	}
-	return info.nodeURL.Address, nil
+	return info.url.Address, nil
 }


### PR DESCRIPTION
Ensure that we directly dial the whitelisted satellites instead of going through kademlia.

To implement, it sets up a custom credentials which captures the auth info during the initial handshake, this avoids the necessity for a separate Endpoint for fetching information.

As a consequence it also removes ability to trust all satellites, which was a bad idea in the first place.

Why: Currently kademlia lookups keep failing, however it's much faster and reliable to dial directly.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
