### PR TITLE
don't use global loggers

### DIFF
--- a/bootstrap/peer.go
+++ b/bootstrap/peer.go
@@ -99,7 +99,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config, ver
 			peer.Log.Sugar().Debugf("Binary Version: %s with CommitHash %s, built at %s as Release %v",
 				versionInfo.Version.String(), versionInfo.CommitHash, versionInfo.Timestamp.String(), versionInfo.Release)
 		}
-		peer.Version = version.NewService(config.Version, versionInfo, "Bootstrap")
+		peer.Version = version.NewService(log.Named("version"), config.Version, versionInfo, "Bootstrap")
 	}
 
 	{ // setup listener and server

--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -99,7 +99,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	if err := process.InitMetricsWithCertPath(ctx, nil, runCfg.Identity.CertPath); err != nil {
+	if err := process.InitMetricsWithCertPath(ctx, log, nil, runCfg.Identity.CertPath); err != nil {
 		zap.S().Error("Failed to initialize telemetry batcher: ", err)
 	}
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -149,7 +149,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 
 	ctx := process.Ctx(cmd)
 
-	if err := process.InitMetrics(ctx, nil, ""); err != nil {
+	if err := process.InitMetrics(ctx, zap.L(), nil, ""); err != nil {
 		zap.S().Error("Failed to initialize telemetry batcher: ", err)
 	}
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -153,7 +153,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 		zap.S().Error("Failed to initialize telemetry batcher: ", err)
 	}
 
-	err = version.CheckProcessVersion(ctx, runCfg.Version, version.Build, "Gateway")
+	err = version.CheckProcessVersion(ctx, zap.L(), runCfg.Version, version.Build, "Gateway")
 	if err != nil {
 		return err
 	}

--- a/cmd/identity/main.go
+++ b/cmd/identity/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/zeebo/errs"
+	"go.uber.org/zap"
 
 	"storj.io/storj/internal/fpath"
 	"storj.io/storj/internal/version"

--- a/cmd/identity/main.go
+++ b/cmd/identity/main.go
@@ -86,7 +86,7 @@ func serviceDirectory(serviceName string) string {
 func cmdNewService(cmd *cobra.Command, args []string) error {
 	ctx := process.Ctx(cmd)
 
-	err := version.CheckProcessVersion(ctx, config.Version, version.Build, "Identity")
+	err := version.CheckProcessVersion(ctx, zap.L(), config.Version, version.Build, "Identity")
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func cmdNewService(cmd *cobra.Command, args []string) error {
 func cmdAuthorize(cmd *cobra.Command, args []string) error {
 	ctx := process.Ctx(cmd)
 
-	err := version.CheckProcessVersion(ctx, config.Version, version.Build, "Identity")
+	err := version.CheckProcessVersion(ctx, zap.L(), config.Version, version.Build, "Identity")
 	if err != nil {
 		return err
 	}

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -142,7 +142,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	if err := process.InitMetricsWithCertPath(ctx, nil, runCfg.Identity.CertPath); err != nil {
+	if err := process.InitMetricsWithCertPath(ctx, log, nil, runCfg.Identity.CertPath); err != nil {
 		zap.S().Error("Failed to initialize telemetry batcher: ", err)
 	}
 

--- a/cmd/storagenode/main.go
+++ b/cmd/storagenode/main.go
@@ -152,7 +152,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	if err := process.InitMetricsWithCertPath(ctx, nil, runCfg.Identity.CertPath); err != nil {
+	if err := process.InitMetricsWithCertPath(ctx, log, nil, runCfg.Identity.CertPath); err != nil {
 		zap.S().Error("Failed to initialize telemetry batcher: ", err)
 	}
 

--- a/cmd/uplink/cmd/root.go
+++ b/cmd/uplink/cmd/root.go
@@ -98,7 +98,7 @@ func (cliCfg *UplinkFlags) NewUplink(ctx context.Context) (*libuplink.Uplink, er
 
 // GetProject returns a *libuplink.Project for interacting with a specific project
 func (cliCfg *UplinkFlags) GetProject(ctx context.Context) (*libuplink.Project, error) {
-	err := version.CheckProcessVersion(ctx, cliCfg.Version, version.Build, "Uplink")
+	err := version.CheckProcessVersion(ctx, zap.L(), cliCfg.Version, version.Build, "Uplink")
 	if err != nil {
 		return nil, err
 	}

--- a/examples/eestream/serve-collected/main.go
+++ b/examples/eestream/serve-collected/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/vivint/infectious"
+	"go.uber.org/zap"
 
 	"storj.io/storj/pkg/encryption"
 	"storj.io/storj/pkg/ranger"
@@ -74,7 +75,7 @@ func Main() error {
 		}
 		rrs[res.i] = res.rr
 	}
-	rc, err := eestream.Decode(rrs, es, 4*1024*1024, false)
+	rc, err := eestream.Decode(zap.L(), rrs, es, 4*1024*1024, false)
 	if err != nil {
 		return err
 	}

--- a/examples/eestream/serve/main.go
+++ b/examples/eestream/serve/main.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/vivint/infectious"
+	"go.uber.org/zap"
 
 	"storj.io/storj/pkg/encryption"
 	"storj.io/storj/pkg/ranger"
@@ -74,7 +75,7 @@ func Main() error {
 		}
 		rrs[piecenum] = r
 	}
-	rc, err := eestream.Decode(rrs, es, 4*1024*1024, false)
+	rc, err := eestream.Decode(zap.L(), rrs, es, 4*1024*1024, false)
 	if err != nil {
 		return err
 	}

--- a/examples/eestream/store/main.go
+++ b/examples/eestream/store/main.go
@@ -60,7 +60,7 @@ func Main() error {
 	if err != nil {
 		return err
 	}
-	readers, err := eestream.EncodeReader(context.Background(),
+	readers, err := eestream.EncodeReader(context.Background(), zap.L(),
 		encryption.TransformReader(eestream.PadReader(os.Stdin,
 			encrypter.InBlockSize()), encrypter, 0), rs)
 	if err != nil {

--- a/examples/eestream/store/main.go
+++ b/examples/eestream/store/main.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 
 	"github.com/vivint/infectious"
+	"go.uber.org/zap"
 
 	"storj.io/storj/pkg/encryption"
 	"storj.io/storj/pkg/storj"

--- a/internal/version/service.go
+++ b/internal/version/service.go
@@ -26,6 +26,7 @@ type Config struct {
 
 // Service contains the information and variables to ensure the Software is up to date
 type Service struct {
+	log     *zap.Logger
 	config  Config
 	info    Info
 	service string
@@ -38,8 +39,9 @@ type Service struct {
 }
 
 // NewService creates a Version Check Client with default configuration
-func NewService(config Config, info Info, service string) (client *Service) {
+func NewService(log *zap.Logger, config Config, info Info, service string) (client *Service) {
 	return &Service{
+		log:     log,
 		config:  config,
 		info:    info,
 		service: service,
@@ -105,22 +107,22 @@ func (srv *Service) checkVersion(ctx context.Context) (allowed bool) {
 	accepted, err := srv.queryVersionFromControlServer(ctx)
 	if err != nil {
 		// Log about the error, but dont crash the service and allow further operation
-		zap.S().Errorf("Failed to do periodic version check: %s", err.Error())
+		srv.log.Sugar().Errorf("Failed to do periodic version check: %s", err.Error())
 		return true
 	}
 
 	minimum := getFieldString(&accepted, srv.service)
-	zap.S().Debugf("allowed minimum version from control server is: %s", minimum.String())
+	srv.log.Sugar().Debugf("allowed minimum version from control server is: %s", minimum.String())
 
 	if minimum.String() == "" {
-		zap.S().Errorf("no version from control server, accepting to run")
+		srv.log.Sugar().Errorf("no version from control server, accepting to run")
 		return true
 	}
 	if isAcceptedVersion(srv.info.Version, minimum) {
-		zap.S().Infof("running on version %s", srv.info.Version.String())
+		srv.log.Sugar().Infof("running on version %s", srv.info.Version.String())
 		return true
 	}
-	zap.S().Errorf("running on not allowed/outdated version %s", srv.info.Version.String())
+	srv.log.Sugar().Errorf("running on not allowed/outdated version %s", srv.info.Version.String())
 	return false
 }
 
@@ -151,8 +153,18 @@ func (srv *Service) queryVersionFromControlServer(ctx context.Context) (ver Allo
 	return ver, err
 }
 
-// DebugHandler returns a json representation of the current version information for the binary
-func DebugHandler(w http.ResponseWriter, r *http.Request) {
+// DebugHandler implements version info endpoint.
+type DebugHandler struct {
+	log *zap.Logger
+}
+
+// NewDebugHandler returns new debug handler.
+func NewDebugHandler(log *zap.Logger) *DebugHandler {
+	return &DebugHandler{log}
+}
+
+// ServeHTTP returns a json representation of the current version information for the binary.
+func (server *DebugHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	j, err := Build.Marshal()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -164,7 +176,7 @@ func DebugHandler(w http.ResponseWriter, r *http.Request) {
 
 	_, err = w.Write(append(j, '\n'))
 	if err != nil {
-		zap.S().Errorf("error writing data to client %v", err)
+		server.log.Sugar().Errorf("error writing data to client %v", err)
 	}
 }
 

--- a/internal/version/service.go
+++ b/internal/version/service.go
@@ -61,9 +61,9 @@ func (srv *Service) CheckVersion(ctx context.Context) (err error) {
 
 // CheckProcessVersion is not meant to be used for peers but is meant to be
 // used for other utilities
-func CheckProcessVersion(ctx context.Context, config Config, info Info, service string) (err error) {
+func CheckProcessVersion(ctx context.Context, log *zap.Logger, config Config, info Info, service string) (err error) {
 	defer mon.Task()(&ctx)(&err)
-	return NewService(config, info, service).CheckVersion(ctx)
+	return NewService(log, config, info, service).CheckVersion(ctx)
 }
 
 // Run logs the current version information

--- a/lib/uplink/uplink.go
+++ b/lib/uplink/uplink.go
@@ -92,7 +92,7 @@ func (cfg *Config) setDefaults(ctx context.Context) error {
 		cfg.Volatile.MaxMemory = 0
 	}
 	if cfg.Volatile.Log == nil {
-		cfg.Volatile.Log = zap.NewNop()
+		cfg.Volatile.Log = zap.L()
 	}
 	if cfg.Volatile.DialTimeout.Seconds() == 0 {
 		cfg.Volatile.DialTimeout = defaultUplinkDialTimeout

--- a/lib/uplink/uplink.go
+++ b/lib/uplink/uplink.go
@@ -92,7 +92,7 @@ func (cfg *Config) setDefaults(ctx context.Context) error {
 		cfg.Volatile.MaxMemory = 0
 	}
 	if cfg.Volatile.Log == nil {
-		cfg.Volatile.Log = zap.L()
+		cfg.Volatile.Log = zap.NewNop()
 	}
 	if cfg.Volatile.DialTimeout.Seconds() == 0 {
 		cfg.Volatile.DialTimeout = defaultUplinkDialTimeout

--- a/pkg/certificates/config.go
+++ b/pkg/certificates/config.go
@@ -111,7 +111,7 @@ func (c CertServerConfig) Run(ctx context.Context, srv *server.Server) (err erro
 	}
 
 	certSrv := NewServer(
-		zap.L(),
+		zap.L(), // TODO: pass this in from somewhere
 		signer,
 		authDB,
 		uint16(c.MinDifficulty),

--- a/pkg/kademlia/routing_helpers_test.go
+++ b/pkg/kademlia/routing_helpers_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap"
 
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/teststorj"
@@ -31,7 +31,7 @@ type routingTableOpts struct {
 }
 
 // newTestRoutingTable returns a newly configured instance of a RoutingTable
-func newTestRoutingTable(ctx context.Context, t *testing.T, local *overlay.NodeDossier, opts routingTableOpts) (*RoutingTable, error) {
+func newTestRoutingTable(ctx context.Context, local *overlay.NodeDossier, opts routingTableOpts) (*RoutingTable, error) {
 	if opts.bucketSize == 0 {
 		opts.bucketSize = 6
 	}
@@ -40,8 +40,8 @@ func newTestRoutingTable(ctx context.Context, t *testing.T, local *overlay.NodeD
 	}
 	rt := &RoutingTable{
 		self:         local,
-		kadBucketDB:  storelogger.New(zaptest.NewLogger(t).Named("rt.kad"), teststore.New()),
-		nodeBucketDB: storelogger.New(zaptest.NewLogger(t).Named("rt.node"), teststore.New()),
+		kadBucketDB:  storelogger.New(zap.L().Named("rt.kad"), teststore.New()),
+		nodeBucketDB: storelogger.New(zap.L().Named("rt.node"), teststore.New()),
 		transport:    &defaultTransport,
 
 		mutex:            &sync.Mutex{},
@@ -51,7 +51,7 @@ func newTestRoutingTable(ctx context.Context, t *testing.T, local *overlay.NodeD
 
 		bucketSize:   opts.bucketSize,
 		rcBucketSize: opts.cacheSize,
-		antechamber:  storelogger.New(zaptest.NewLogger(t).Named("rt.antechamber"), teststore.New()),
+		antechamber:  storelogger.New(zap.L().Named("rt.antechamber"), teststore.New()),
 	}
 	ok, err := rt.addNode(ctx, &local.Node)
 	if !ok || err != nil {
@@ -60,27 +60,27 @@ func newTestRoutingTable(ctx context.Context, t *testing.T, local *overlay.NodeD
 	return rt, nil
 }
 
-func createRoutingTableWith(ctx context.Context, t *testing.T, localNodeID storj.NodeID, opts routingTableOpts) *RoutingTable {
+func createRoutingTableWith(ctx context.Context, localNodeID storj.NodeID, opts routingTableOpts) *RoutingTable {
 	if localNodeID == (storj.NodeID{}) {
 		panic("empty local node id")
 	}
 	local := &overlay.NodeDossier{Node: pb.Node{Id: localNodeID}}
 
-	rt, err := newTestRoutingTable(ctx, t, local, opts)
+	rt, err := newTestRoutingTable(ctx, local, opts)
 	if err != nil {
 		panic(err)
 	}
 	return rt
 }
 
-func createRoutingTable(ctx context.Context, t *testing.T, localNodeID storj.NodeID) *RoutingTable {
-	return createRoutingTableWith(ctx, t, localNodeID, routingTableOpts{})
+func createRoutingTable(ctx context.Context, localNodeID storj.NodeID) *RoutingTable {
+	return createRoutingTableWith(ctx, localNodeID, routingTableOpts{})
 }
 
 func TestAddNode(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
-	rt := createRoutingTable(ctx, t, teststorj.NodeIDFromString("OO"))
+	rt := createRoutingTable(ctx, teststorj.NodeIDFromString("OO"))
 	defer ctx.Check(rt.Close)
 
 	cases := []struct {
@@ -235,7 +235,7 @@ func TestAddNode(t *testing.T) {
 func TestUpdateNode(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
-	rt := createRoutingTable(ctx, t, teststorj.NodeIDFromString("AA"))
+	rt := createRoutingTable(ctx, teststorj.NodeIDFromString("AA"))
 	defer ctx.Check(rt.Close)
 	node := teststorj.MockNode("BB")
 	ok, err := rt.addNode(ctx, node)
@@ -262,7 +262,7 @@ func TestUpdateNode(t *testing.T) {
 func TestRemoveNode(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
-	rt := createRoutingTable(ctx, t, teststorj.NodeIDFromString("AA"))
+	rt := createRoutingTable(ctx, teststorj.NodeIDFromString("AA"))
 	defer ctx.Check(rt.Close)
 	// Add node to RT
 	kadBucketID := firstBucketID
@@ -342,7 +342,7 @@ func TestCreateOrUpdateKBucket(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
 	id := bucketID{255, 255}
-	rt := createRoutingTable(ctx, t, teststorj.NodeIDFromString("AA"))
+	rt := createRoutingTable(ctx, teststorj.NodeIDFromString("AA"))
 	defer ctx.Check(rt.Close)
 	err := rt.createOrUpdateKBucket(ctx, id, time.Now())
 	assert.NoError(t, err)
@@ -357,7 +357,7 @@ func TestGetKBucketID(t *testing.T) {
 	defer ctx.Cleanup()
 	kadIDA := bucketID{255, 255}
 	nodeIDA := teststorj.NodeIDFromString("AA")
-	rt := createRoutingTable(ctx, t, nodeIDA)
+	rt := createRoutingTable(ctx, nodeIDA)
 	defer ctx.Check(rt.Close)
 	keyA, err := rt.getKBucketID(ctx, nodeIDA)
 	assert.NoError(t, err)
@@ -411,7 +411,7 @@ func TestKadBucketContainsLocalNode(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
 	nodeIDA := storj.NodeID{183, 255} //[10110111, 1111111]
-	rt := createRoutingTable(ctx, t, nodeIDA)
+	rt := createRoutingTable(ctx, nodeIDA)
 	defer ctx.Check(rt.Close)
 	kadIDA := firstBucketID
 	var kadIDB bucketID
@@ -432,7 +432,7 @@ func TestKadBucketHasRoom(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
 	node1 := storj.NodeID{255, 255}
-	rt := createRoutingTable(ctx, t, node1)
+	rt := createRoutingTable(ctx, node1)
 	defer ctx.Check(rt.Close)
 	kadIDA := firstBucketID
 	node2 := storj.NodeID{191, 255}
@@ -457,7 +457,7 @@ func TestGetNodeIDsWithinKBucket(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
 	nodeIDA := storj.NodeID{183, 255} //[10110111, 1111111]
-	rt := createRoutingTable(ctx, t, nodeIDA)
+	rt := createRoutingTable(ctx, nodeIDA)
 	defer ctx.Check(rt.Close)
 	kadIDA := firstBucketID
 	var kadIDB bucketID
@@ -510,7 +510,7 @@ func TestGetNodesFromIDs(t *testing.T) {
 	assert.NoError(t, err)
 	c, err := proto.Marshal(nodeC)
 	assert.NoError(t, err)
-	rt := createRoutingTable(ctx, t, nodeA.Id)
+	rt := createRoutingTable(ctx, nodeA.Id)
 	defer ctx.Check(rt.Close)
 
 	assert.NoError(t, rt.nodeBucketDB.Put(ctx, nodeA.Id.Bytes(), a))
@@ -540,7 +540,7 @@ func TestUnmarshalNodes(t *testing.T) {
 	assert.NoError(t, err)
 	c, err := proto.Marshal(nodeC)
 	assert.NoError(t, err)
-	rt := createRoutingTable(ctx, t, nodeA.Id)
+	rt := createRoutingTable(ctx, nodeA.Id)
 	defer ctx.Check(rt.Close)
 	assert.NoError(t, rt.nodeBucketDB.Put(ctx, nodeA.Id.Bytes(), a))
 	assert.NoError(t, rt.nodeBucketDB.Put(ctx, nodeB.Id.Bytes(), b))
@@ -559,7 +559,7 @@ func TestGetUnmarshaledNodesFromBucket(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
 	nodeA := teststorj.MockNode("AA")
-	rt := createRoutingTable(ctx, t, nodeA.Id)
+	rt := createRoutingTable(ctx, nodeA.Id)
 	defer ctx.Check(rt.Close)
 	bucketID := firstBucketID
 	nodeB := teststorj.MockNode("BB")
@@ -580,7 +580,7 @@ func TestGetUnmarshaledNodesFromBucket(t *testing.T) {
 func TestGetKBucketRange(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
-	rt := createRoutingTable(ctx, t, teststorj.NodeIDFromString("AA"))
+	rt := createRoutingTable(ctx, teststorj.NodeIDFromString("AA"))
 	defer ctx.Check(rt.Close)
 	idA := storj.NodeID{255, 255}
 	idB := storj.NodeID{127, 255}
@@ -627,7 +627,7 @@ func TestBucketIDZeroValue(t *testing.T) {
 func TestDetermineLeafDepth(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
-	rt := createRoutingTable(ctx, t, teststorj.NodeIDFromString("AA"))
+	rt := createRoutingTable(ctx, teststorj.NodeIDFromString("AA"))
 	defer ctx.Check(rt.Close)
 	idA, idB, idC := firstBucketID, firstBucketID, firstBucketID
 	idA[0] = 255
@@ -689,7 +689,7 @@ func TestDetermineLeafDepth(t *testing.T) {
 func TestSplitBucket(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
-	rt := createRoutingTable(ctx, t, teststorj.NodeIDFromString("AA"))
+	rt := createRoutingTable(ctx, teststorj.NodeIDFromString("AA"))
 	defer ctx.Check(rt.Close)
 	cases := []struct {
 		testID string

--- a/pkg/process/debug.go
+++ b/pkg/process/debug.go
@@ -36,7 +36,7 @@ func initDebug(logger *zap.Logger, r *monkit.Registry) (err error) {
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
-	mux.Handle("/version/", http.StripPrefix("/version", version.NewDebugHandler(logger.Named("version")))
+	mux.Handle("/version/", http.StripPrefix("/version", version.NewDebugHandler(logger.Named("version"))))
 	mux.Handle("/mon/", http.StripPrefix("/mon", present.HTTP(r)))
 	mux.HandleFunc("/metrics", prometheus)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/process/debug.go
+++ b/pkg/process/debug.go
@@ -36,7 +36,7 @@ func initDebug(logger *zap.Logger, r *monkit.Registry) (err error) {
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
-	mux.Handle("/version/", http.StripPrefix("/version", http.HandlerFunc(version.DebugHandler)))
+	mux.Handle("/version/", http.StripPrefix("/version", version.NewDebugHandler(logger.Named("version")))
 	mux.Handle("/mon/", http.StripPrefix("/mon", present.HTTP(r)))
 	mux.HandleFunc("/metrics", prometheus)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -42,7 +42,7 @@ func flagDefault(dev, release string) string {
 
 // InitMetrics initializes telemetry reporting. Makes a telemetry.Client and calls
 // its Run() method in a goroutine.
-func InitMetrics(ctx context.Context, r *monkit.Registry, instanceID string) (err error) {
+func InitMetrics(ctx context.Context, log *zap.Logger, r *monkit.Registry, instanceID string) (err error) {
 	if *metricCollector == "" || *metricInterval == 0 {
 		return Error.New("telemetry disabled")
 	}
@@ -56,7 +56,7 @@ func InitMetrics(ctx context.Context, r *monkit.Registry, instanceID string) (er
 	if len(instanceID) > maxInstanceLength {
 		instanceID = instanceID[:maxInstanceLength]
 	}
-	c, err := telemetry.NewClient(*metricCollector, telemetry.ClientOpts{
+	c, err := telemetry.NewClient(log, *metricCollector, telemetry.ClientOpts{
 		Interval:      *metricInterval,
 		Application:   *metricApp + *metricAppSuffix,
 		Instance:      instanceID,
@@ -84,5 +84,5 @@ func InitMetricsWithCertPath(ctx context.Context, log *zap.Logger, r *monkit.Reg
 	} else {
 		metricsID = nodeID.String()
 	}
-	return InitMetrics(ctx, r, metricsID)
+	return InitMetrics(ctx, log, r, metricsID)
 }

--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -75,11 +75,11 @@ func InitMetrics(ctx context.Context, r *monkit.Registry, instanceID string) (er
 
 // InitMetricsWithCertPath initializes telemetry reporting, using the node ID
 // corresponding to the given certificate as the telemetry instance ID.
-func InitMetricsWithCertPath(ctx context.Context, r *monkit.Registry, certPath string) error {
+func InitMetricsWithCertPath(ctx context.Context, log *zap.Logger, r *monkit.Registry, certPath string) error {
 	var metricsID string
 	nodeID, err := identity.NodeIDFromCertPath(certPath)
 	if err != nil {
-		zap.S().Errorf("Could not read identity for telemetry setup: %v", err)
+		log.Sugar().Errorf("Could not read identity for telemetry setup: %v", err)
 		metricsID = "" // InitMetrics() will fill in a default value
 	} else {
 		metricsID = nodeID.String()

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -40,10 +40,10 @@ func (sc Config) Run(ctx context.Context, log *zap.Logger, identity *identity.Fu
 	go func() {
 		<-ctx.Done()
 		if closeErr := server.Close(); closeErr != nil {
-			zap.S().Errorf("Failed to close server: %s", closeErr)
+			log.Sugar().Errorf("Failed to close server: %s", closeErr)
 		}
 	}()
 
-	zap.S().Infof("Node %s started on %s", server.Identity().ID, sc.Address)
+	log.Sugar().Infof("Node %s started on %s", server.Identity().ID, sc.Address)
 	return server.Run(ctx)
 }

--- a/pkg/telemetry/client_test.go
+++ b/pkg/telemetry/client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zeebo/admission/admmonkit"
+	"go.uber.org/zap/zaptest"
 	monkit "gopkg.in/spacemonkeygo/monkit.v2"
 )
 
@@ -18,7 +19,7 @@ func TestNewClient_IntervalIsZero(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { assert.NoError(t, s.Close()) }()
 
-	client, err := NewClient(s.Addr(), ClientOpts{
+	client, err := NewClient(zaptest.NewLogger(t), s.Addr(), ClientOpts{
 		Application: "testapp",
 		Instance:    "testinst",
 		Interval:    0,
@@ -41,7 +42,7 @@ func TestNewClient_ApplicationAndArgsAreEmpty(t *testing.T) {
 
 	os.Args = nil
 
-	client, err := NewClient(s.Addr(), ClientOpts{
+	client, err := NewClient(zaptest.NewLogger(t), s.Addr(), ClientOpts{
 		Application: "",
 		Instance:    "testinst",
 		Interval:    0,
@@ -57,7 +58,7 @@ func TestNewClient_ApplicationIsEmpty(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { assert.NoError(t, s.Close()) }()
 
-	client, err := NewClient(s.Addr(), ClientOpts{
+	client, err := NewClient(zaptest.NewLogger(t), s.Addr(), ClientOpts{
 		Application: "",
 		Instance:    "testinst",
 		Interval:    0,
@@ -73,7 +74,7 @@ func TestNewClient_InstanceIsEmpty(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { assert.NoError(t, s.Close()) }()
 
-	client, err := NewClient(s.Addr(), ClientOpts{
+	client, err := NewClient(zaptest.NewLogger(t), s.Addr(), ClientOpts{
 		Application: "qwe",
 		Instance:    "",
 		Interval:    0,
@@ -92,7 +93,7 @@ func TestNewClient_RegistryIsNil(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { assert.NoError(t, s.Close()) }()
 
-	client, err := NewClient(s.Addr(), ClientOpts{
+	client, err := NewClient(zaptest.NewLogger(t), s.Addr(), ClientOpts{
 		Application: "qwe",
 		Instance:    "",
 		Interval:    0,
@@ -111,7 +112,7 @@ func TestNewClient_PacketSizeIsZero(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { assert.NoError(t, s.Close()) }()
 
-	client, err := NewClient(s.Addr(), ClientOpts{
+	client, err := NewClient(zaptest.NewLogger(t), s.Addr(), ClientOpts{
 		Application: "qwe",
 		Instance:    "",
 		Interval:    0,
@@ -129,7 +130,7 @@ func TestNewClient_PacketSizeIsZero(t *testing.T) {
 }
 
 func TestRun_ReportNoCalled(t *testing.T) {
-	client, err := NewClient("127.0.0.1:0", ClientOpts{
+	client, err := NewClient(zaptest.NewLogger(t), "127.0.0.1:0", ClientOpts{
 		Application: "qwe",
 		Instance:    "",
 		Interval:    time.Millisecond,

--- a/pkg/telemetry/example_test.go
+++ b/pkg/telemetry/example_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/zeebo/admission/admproto"
 	"github.com/zeebo/errs"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	monkit "gopkg.in/spacemonkeygo/monkit.v2"
 
@@ -45,7 +46,7 @@ func Example() {
 
 	// sender
 	group.Go(func() error {
-		client, err := telemetry.NewClient(receiver.Addr(), telemetry.ClientOpts{
+		client, err := telemetry.NewClient(zap.L(), receiver.Addr(), telemetry.ClientOpts{
 			Interval:      time.Second,
 			Application:   "example",
 			Instance:      telemetry.DefaultInstanceID(),

--- a/pkg/telemetry/tm_test.go
+++ b/pkg/telemetry/tm_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
 	monkit "gopkg.in/spacemonkeygo/monkit.v2"
 )
 
@@ -26,7 +27,7 @@ func TestMetrics(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { _ = s.Close() }()
 
-	c, err := NewClient(s.Addr(), ClientOpts{
+	c, err := NewClient(zaptest.NewLogger(t), s.Addr(), ClientOpts{
 		Application: "testapp",
 		Instance:    "testinst",
 	})

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -245,7 +245,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config *Config, ve
 			peer.Log.Sugar().Debugf("Binary Version: %s with CommitHash %s, built at %s as Release %v",
 				versionInfo.Version.String(), versionInfo.CommitHash, versionInfo.Timestamp.String(), versionInfo.Release)
 		}
-		peer.Version = version.NewService(config.Version, versionInfo, "Satellite")
+		peer.Version = version.NewService(log.Named("version"), config.Version, versionInfo, "Satellite")
 	}
 
 	{ // setup listener and server

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -153,7 +153,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, config Config, ver
 			peer.Log.Sugar().Debugf("Binary Version: %s with CommitHash %s, built at %s as Release %v",
 				versionInfo.Version.String(), versionInfo.CommitHash, versionInfo.Timestamp.String(), versionInfo.Release)
 		}
-		peer.Version = version.NewService(config.Version, versionInfo, "Storagenode")
+		peer.Version = version.NewService(log.Named("version"), config.Version, versionInfo, "Storagenode")
 	}
 
 	{ // setup listener and server

--- a/uplink/ecclient/client.go
+++ b/uplink/ecclient/client.go
@@ -355,7 +355,7 @@ func (ec *ecClient) Get(ctx context.Context, limits []*pb.AddressedOrderLimit, p
 		}
 	}
 
-	rr, err = eestream.Decode(rrs, es, ec.memoryLimit, ec.forceErrorDetection)
+	rr, err = eestream.Decode(ec.log, rrs, es, ec.memoryLimit, ec.forceErrorDetection)
 	if err != nil {
 		return nil, Error.Wrap(err)
 	}

--- a/uplink/ecclient/client.go
+++ b/uplink/ecclient/client.go
@@ -83,7 +83,7 @@ func (ec *ecClient) Put(ctx context.Context, limits []*pb.AddressedOrderLimit, p
 		rs.ErasureShareSize(), rs.StripeSize(), rs.RepairThreshold(), rs.OptimalThreshold())
 
 	padded := eestream.PadReader(ioutil.NopCloser(data), rs.StripeSize())
-	readers, err := eestream.EncodeReader(ctx, padded, rs)
+	readers, err := eestream.EncodeReader(ctx, ec.log, padded, rs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -171,7 +171,7 @@ func (ec *ecClient) Repair(ctx context.Context, limits []*pb.AddressedOrderLimit
 	}
 
 	padded := eestream.PadReader(ioutil.NopCloser(data), rs.StripeSize())
-	readers, err := eestream.EncodeReader(ctx, padded, rs)
+	readers, err := eestream.EncodeReader(ctx, ec.log, padded, rs)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/uplink/eestream/decode.go
+++ b/uplink/eestream/decode.go
@@ -59,7 +59,7 @@ func DecodeReaders(ctx context.Context, log *zap.Logger, rs map[int]io.ReadClose
 		log:             log,
 		readers:         rs,
 		scheme:          es,
-		stripeReader:    NewStripeReader(rs, es, mbm, forceErrorDetection),
+		stripeReader:    NewStripeReader(log, rs, es, mbm, forceErrorDetection),
 		outbuf:          make([]byte, 0, es.StripeSize()),
 		expectedStripes: expectedSize / int64(es.StripeSize()),
 	}

--- a/uplink/eestream/decode.go
+++ b/uplink/eestream/decode.go
@@ -19,6 +19,7 @@ import (
 )
 
 type decodedReader struct {
+	log             *zap.Logger
 	ctx             context.Context
 	cancel          context.CancelFunc
 	readers         map[int]io.ReadCloser
@@ -41,7 +42,7 @@ type decodedReader struct {
 // set to 0, the minimum possible memory will be used.
 // if forceErrorDetection is set to true then k+1 pieces will be always
 // required for decoding, so corrupted pieces can be detected.
-func DecodeReaders(ctx context.Context, rs map[int]io.ReadCloser, es ErasureScheme, expectedSize int64, mbm int, forceErrorDetection bool) io.ReadCloser {
+func DecodeReaders(ctx context.Context, log *zap.Logger, rs map[int]io.ReadCloser, es ErasureScheme, expectedSize int64, mbm int, forceErrorDetection bool) io.ReadCloser {
 	defer mon.Task()(&ctx)(nil)
 	if expectedSize < 0 {
 		return readcloser.FatalReadCloser(Error.New("negative expected size"))
@@ -55,6 +56,7 @@ func DecodeReaders(ctx context.Context, rs map[int]io.ReadCloser, es ErasureSche
 		return readcloser.FatalReadCloser(err)
 	}
 	dr := &decodedReader{
+		log:             log,
 		readers:         rs,
 		scheme:          es,
 		stripeReader:    NewStripeReader(rs, es, mbm, forceErrorDetection),
@@ -127,12 +129,13 @@ func (dr *decodedReader) Close() (err error) {
 		return dr.closeErr
 	}
 	if dr.closeErr != nil {
-		zap.L().Debug("decode close non fatal error: ", zap.Error(dr.closeErr))
+		dr.log.Debug("decode close non fatal error: ", zap.Error(dr.closeErr))
 	}
 	return nil
 }
 
 type decodedRanger struct {
+	log                 *zap.Logger
 	es                  ErasureScheme
 	rrs                 map[int]ranger.Ranger
 	inSize              int64
@@ -148,7 +151,7 @@ type decodedRanger struct {
 // set to 0, the minimum possible memory will be used.
 // if forceErrorDetection is set to true then k+1 pieces will be always
 // required for decoding, so corrupted pieces can be detected.
-func Decode(rrs map[int]ranger.Ranger, es ErasureScheme, mbm int, forceErrorDetection bool) (ranger.Ranger, error) {
+func Decode(log *zap.Logger, rrs map[int]ranger.Ranger, es ErasureScheme, mbm int, forceErrorDetection bool) (ranger.Ranger, error) {
 	if err := checkMBM(mbm); err != nil {
 		return nil, err
 	}
@@ -173,6 +176,7 @@ func Decode(rrs map[int]ranger.Ranger, es ErasureScheme, mbm int, forceErrorDete
 			size, es.ErasureShareSize())
 	}
 	return &decodedRanger{
+		log:                 log,
 		es:                  es,
 		rrs:                 rrs,
 		inSize:              size,
@@ -218,10 +222,9 @@ func (dr *decodedRanger) Range(ctx context.Context, offset, length int64) (_ io.
 		}
 	}
 	// decode from all those ranges
-	r := DecodeReaders(ctx, readers, dr.es, blockCount*int64(dr.es.StripeSize()), dr.mbm, dr.forceErrorDetection)
+	r := DecodeReaders(ctx, dr.log, readers, dr.es, blockCount*int64(dr.es.StripeSize()), dr.mbm, dr.forceErrorDetection)
 	// offset might start a few bytes in, potentially discard the initial bytes
-	_, err = io.CopyN(ioutil.Discard, r,
-		offset-firstBlock*int64(dr.es.StripeSize()))
+	_, err = io.CopyN(ioutil.Discard, r, offset-firstBlock*int64(dr.es.StripeSize()))
 	if err != nil {
 		return nil, Error.Wrap(err)
 	}

--- a/uplink/eestream/encode.go
+++ b/uplink/eestream/encode.go
@@ -177,7 +177,7 @@ func (er *encodedReader) fillBuffer(ctx context.Context, r io.Reader, w sync2.Pi
 	_, err = sync2.Copy(ctx, w, r)
 	err = w.CloseWithError(err)
 	if err != nil {
-		er.log.Error(err)
+		er.log.Sugar().Error(err)
 	}
 }
 

--- a/uplink/eestream/encode.go
+++ b/uplink/eestream/encode.go
@@ -119,6 +119,7 @@ func (rs *RedundancyStrategy) OptimalThreshold() int {
 }
 
 type encodedReader struct {
+	log    *zap.Logger
 	ctx    context.Context
 	rs     RedundancyStrategy
 	pieces map[int]*encodedPiece
@@ -126,10 +127,11 @@ type encodedReader struct {
 
 // EncodeReader takes a Reader and a RedundancyStrategy and returns a slice of
 // io.ReadClosers.
-func EncodeReader(ctx context.Context, r io.Reader, rs RedundancyStrategy) (_ []io.ReadCloser, err error) {
+func EncodeReader(ctx context.Context, log *zap.Logger, r io.Reader, rs RedundancyStrategy) (_ []io.ReadCloser, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	er := &encodedReader{
+		log:    log,
 		ctx:    ctx,
 		rs:     rs,
 		pieces: make(map[int]*encodedPiece, rs.TotalCount()),
@@ -175,7 +177,7 @@ func (er *encodedReader) fillBuffer(ctx context.Context, r io.Reader, w sync2.Pi
 	_, err = sync2.Copy(ctx, w, r)
 	err = w.CloseWithError(err)
 	if err != nil {
-		zap.S().Error(err)
+		er.log.Error(err)
 	}
 }
 
@@ -231,20 +233,22 @@ func (ep *encodedPiece) Close() (err error) {
 // multiple Ranged sub-Readers. EncodedRanger does not match the normal Ranger
 // interface.
 type EncodedRanger struct {
-	rr ranger.Ranger
-	rs RedundancyStrategy
+	log *zap.Logger
+	rr  ranger.Ranger
+	rs  RedundancyStrategy
 }
 
 // NewEncodedRanger from the given Ranger and RedundancyStrategy. See the
 // comments for EncodeReader about the repair and success thresholds.
-func NewEncodedRanger(rr ranger.Ranger, rs RedundancyStrategy) (*EncodedRanger, error) {
+func NewEncodedRanger(log *zap.Logger, rr ranger.Ranger, rs RedundancyStrategy) (*EncodedRanger, error) {
 	if rr.Size()%int64(rs.StripeSize()) != 0 {
 		return nil, Error.New("invalid erasure encoder and range reader combo. " +
 			"range reader size must be a multiple of erasure encoder block size")
 	}
 	return &EncodedRanger{
-		rs: rs,
-		rr: rr,
+		log: log,
+		rs:  rs,
+		rr:  rr,
 	}, nil
 }
 
@@ -269,7 +273,7 @@ func (er *EncodedRanger) Range(ctx context.Context, offset, length int64) (_ []i
 	if err != nil {
 		return nil, err
 	}
-	readers, err := EncodeReader(ctx, r, er.rs)
+	readers, err := EncodeReader(ctx, er.log, r, er.rs)
 	if err != nil {
 		return nil, err
 	}

--- a/uplink/eestream/piecebuf.go
+++ b/uplink/eestream/piecebuf.go
@@ -12,6 +12,7 @@ import (
 
 // PieceBuffer is a synchronized buffer for storing erasure shares for a piece.
 type PieceBuffer struct {
+	log          *zap.Logger
 	buf          []byte
 	shareSize    int
 	cond         *sync.Cond
@@ -27,8 +28,9 @@ type PieceBuffer struct {
 // NewPieceBuffer creates and initializes a new PieceBuffer using buf as its
 // internal content. If new data is written to the buffer, newDataCond will be
 // notified.
-func NewPieceBuffer(buf []byte, shareSize int, newDataCond *sync.Cond) *PieceBuffer {
+func NewPieceBuffer(log *zap.Logger, buf []byte, shareSize int, newDataCond *sync.Cond) *PieceBuffer {
 	return &PieceBuffer{
+		log:         log,
 		buf:         buf,
 		shareSize:   shareSize,
 		cond:        sync.NewCond(&sync.Mutex{}),
@@ -230,8 +232,7 @@ func (b *PieceBuffer) buffered() int {
 func (b *PieceBuffer) HasShare(num int64) bool {
 	if num < b.currentShare {
 		// we should never get here!
-		zap.S().Fatalf("Checking for erasure share %d while the current erasure share is %d.",
-			num, b.currentShare)
+		b.log.Fatalf("Checking for erasure share %d while the current erasure share is %d.", num, b.currentShare)
 	}
 
 	if b.getError() != nil {
@@ -257,8 +258,7 @@ func (b *PieceBuffer) HasShare(num int64) bool {
 func (b *PieceBuffer) ReadShare(num int64, p []byte) error {
 	if num < b.currentShare {
 		// we should never get here!
-		zap.S().Fatalf("Trying to read erasure share %d while the current erasure share is already %d.",
-			num, b.currentShare)
+		b.log.Fatalf("Trying to read erasure share %d while the current erasure share is already %d.", num, b.currentShare)
 	}
 
 	err := b.discardUntil(num)

--- a/uplink/eestream/piecebuf.go
+++ b/uplink/eestream/piecebuf.go
@@ -232,7 +232,7 @@ func (b *PieceBuffer) buffered() int {
 func (b *PieceBuffer) HasShare(num int64) bool {
 	if num < b.currentShare {
 		// we should never get here!
-		b.log.Fatalf("Checking for erasure share %d while the current erasure share is %d.", num, b.currentShare)
+		b.log.Sugar().Fatalf("Checking for erasure share %d while the current erasure share is %d.", num, b.currentShare)
 	}
 
 	if b.getError() != nil {
@@ -258,7 +258,7 @@ func (b *PieceBuffer) HasShare(num int64) bool {
 func (b *PieceBuffer) ReadShare(num int64, p []byte) error {
 	if num < b.currentShare {
 		// we should never get here!
-		b.log.Fatalf("Trying to read erasure share %d while the current erasure share is already %d.", num, b.currentShare)
+		b.log.Sugar().Fatalf("Trying to read erasure share %d while the current erasure share is already %d.", num, b.currentShare)
 	}
 
 	err := b.discardUntil(num)

--- a/uplink/eestream/rs_test.go
+++ b/uplink/eestream/rs_test.go
@@ -41,7 +41,7 @@ func TestRS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	readers, err := EncodeReader(ctx, bytes.NewReader(data), rs)
+	readers, err := EncodeReader(ctx, zaptest.NewLogger(t), bytes.NewReader(data), rs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestRSUnexpectedEOF(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	readers, err := EncodeReader(ctx, bytes.NewReader(data), rs)
+	readers, err := EncodeReader(ctx, zaptest.NewLogger(t), bytes.NewReader(data), rs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestRSRanger(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	readers, err := EncodeReader(ctx, encryption.TransformReader(PadReader(ioutil.NopCloser(
+	readers, err := EncodeReader(ctx, zaptest.NewLogger(t), encryption.TransformReader(PadReader(ioutil.NopCloser(
 		bytes.NewReader(data)), encrypter.InBlockSize()), encrypter, 0), rs)
 	if err != nil {
 		t.Fatal(err)
@@ -386,7 +386,7 @@ func testRSProblematic(t *testing.T, tt testCase, i int, fn problematicReadClose
 	if !assert.NoError(t, err, errTag) {
 		return
 	}
-	readers, err := EncodeReader(ctx, bytes.NewReader(data), rs)
+	readers, err := EncodeReader(ctx, zaptest.NewLogger(t), bytes.NewReader(data), rs)
 	if !assert.NoError(t, err, errTag) {
 		return
 	}
@@ -462,7 +462,7 @@ func TestEncoderStalledReaders(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	readers, err := EncodeReader(ctx, bytes.NewReader(data), rs)
+	readers, err := EncodeReader(ctx, zaptest.NewLogger(t), bytes.NewReader(data), rs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -508,7 +508,7 @@ func TestDecoderErrorWithStalledReaders(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	readers, err := EncodeReader(ctx, bytes.NewReader(data), rs)
+	readers, err := EncodeReader(ctx, zaptest.NewLogger(t), bytes.NewReader(data), rs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -663,7 +663,7 @@ func TestCalcPieceSize(t *testing.T) {
 		calculatedSize := CalcPieceSize(dataSize, es)
 
 		randReader := ioutil.NopCloser(io.LimitReader(testrand.Reader(), dataSize))
-		readers, err := EncodeReader(ctx, PadReader(randReader, es.StripeSize()), rs)
+		readers, err := EncodeReader(ctx, zaptest.NewLogger(t), PadReader(randReader, es.StripeSize()), rs)
 		require.NoError(t, err, errTag)
 
 		for _, reader := range readers {

--- a/uplink/eestream/rs_test.go
+++ b/uplink/eestream/rs_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vivint/infectious"
 	"github.com/zeebo/errs"
+	"go.uber.org/zap/zaptest"
 
 	"storj.io/storj/internal/memory"
 	"storj.io/storj/internal/readcloser"
@@ -531,7 +532,7 @@ func TestDecoderErrorWithStalledReaders(t *testing.T) {
 	for i := 7; i < 20; i++ {
 		readerMap[i] = readcloser.FatalReadCloser(errors.New("I am an error piece"))
 	}
-	decoder := DecodeReaders(ctx, readerMap, rs, int64(10*1024), 0, false)
+	decoder := DecodeReaders(ctx, zaptest.NewLogger(t), readerMap, rs, int64(10*1024), 0, false)
 	defer func() { assert.NoError(t, decoder.Close()) }()
 	// record the time for reading the data from the decoder
 	start := time.Now()

--- a/uplink/eestream/rs_test.go
+++ b/uplink/eestream/rs_test.go
@@ -50,7 +50,7 @@ func TestRS(t *testing.T) {
 	for i, reader := range readers {
 		readerMap[i] = reader
 	}
-	decoder := DecodeReaders(ctx, readerMap, rs, 32*1024, 0, false)
+	decoder := DecodeReaders(ctx, zaptest.NewLogger(t), readerMap, rs, 32*1024, 0, false)
 	defer func() { assert.NoError(t, decoder.Close()) }()
 	data2, err := ioutil.ReadAll(decoder)
 	if err != nil {
@@ -81,7 +81,7 @@ func TestRSUnexpectedEOF(t *testing.T) {
 	for i, reader := range readers {
 		readerMap[i] = reader
 	}
-	decoder := DecodeReaders(ctx, readerMap, rs, 32*1024, 0, false)
+	decoder := DecodeReaders(ctx, zaptest.NewLogger(t), readerMap, rs, 32*1024, 0, false)
 	defer func() { assert.NoError(t, decoder.Close()) }()
 	// Try ReadFull more data from DecodeReaders than available
 	data2 := make([]byte, len(data)+1024)
@@ -126,7 +126,7 @@ func TestRSRanger(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rc, err := Decode(rrs, rs, 0, false)
+	rc, err := Decode(zaptest.NewLogger(t), rrs, rs, 0, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -406,7 +406,7 @@ func testRSProblematic(t *testing.T, tt testCase, i int, fn problematicReadClose
 	for i := tt.problematic; i < tt.total; i++ {
 		readerMap[i] = ioutil.NopCloser(bytes.NewReader(pieces[i]))
 	}
-	decoder := DecodeReaders(ctx, readerMap, rs, int64(tt.dataSize), 3*1024, false)
+	decoder := DecodeReaders(ctx, zaptest.NewLogger(t), readerMap, rs, int64(tt.dataSize), 3*1024, false)
 	defer func() { assert.NoError(t, decoder.Close()) }()
 	data2, err := ioutil.ReadAll(decoder)
 	if tt.fail {

--- a/uplink/eestream/stripe.go
+++ b/uplink/eestream/stripe.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/vivint/infectious"
+	"go.uber.org/zap"
 	monkit "gopkg.in/spacemonkeygo/monkit.v2"
 )
 
@@ -33,7 +34,7 @@ type StripeReader struct {
 
 // NewStripeReader creates a new StripeReader from the given readers, erasure
 // scheme and max buffer memory.
-func NewStripeReader(rs map[int]io.ReadCloser, es ErasureScheme, mbm int, forceErrorDetection bool) *StripeReader {
+func NewStripeReader(log *zap.Logger, rs map[int]io.ReadCloser, es ErasureScheme, mbm int, forceErrorDetection bool) *StripeReader {
 	readerCount := len(rs)
 
 	r := &StripeReader{
@@ -55,7 +56,7 @@ func NewStripeReader(rs map[int]io.ReadCloser, es ErasureScheme, mbm int, forceE
 
 	for i := range rs {
 		r.inbufs[i] = make([]byte, es.ErasureShareSize())
-		r.bufs[i] = NewPieceBuffer(make([]byte, bufSize), es.ErasureShareSize(), r.cond)
+		r.bufs[i] = NewPieceBuffer(log, make([]byte, bufSize), es.ErasureShareSize(), r.cond)
 		// Kick off a goroutine each reader to be copied into a PieceBuffer.
 		go func(r io.Reader, buf *PieceBuffer) {
 			_, err := io.Copy(buf, r)

--- a/versioncontrol/peer.go
+++ b/versioncontrol/peer.go
@@ -61,12 +61,12 @@ func (peer *Peer) HandleGet(w http.ResponseWriter, r *http.Request) {
 	if xfor = r.Header.Get("X-Forwarded-For"); xfor == "" {
 		xfor = r.RemoteAddr
 	}
-	zap.S().Debugf("Request from: %s for %s", r.RemoteAddr, xfor)
+	peer.Log.Sugar().Debugf("Request from: %s for %s", r.RemoteAddr, xfor)
 
 	w.Header().Set("Content-Type", "application/json")
 	_, err := w.Write(peer.response)
 	if err != nil {
-		zap.S().Errorf("error writing response to client: %v", err)
+		peer.Log.Sugar().Errorf("error writing response to client: %v", err)
 	}
 }
 


### PR DESCRIPTION
What: Don't use global loggers to ensure that the messages are properly scoped and silenced (when requested).

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
