### PR TITLE
Disable bandwidth rollups until duplicate data issue is resolved

### DIFF
--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -354,9 +354,9 @@ func (peer *Peer) Run(ctx context.Context) (err error) {
 		return errs2.IgnoreCanceled(peer.Vouchers.Run(ctx))
 	})
 
-	group.Go(func() error {
-		return errs2.IgnoreCanceled(peer.DB.Bandwidth().Run(ctx))
-	})
+	//group.Go(func() error {
+	//	return errs2.IgnoreCanceled(peer.DB.Bandwidth().Run(ctx))
+	//})
 
 	group.Go(func() error {
 		// TODO: move the message into Server instead
@@ -387,9 +387,9 @@ func (peer *Peer) Close() error {
 
 	// close services in reverse initialization order
 
-	if peer.DB.Bandwidth() != nil {
-		errlist.Add(peer.DB.Bandwidth().Close())
-	}
+	//if peer.DB.Bandwidth() != nil {
+	//	errlist.Add(peer.DB.Bandwidth().Close())
+	//}
 	if peer.Vouchers != nil {
 		errlist.Add(peer.Vouchers.Close())
 	}

--- a/storagenode/storagenodedb/storagenodedbtest/run_test.go
+++ b/storagenode/storagenodedb/storagenodedbtest/run_test.go
@@ -71,8 +71,8 @@ func TestBandwidthRollup(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(27), usage.Total())
 
-		err = db.Bandwidth().Rollup(ctx)
-		require.NoError(t, err)
+		//err = db.Bandwidth().Rollup(ctx)
+		//require.NoError(t, err)
 
 		// After rollup, the totals should still be the same
 		usage, err = db.Bandwidth().Summary(ctx, time.Now().Add(time.Hour*-48), time.Now())


### PR DESCRIPTION
What: 
Disable storagenode bandwidth rollups
Why:
Duplicate rollups causing issue with some storagenodes

Bandwidth usage will still be reported correctly b/c the queries UNION the bandwidth_usage and bandwidth_usage_rollup tables.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
