### PR TITLE
satellite/satellitedb: Use var block for single variable declaration

### DIFF
--- a/satellite/satellitedb/migrate.go
+++ b/satellite/satellitedb/migrate.go
@@ -18,8 +18,10 @@ import (
 	"storj.io/storj/satellite/satellitedb/pbold"
 )
 
-// ErrMigrate is for tracking migration errors
-var ErrMigrate = errs.Class("migrate")
+var (
+	// ErrMigrate is for tracking migration errors
+	ErrMigrate = errs.Class("migrate")
+)
 
 // CreateTables is a method for creating all tables for database
 func (db *DB) CreateTables() error {

--- a/satellite/satellitedb/migrate.go
+++ b/satellite/satellitedb/migrate.go
@@ -880,7 +880,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 					where a.interval_start = b.interval_start
 					  and a.bucket_name = b.bucket_name
 					  and a.action = b.action
-					  and a.project_id = decode(replace(encode(b.project_id, 'escape'), '-', ''), 'hex')  
+					  and a.project_id = decode(replace(encode(b.project_id, 'escape'), '-', ''), 'hex')
 					  and length(b.project_id) = 36
 					  and length(a.project_id) = 16
 					;`,
@@ -890,7 +890,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 					where a.interval_start = b.interval_start
 					  and a.bucket_name = b.bucket_name
 					  and a.action = b.action
-					  and a.project_id = decode(replace(encode(b.project_id, 'escape'), '-', ''), 'hex')  
+					  and a.project_id = decode(replace(encode(b.project_id, 'escape'), '-', ''), 'hex')
 					  and length(b.project_id) = 36
 					  and length(a.project_id) = 16
 					;`,


### PR DESCRIPTION
What: Use var block and remove some spaces at the end of lines.

Why: To have more consistent godoc format

Before this change the godoc format is rendered as

![2019-07-23-135743_813x252_scrot](https://user-images.githubusercontent.com/1731633/61710590-3cc55680-ad52-11e9-9781-5dcf2fcf51fd.png)

While in other packages we have used blocks for a single var declaration at package level. For example

![2019-07-23-135804_1090x345_scrot](https://user-images.githubusercontent.com/1731633/61710660-5e264280-ad52-11e9-968a-00cdc46f103a.png)

I consider that when there is more than block of error variables, it's easier to read that all the different variables declared in different files of the same package be defined in blocs.

Please describe the tests: N/A
Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
