### PR TITLE
Initialize correctly libuplink for `uplink setup` and `gateway setup`

### DIFF
--- a/cmd/uplink/cmd/setup.go
+++ b/cmd/uplink/cmd/setup.go
@@ -129,7 +129,7 @@ func cmdSetupInteractive(cmd *cobra.Command, setupDir string, encryptionKeyFilep
 		return Error.Wrap(err)
 	}
 
-	uplk, err := libuplink.NewUplink(ctx, nil)
+	uplk, err := setupCfg.NewUplink(ctx)
 	if err != nil {
 		return Error.Wrap(err)
 	}


### PR DESCRIPTION
What: Fixes a regression introduced with #2637.

Starting with #2637, the `uplink setup` and `gateway setup` commands contact the satellite for the generation of the salted encryption key from the configured passphrase. The libuplink was not initialized with the correct TLS settings and the call to the satellite may fail with `transport: authentication handshake failed: tls peer certificate verification error: not signed by any CA in the whitelist: CA cert`.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
