### PR TITLE
docs/design: Remove "Title" word from title header

### DIFF
--- a/docs/design/TEMPLATE.md
+++ b/docs/design/TEMPLATE.md
@@ -1,6 +1,6 @@
 [This is a template for Storj v3 design docs]
 
-# Title: [Title]
+# [Title]
 
 ## Abstract
 


### PR DESCRIPTION
What: remove _"title"_ word from the title header. 

Why: because there is no need to mention that's the title of the document.

Please describe the tests: N/A
Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
