### PR TITLE
Ensure we dont enforce a signed Peer Identity during the Authorize command

### DIFF
--- a/cmd/identity/main.go
+++ b/cmd/identity/main.go
@@ -181,6 +181,9 @@ func cmdAuthorize(cmd *cobra.Command, args []string) error {
 		config.Signer.Address = defaultSignerAddress
 	}
 
+	// Ensure we dont enforce a signed Peer Identity
+	config.Signer.TLS.UsePeerCAWhitelist = false
+
 	signedChainBytes, err := config.Signer.Sign(ctx, ident, authToken)
 	if err != nil {
 		return errs.New("error occurred while signing certificate: %s\n(identity files were still generated and saved, if you try again existing files will be loaded)", err)


### PR DESCRIPTION
What: Disables the PeerCAWhitelist config to let our identity tool reach out to the CA properly.

Why: Its refuses the identity tool to sign identities -> Chicken-Egg Problem
Solves https://github.com/storj/docs/issues/98

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
