### PR TITLE
Prevent uniqueness failure in bandwidth rollup

### DIFF
--- a/storagenode/storagenodedb/bandwidthdb.go
+++ b/storagenode/storagenodedb/bandwidthdb.go
@@ -197,6 +197,7 @@ func (db *bandwidthdb) Rollup(ctx context.Context) (err error) {
 		SELECT datetime(strftime('%Y-%m-%dT%H:00:00', created_at)) created_hr, satellite_id, action, SUM(amount)
 			FROM bandwidth_usage
 		WHERE datetime(created_at) < datetime(?)
+		AND datetime(created_at) >= (SELECT datetime(MAX(interval_start), '+1 hour') FROM bandwidth_usage_rollups)
 		GROUP BY created_hr, satellite_id, action;
 
 		DELETE FROM bandwidth_usage WHERE datetime(created_at) < datetime(?);

--- a/storagenode/storagenodedb/bandwidthdb.go
+++ b/storagenode/storagenodedb/bandwidthdb.go
@@ -197,7 +197,7 @@ func (db *bandwidthdb) Rollup(ctx context.Context) (err error) {
 		SELECT datetime(strftime('%Y-%m-%dT%H:00:00', created_at)) created_hr, satellite_id, action, SUM(amount)
 			FROM bandwidth_usage
 		WHERE datetime(created_at) < datetime(?)
-		AND datetime(created_at) >= (SELECT datetime(MAX(interval_start), '+1 hour') FROM bandwidth_usage_rollups)
+		AND datetime(created_at) >= coalesce((SELECT datetime(MAX(interval_start), '+1 hour') FROM bandwidth_usage_rollups), datetime(0, 'unixepoch'))
 		GROUP BY created_hr, satellite_id, action;
 
 		DELETE FROM bandwidth_usage WHERE datetime(created_at) < datetime(?);


### PR DESCRIPTION
What: 
Prevent reinserting of already calculated bandwidth rollups by adding a start timestamp condition based on the latest rollup in the bandwidth_usage_rollups table.

Why:
Several SNO's have run into issues when their info.db has overlap between bandwidth_usage and bandwidth_usage_rollup tables. When this happens the subsequent rollup runs into a primary key uniqueness violation, which results in a fatal error that restarts the node.

Please describe the tests:
 - Test 1:
Downloaded an info.db from a SNO running into this issue. Ran the insert to verify it indeed throws a uniqueness violation error.
 - Test 2:
Added this condition and retried the insert, which then succeeded.
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
