### PR TITLE
satellite/overlay: reduce calls to UpdateAddress

### DIFF
--- a/satellite/overlay/combinedcache.go
+++ b/satellite/overlay/combinedcache.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package overlay
+
+import (
+	"context"
+	"sync"
+
+	"storj.io/storj/pkg/pb"
+	"storj.io/storj/pkg/storj"
+)
+
+type addressInfo struct {
+	address   string
+	lastIP    string
+	transport pb.NodeTransport
+}
+
+// CombinedCache is a simple caching mechanism for overlaycache updates. It
+// provdes methods to help reduce calls to UpdateAddress and UpdateTime, but can
+// be extended for other calls in the future.
+type CombinedCache struct {
+	DB
+	addressLock  sync.RWMutex
+	addressCache map[storj.NodeID]*addressInfo
+
+	keyLock *KeyLock
+}
+
+// NewCombinedCache instantiates a new CombinedCache
+func NewCombinedCache(db DB) *CombinedCache {
+	return &CombinedCache{
+		DB:           db,
+		addressCache: make(map[storj.NodeID]*addressInfo),
+		keyLock:      NewKeyLock(),
+	}
+}
+
+// UpdateAddress overrides the underlying db.UpdateAddress and provides a simple
+// caching layer to reduce calls to the underlying db. The cache is guaranteed
+// to match the values held in the database; however this code does not
+// guarantee that concurrent UpdateAddress calls will be handled in any
+// particular order.
+func (c *CombinedCache) UpdateAddress(ctx context.Context, info *pb.Node, defaults NodeSelectionConfig) (err error) {
+	// Update internal cache and check if this call requires a db call
+
+	if info == nil {
+		return ErrEmptyNode
+	}
+
+	address := info.Address
+	if address == nil {
+		address = &pb.NodeAddress{}
+	}
+
+	c.addressLock.RLock()
+	cached, ok := c.addressCache[info.Id]
+	c.addressLock.RUnlock()
+
+	if ok &&
+		address.Address == cached.address &&
+		address.Transport == cached.transport &&
+		info.LastIp == cached.lastIP {
+
+		return nil
+	}
+
+	// Acquire lock for this node ID. This prevents a concurrent db update to
+	// this same node ID and guarantees the cache and database stay in sync.
+	// This solution works so long as calls to this code are occurring within a
+	// single process.
+	unlockFunc := c.keyLock.Lock(info.Id)
+	defer unlockFunc()
+
+	err = c.DB.UpdateAddress(ctx, info, defaults)
+	if err != nil {
+		return err
+	}
+
+	c.addressLock.Lock()
+	c.addressCache[info.Id] = &addressInfo{
+		address:   address.Address,
+		lastIP:    info.LastIp,
+		transport: address.Transport,
+	}
+	c.addressLock.Unlock()
+
+	return nil
+}

--- a/satellite/overlay/keylock.go
+++ b/satellite/overlay/keylock.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information
+
+package overlay
+
+import (
+	"sync"
+
+	"storj.io/storj/pkg/storj"
+)
+
+// KeyLock provides per-key RW locking. Locking is key-specific, meaning lock
+// contention only exists for locking calls using the same key parameter. As
+// with all locks, do not call Unlock() or RUnlock() before a corresponding
+// Lock() or RLock() call.
+//
+// Note on memory usage: internally KeyLock lazily and atomically creates a
+// separate sync.RWMutex for each key. To maintain synchronization guarantees,
+// these interal mutexes are not freed until the entire KeyLock instance is
+// freed.
+type KeyLock struct {
+	locksMu sync.Mutex
+	locks   map[storj.NodeID]*sync.RWMutex
+}
+
+// UnlockFunc is the function to unlock the associated successful lock
+type UnlockFunc func()
+
+// NewKeyLock create a new KeyLock
+func NewKeyLock() *KeyLock {
+	return &KeyLock{
+		locks: make(map[storj.NodeID]*sync.RWMutex),
+	}
+}
+
+// Lock the provided key. Returns the unlock function.
+func (l *KeyLock) Lock(nodeID storj.NodeID) UnlockFunc {
+	lock := l.getLock(nodeID)
+	lock.Lock()
+	return lock.Unlock
+}
+
+// RLock the provided key. Returns the unlock function.
+func (l *KeyLock) RLock(nodeID storj.NodeID) UnlockFunc {
+	lock := l.getLock(nodeID)
+	lock.RLock()
+	return lock.RUnlock
+}
+
+// getLock will atomically load the RWMutex for this key. If one does not yet
+// exist, it will be lazily and atomically created. The resulting RWMutex is
+// returned.
+func (l *KeyLock) getLock(nodeID storj.NodeID) *sync.RWMutex {
+	l.locksMu.Lock()
+	defer l.locksMu.Unlock()
+
+	lo, ok := l.locks[nodeID]
+	if ok {
+		return lo
+	}
+	mu := &sync.RWMutex{}
+	l.locks[nodeID] = mu
+	return mu
+}

--- a/satellite/overlay/keylock_test.go
+++ b/satellite/overlay/keylock_test.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information
+
+package overlay_test
+
+import (
+	"testing"
+
+	"storj.io/storj/internal/testrand"
+	"storj.io/storj/internal/teststorj"
+	"storj.io/storj/pkg/storj"
+	"storj.io/storj/satellite/overlay"
+)
+
+func TestKeyLock(t *testing.T) {
+	ml := overlay.NewKeyLock()
+	key := teststorj.NodeIDFromString("hi")
+	unlockFunc := ml.Lock(key)
+	unlockFunc()
+	unlockFunc = ml.RLock(key)
+	unlockFunc()
+}
+
+func BenchmarkKeyLock(b *testing.B) {
+	b.ReportAllocs()
+	ml := overlay.NewKeyLock()
+	numNodes := 100
+	nodeIDs := make([]storj.NodeID, numNodes)
+	for i := 0; i < numNodes; i++ {
+		nodeIDs[i] = testrand.NodeID()
+	}
+	b.Run("lock all new nodes", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			unlockFunc := ml.Lock(testrand.NodeID())
+			unlockFunc()
+		}
+	})
+	b.Run("lock existing nodes", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			idx := i % numNodes
+			unlockFunc := ml.Lock(nodeIDs[idx])
+			unlockFunc()
+		}
+	})
+	b.Run("rlock existing nodes", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			idx := i % numNodes
+			unlockFunc := ml.RLock(nodeIDs[idx])
+			unlockFunc()
+		}
+	})
+}

--- a/satellite/overlay/service.go
+++ b/satellite/overlay/service.go
@@ -305,6 +305,7 @@ func (service *Service) Put(ctx context.Context, nodeID storj.NodeID, value pb.N
 	if value.Address == nil {
 		return errors.New("node has no address")
 	}
+
 	// Resolve IP Address Network to ensure it is set
 	value.LastIp, err = GetNetwork(ctx, value.Address.Address)
 	if err != nil {

--- a/satellite/overlay/statdb_test.go
+++ b/satellite/overlay/statdb_test.go
@@ -26,6 +26,12 @@ func TestStatDB(t *testing.T) {
 
 		testDatabase(ctx, t, db.OverlayCache())
 	})
+	satellitedbtest.Run(t, func(t *testing.T, db satellite.DB) {
+		ctx := testcontext.New(t)
+		defer ctx.Cleanup()
+
+		testDatabase(ctx, t, overlay.NewCombinedCache(db.OverlayCache()))
+	})
 }
 
 func testDatabase(ctx context.Context, t *testing.T, cache overlay.DB) {


### PR DESCRIPTION
What: We frequently call UpdateAddress in the overlaycache. This is causing issues with database performance. This is a quick fix that reduces those calls.

It adds an in-memory cache that checks whether the address has changed from before in the UpdateAddress call.

Why: Database performance is suffering due to so many UpdateAddress calls.

Please describe the tests:
 - Test 1: New unit tests confirm that the caching mechanism works as designed.
 
Please describe the performance impact: This should great improve database performance by greatly reducing UpdateAddress calls.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
