### PR TITLE
Check nil against Bandwidth service not DB before calling Bandwidth

### DIFF
--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -393,7 +393,7 @@ func (peer *Peer) Close() error {
 
 	// close services in reverse initialization order
 
-	if peer.DB.Bandwidth() != nil {
+	if peer.Bandwidth != nil {
 		errlist.Add(peer.Bandwidth.Close())
 	}
 	if peer.Vouchers != nil {


### PR DESCRIPTION
What: 
Fix the nil check before close

Why:
Causes issue if Bandwidth service wasn't created

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
