### PR TITLE
Upload failing as object size aproaches 1MB

### DIFF
--- a/lib/uplink/project_test.go
+++ b/lib/uplink/project_test.go
@@ -27,7 +27,7 @@ func TestProjectListBuckets(t *testing.T) {
 			cfg := uplink.Config{}
 			cfg.Volatile.TLS.SkipPeerCAWhitelist = true
 
-			satelliteAddr := planet.Satellites[0].Local().Address.Address
+			satelliteAddr := planet.Satellites[0].Addr()
 			apiKey := planet.Uplinks[0].APIKey[planet.Satellites[0].ID()]
 
 			ul, err := uplink.NewUplink(ctx, &cfg)

--- a/lib/uplink/upload_test.go
+++ b/lib/uplink/upload_test.go
@@ -88,7 +88,7 @@ func TestUploadDownload(t *testing.T) {
 
 			written, err := upload.Write(data[:write])
 			require.NoError(t, err)
-			data = data[:written]
+			data = data[written:]
 		}
 
 		require.NoError(t, upload.Close())

--- a/lib/uplink/upload_test.go
+++ b/lib/uplink/upload_test.go
@@ -1,0 +1,114 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package uplink_test
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"storj.io/storj/internal/testcontext"
+	"storj.io/storj/internal/testplanet"
+	"storj.io/storj/internal/testrand"
+	"storj.io/storj/lib/uplink"
+	"storj.io/storj/pkg/storj"
+)
+
+func TestUploadDownload(t *testing.T) {
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount:   1,
+		StorageNodeCount: 6,
+		UplinkCount:      1,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		cfg := uplink.Config{}
+		cfg.Volatile.TLS.SkipPeerCAWhitelist = true
+
+		satelliteAddr := planet.Satellites[0].Addr()
+		apiKey := planet.Uplinks[0].APIKey[planet.Satellites[0].ID()]
+
+		ul, err := uplink.NewUplink(ctx, &cfg)
+		require.NoError(t, err)
+		defer ctx.Check(ul.Close)
+
+		// setup key
+		key, err := uplink.ParseAPIKey(apiKey)
+		require.NoError(t, err)
+
+		// open project
+		project, err := ul.OpenProject(ctx, satelliteAddr, key)
+		require.NoError(t, err)
+		defer ctx.Check(project.Close)
+
+		// setup bucket
+		config := &uplink.BucketConfig{}
+		config.PathCipher = storj.EncAESGCM
+		config.EncryptionParameters.CipherSuite = storj.EncAESGCM
+		config.EncryptionParameters.BlockSize = 2048
+
+		config.Volatile.RedundancyScheme.Algorithm = storj.ReedSolomon
+		config.Volatile.RedundancyScheme.ShareSize = 1024
+		config.Volatile.RedundancyScheme.RequiredShares = 2
+		config.Volatile.RedundancyScheme.RepairShares = 4
+		config.Volatile.RedundancyScheme.OptimalShares = 5
+		config.Volatile.RedundancyScheme.TotalShares = 6
+
+		_, err = project.CreateBucket(ctx, "main", config)
+		require.NoError(t, err)
+
+		// Make a key
+		encKey, err := project.SaltedKeyFromPassphrase(ctx, "my secret passphrase")
+		require.NoError(t, err)
+
+		// Make an encryption context
+		access := uplink.NewEncryptionAccessWithDefaultKey(*encKey)
+
+		// open bucket
+		bucket, err := project.OpenBucket(ctx, "main", access)
+		require.NoError(t, err)
+		defer ctx.Check(bucket.Close)
+
+		// upload data
+		uploadOptions := &uplink.UploadOptions{}
+		uploadOptions.ContentType = "text/plain"
+		uploadOptions.Expires = time.Now().Add(600 * 24 * time.Hour)
+
+		upload, err := bucket.NewWriter(ctx, "a", uploadOptions)
+		require.NoError(t, err)
+		defer ctx.Check(upload.Close)
+
+		data := testrand.Bytes(1024 * 1024)
+		for len(data) > 0 {
+			write := len(data)
+			if write > 256 {
+				write = 256
+			}
+
+			written, err := upload.Write(data[:write])
+			require.NoError(t, err)
+			data = data[:written]
+		}
+
+		require.NoError(t, upload.Close())
+
+		// download data
+		download, err := bucket.NewReader(ctx, "a")
+		require.NoError(t, err)
+		defer ctx.Check(download.Close)
+
+		downloaded := make([]byte, 3*1024*1024)
+		head := 0
+		for {
+			read, err := download.Read(downloaded[head : head+256])
+			head += read
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, data, downloaded[:head])
+	})
+}

--- a/lib/uplink/upload_test.go
+++ b/lib/uplink/upload_test.go
@@ -77,18 +77,18 @@ func TestUploadDownload(t *testing.T) {
 
 		upload, err := bucket.NewWriter(ctx, "a", uploadOptions)
 		require.NoError(t, err)
-		defer ctx.Check(upload.Close)
 
 		data := testrand.Bytes(1024 * 1024)
-		for len(data) > 0 {
-			write := len(data)
+		uploading := data
+		for len(uploading) > 0 {
+			write := len(uploading)
 			if write > 256 {
 				write = 256
 			}
 
-			written, err := upload.Write(data[:write])
+			written, err := upload.Write(uploading[:write])
 			require.NoError(t, err)
-			data = data[written:]
+			uploading = uploading[written:]
 		}
 
 		require.NoError(t, upload.Close())

--- a/lib/uplinkc/testdata/object_test.c
+++ b/lib/uplinkc/testdata/object_test.c
@@ -40,7 +40,10 @@ void handle_project(ProjectRef project) {
 
 
     for(int i = 0; i < num_of_objects; i++) {
-        size_t data_len = 1024 * (i + 1) * (i + 1);
+// DOESN'T WORK --v
+        size_t data_len = 1024 * 1024;
+// WORKS --v
+//        size_t data_len = 1024 * 1000;
         uint8_t *data = malloc(data_len);
         fill_random_data(data, data_len);
 

--- a/lib/uplinkc/testdata_test.go
+++ b/lib/uplinkc/testdata_test.go
@@ -23,7 +23,7 @@ func RunPlanet(t *testing.T, run func(ctx *testcontext.Context, planet *testplan
 	defer ctx.Cleanup()
 
 	planet, err := testplanet.NewCustom(
-		zaptest.NewLogger(t, zaptest.Level(zapcore.WarnLevel)),
+		zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel)),
 		testplanet.Config{
 			SatelliteCount:   1,
 			StorageNodeCount: 6,

--- a/lib/uplinkc/uplink.go
+++ b/lib/uplinkc/uplink.go
@@ -20,7 +20,7 @@ type Uplink struct {
 //
 // Caller must call close_uplink to close associated resources.
 func new_uplink(cfg C.UplinkConfig, cerr **C.char) C.UplinkRef {
-	scope := rootScope("inmemory") // TODO: pass in as argument
+	scope := rootScope("") // TODO: pass in as argument
 
 	libcfg := &uplink.Config{} // TODO: figure out a better name
 	libcfg.Volatile.TLS.SkipPeerCAWhitelist = cfg.Volatile.TLS.SkipPeerCAWhitelist == C.bool(true)


### PR DESCRIPTION
It seems like the libuplink C api test for uploading an object is passing for objects below 1MB but as the uploaded objects size approaches 1MB, it starts failing like this:

_([Jenkins log](https://build.ops.storj.io/blue/rest/organizations/jenkins/pipelines/storj/branches/PR-2592/runs/1/nodes/42/steps/60/log/?start=0)):_
```
logger.go:130: 2019-07-18T14:53:24.571Z	DEBUG	storage5.kademlia:endpoint	Successfully connected with 127.0.0.1:36781
logger.go:130: 2019-07-18T14:53:24.610Z	DEBUG	storage3.kademlia:endpoint	Successfully connected with 127.0.0.1:36781
logger.go:130: 2019-07-18T14:53:25.757Z	DEBUG	storage2.kademlia:endpoint	Successfully connected with 127.0.0.1:34845
logger.go:130: 2019-07-18T14:53:26.468Z	DEBUG	storage1.kademlia:endpoint	Successfully connected with 127.0.0.1:35293
logger.go:130: 2019-07-18T14:53:27.148Z	DEBUG	storage4.kademlia:endpoint	Successfully connected with 127.0.0.1:37911
logger.go:130: 2019-07-18T14:53:28.096Z	DEBUG	storage0.kademlia:endpoint	Successfully connected with 127.0.0.1:35205
logger.go:130: 2019-07-18T14:53:34.922Z	INFO	storage4.piecestore	upload started	{"Piece ID": "72G5BT3IDHDZKIXPDATKLZVB33Q33JGFRY2SZC7AF2T5GAHE5ALQ", "SatelliteID": "1ZgnjCicAfiGjJfKh7rnGG5if1Ps7i39THiEjMe1SgZs9xHYGr", "Action": "PUT"}
logger.go:130: 2019-07-18T14:53:34.931Z	INFO	storage3.piecestore	upload started	{"Piece ID": "WCVBHMLXQOG24CK5MUS5ED3ABGDLWCOFZ4UBOXTHWXZN4A3URGTQ", "SatelliteID": "1ZgnjCicAfiGjJfKh7rnGG5if1Ps7i39THiEjMe1SgZs9xHYGr", "Action": "PUT"}
logger.go:130: 2019-07-18T14:53:34.942Z	INFO	storage5.piecestore	upload started	{"Piece ID": "VJGTQPQRIVKIMVXFT443LUT4ITACKCRKOM2FCV52YJDMEYSGAARQ", "SatelliteID": "1ZgnjCicAfiGjJfKh7rnGG5if1Ps7i39THiEjMe1SgZs9xHYGr", "Action": "PUT"}
logger.go:130: 2019-07-18T14:53:34.940Z	INFO	storage2.piecestore	upload started	{"Piece ID": "DHDQMVZGWPBFFUZR3QUJDP5P7GZEE2Y2UH5J3KZQS42C3UWMYZEQ", "SatelliteID": "1ZgnjCicAfiGjJfKh7rnGG5if1Ps7i39THiEjMe1SgZs9xHYGr", "Action": "PUT"}
logger.go:130: 2019-07-18T14:53:34.935Z	INFO	storage1.piecestore	upload started	{"Piece ID": "TZ3ZBPRZLLZMJLMSOJ7BPMAD4HF4K65LAXCNGVEJMV3WF7I73KXQ", "SatelliteID": "1ZgnjCicAfiGjJfKh7rnGG5if1Ps7i39THiEjMe1SgZs9xHYGr", "Action": "PUT"}
logger.go:130: 2019-07-18T14:53:34.971Z	INFO	storage0.piecestore	upload started	{"Piece ID": "VLKTL4FST4VTYAR2MSRH6RERQYBCAGQYYAZOTO47HL7GERNZJIJA", "SatelliteID": "1ZgnjCicAfiGjJfKh7rnGG5if1Ps7i39THiEjMe1SgZs9xHYGr", "Action": "PUT"}
testdata_test.go:79: using SATELLITE_0_ADDR: 127.0.0.1:43235
    using GATEWAY_0_API_KEY: 13YqepYiBts1N31HAWEtTfp3BcSirBpiuxeRwMAJodwMngiDi6azVHrLLH7RfabXCAMMoK5uHH5vGhkjw2T3JCh37FpcwTpQ9TZ8vY7
    failed:
    	testdata/object_test.c:63: segment error: ecclient error: successful puts (0) less than or equal to repair threshold (4)
testdata_test.go:80: exit status 1
logger.go:130: 2019-07-18T14:53:35.521Z	INFO	storage2.piecestore	upload failed	{"Piece ID": "DHDQMVZGWPBFFUZR3QUJDP5P7GZEE2Y2UH5J3KZQS42C3UWMYZEQ", "SatelliteID": "1ZgnjCicAfiGjJfKh7rnGG5if1Ps7i39THiEjMe1SgZs9xHYGr", "Action": "PUT", "error": "piecestore protocol: unexpected EOF", "errorVerbose": "piecestore protocol: unexpected EOF\n\tstorj.io/storj/storagenode/piecestore.(*Endpoint).Upload:236\n\tstorj.io/storj/pkg/pb._Piecestore_Upload_Handler:701\n\tstorj.io/storj/pkg/server.logOnErrorStreamInterceptor:23\n\tgoogle.golang.org/grpc.(*Server).processStreamingRPC:1209\n\tgoogle.golang.org/grpc.(*Server).handleStream:1282\n\tgoogle.golang.org/grpc.(*Server).serveStreams.func1.1:717"}
... <error repeats for each storagenode>
```

Here, we see 6 storagenodes starting uploads but then failing with this "unexpected EOF" error.

When uploading a 1MB object, this happens consistently for me at exactly 1048576 (1MB) - 6160 bytes of progress.