### PR TITLE
Add RetainStatus to storagenode config

### DIFF
--- a/internal/testplanet/storagenode.go
+++ b/internal/testplanet/storagenode.go
@@ -122,7 +122,7 @@ func (planet *Planet) newStorageNodes(count int, whitelistedSatellites storj.Nod
 					MinimumBandwidth: 100 * memory.MB,
 					MinimumDiskSpace: 100 * memory.MB,
 				},
-				RetainStatus: piecestore.ENABLED,
+				RetainStatus: piecestore.RetainEnabled,
 			},
 			Vouchers: vouchers.Config{
 				Interval: time.Hour,

--- a/internal/testplanet/storagenode.go
+++ b/internal/testplanet/storagenode.go
@@ -122,6 +122,7 @@ func (planet *Planet) newStorageNodes(count int, whitelistedSatellites storj.Nod
 					MinimumBandwidth: 100 * memory.MB,
 					MinimumDiskSpace: 100 * memory.MB,
 				},
+				RetainStatus: piecestore.ENABLED,
 			},
 			Vouchers: vouchers.Config{
 				Interval: time.Hour,

--- a/storagenode/piecestore/endpoint.go
+++ b/storagenode/piecestore/endpoint.go
@@ -70,7 +70,7 @@ type RetainStatus uint32
 
 const (
 	// RetainDisabled means we do not do anything with retain requests
-	RetainDisabled RetainStatus = iota
+	RetainDisabled RetainStatus = iota + 1
 	// RetainEnabled means we fully enable retain requests and delete data not defined by bloom filter
 	RetainEnabled
 	// RetainDebug means we partially enable retain requests, and print out pieces we should delete, without actually deleting them

--- a/storagenode/piecestore/endpoint.go
+++ b/storagenode/piecestore/endpoint.go
@@ -87,7 +87,7 @@ func (v *RetainStatus) Set(s string) error {
 	case "debug":
 		*v = RetainDebug
 	default:
-		return Error.New("invalid option %q", s)
+		return Error.New("invalid RetainStatus %q", s)
 	}
 	return nil
 }

--- a/storagenode/piecestore/endpoint.go
+++ b/storagenode/piecestore/endpoint.go
@@ -69,23 +69,23 @@ type Config struct {
 type RetainStatus int
 
 const (
-	// DISABLED means we do not do anything with retain requests
-	DISABLED RetainStatus = iota
-	// ENABLED means we fully enable retain requests and delete data not defined by bloom filter
-	ENABLED
-	// DEBUG means we partially enable retain requests, and print out pieces we should delete, without actually deleting them
-	DEBUG
+	// RetainDisabled means we do not do anything with retain requests
+	RetainDisabled RetainStatus = iota
+	// RetainEnabled means we fully enable retain requests and delete data not defined by bloom filter
+	RetainEnabled
+	// RetainDebug means we partially enable retain requests, and print out pieces we should delete, without actually deleting them
+	RetainDebug
 )
 
 // Set implements pflag.Value
 func (v *RetainStatus) Set(s string) error {
 	switch s {
 	case "disabled":
-		*v = DISABLED
+		*v = RetainDisabled
 	case "enabled":
-		*v = ENABLED
+		*v = RetainEnabled
 	case "debug":
-		*v = DEBUG
+		*v = RetainDebug
 	default:
 		return Error.New("invalid option %q", s)
 	}
@@ -98,11 +98,11 @@ func (*RetainStatus) Type() string { return "storj.RetainStatus" }
 // String implements pflag.Value
 func (v *RetainStatus) String() string {
 	switch *v {
-	case DISABLED:
+	case RetainDisabled:
 		return "disabled"
-	case ENABLED:
+	case RetainEnabled:
 		return "enabled"
-	case DEBUG:
+	case RetainDebug:
 		return "debug"
 	default:
 		return "invalid"

--- a/storagenode/piecestore/endpoint_test.go
+++ b/storagenode/piecestore/endpoint_test.go
@@ -535,9 +535,11 @@ func TestRetain(t *testing.T) {
 		endpointEnabled, err := ps.NewEndpoint(zaptest.NewLogger(t), nil, trusted, nil, store, pieceInfos, nil, nil, nil, ps.Config{
 			RetainStatus: ps.RetainEnabled,
 		})
+		require.NoError(t, err)
 		endpointDisabled, err := ps.NewEndpoint(zaptest.NewLogger(t), nil, trusted, nil, store, pieceInfos, nil, nil, nil, ps.Config{
 			RetainStatus: ps.RetainDisabled,
 		})
+		require.NoError(t, err)
 		endpointDebug, err := ps.NewEndpoint(zaptest.NewLogger(t), nil, trusted, nil, store, pieceInfos, nil, nil, nil, ps.Config{
 			RetainStatus: ps.RetainDebug,
 		})

--- a/storagenode/piecestore/endpoint_test.go
+++ b/storagenode/piecestore/endpoint_test.go
@@ -515,7 +515,8 @@ func TestRetain(t *testing.T) {
 		// have a recent timestamp and thus should not be deleted
 		const numOldPieces = 5
 
-		filter := bloomfilter.NewOptimal(numPiecesToKeep, 0.1)
+		// for this test, we set the false positive rate very low, so we can test which pieces should be deleted with precision
+		filter := bloomfilter.NewOptimal(numPieces, 0.000000001)
 
 		pieceIDs := generateTestIDs(numPieces)
 
@@ -531,12 +532,23 @@ func TestRetain(t *testing.T) {
 		require.NoError(t, err)
 
 		uplink := testidentity.MustPregeneratedSignedIdentity(3, storj.LatestIDVersion())
-		endpoint, err := ps.NewEndpoint(zaptest.NewLogger(t), nil, trusted, nil, store, pieceInfos, nil, nil, nil, ps.Config{})
+		endpointEnabled, err := ps.NewEndpoint(zaptest.NewLogger(t), nil, trusted, nil, store, pieceInfos, nil, nil, nil, ps.Config{
+			RetainStatus: ps.RetainEnabled,
+		})
+		endpointDisabled, err := ps.NewEndpoint(zaptest.NewLogger(t), nil, trusted, nil, store, pieceInfos, nil, nil, nil, ps.Config{
+			RetainStatus: ps.RetainDisabled,
+		})
+		endpointDebug, err := ps.NewEndpoint(zaptest.NewLogger(t), nil, trusted, nil, store, pieceInfos, nil, nil, nil, ps.Config{
+			RetainStatus: ps.RetainDebug,
+		})
 		require.NoError(t, err)
 
 		recentTime := time.Now()
 		oldTime := recentTime.Add(-time.Duration(48) * time.Hour)
 
+		// keep pieceIDs[0 : numPiecesToKeep] (old + in filter)
+		// delete pieceIDs[numPiecesToKeep : numPiecesToKeep+numOldPieces] (old + not in filter)
+		// keep pieceIDs[numPiecesToKeep+numOldPieces : numPieces] (recent + not in filter)
 		var pieceCreation time.Time
 		// add all pieces to the node pieces info DB - but only count piece ids in filter
 		for index, id := range pieceIDs {
@@ -603,17 +615,35 @@ func TestRetain(t *testing.T) {
 		retainReq.Filter = filter.Bytes()
 		retainReq.CreationDate = recentTime
 
-		_, err = endpoint.Retain(ctxSatellite0, &retainReq)
+		// expect that disabled and debug endpoints do not delete any pieces
+		_, err = endpointDisabled.Retain(ctxSatellite0, &retainReq)
 		require.NoError(t, err)
 
-		// check we have deleted nothing for satellite1
+		_, err = endpointDebug.Retain(ctxSatellite0, &retainReq)
+		require.NoError(t, err)
+
 		satellite1Pieces, err := pieceInfos.GetPieceIDs(ctx, satellite1.ID, recentTime.Add(time.Duration(5)*time.Second), numPieces, 0)
 		require.NoError(t, err)
 		require.Equal(t, numPieces, len(satellite1Pieces))
 
-		// check we did not delete recent pieces
 		satellite0Pieces, err := pieceInfos.GetPieceIDs(ctx, satellite0.ID, recentTime.Add(time.Duration(5)*time.Second), numPieces, 0)
 		require.NoError(t, err)
+		require.Equal(t, numPieces, len(satellite0Pieces))
+
+		// expect that enabled endpoint deletes the correct pieces
+		_, err = endpointEnabled.Retain(ctxSatellite0, &retainReq)
+		require.NoError(t, err)
+
+		// check we have deleted nothing for satellite1
+		satellite1Pieces, err = pieceInfos.GetPieceIDs(ctx, satellite1.ID, recentTime.Add(time.Duration(5)*time.Second), numPieces, 0)
+		require.NoError(t, err)
+		require.Equal(t, numPieces, len(satellite1Pieces))
+
+		// check we did not delete recent pieces or retained pieces for satellite0
+		// also check that we deleted the correct pieces for satellite0
+		satellite0Pieces, err = pieceInfos.GetPieceIDs(ctx, satellite0.ID, recentTime.Add(time.Duration(5)*time.Second), numPieces, 0)
+		require.NoError(t, err)
+		require.Equal(t, numPieces-numOldPieces, len(satellite0Pieces))
 
 		for _, id := range pieceIDs[:numPiecesToKeep] {
 			require.Contains(t, satellite0Pieces, id, "piece should not have been deleted (not in bloom filter)")
@@ -621,6 +651,10 @@ func TestRetain(t *testing.T) {
 
 		for _, id := range pieceIDs[numPiecesToKeep+numOldPieces:] {
 			require.Contains(t, satellite0Pieces, id, "piece should not have been deleted (recent piece)")
+		}
+
+		for _, id := range pieceIDs[numPiecesToKeep : numPiecesToKeep+numOldPieces] {
+			require.NotContains(t, satellite0Pieces, id, "piece should have been deleted")
 		}
 	})
 }


### PR DESCRIPTION
What: 
Make it possible for SNOs to configure retain requests to be enabled, disabled, or in debug mode.

The default setting for RetainStatus is "disabled", which will ignore retain requests from the satellite.

Why:
In the future, we will want to enable garbage collection on the satellite. But we may want to be more careful before we fully enable garbage collection everywhere. With this change, we will be able to set retain requests on the storagenode to "debug", which will log the pieces to be deleted and the number of pieces to be deleted, without actually deleting them. It should allow us to verify that garbage collection works as intended before doing it for real.

https://storjlabs.atlassian.net/browse/V3-2232

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
