### PR TITLE
Add 24 hours to account for the entire rest of the end day when do accounting exports

### DIFF
--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -221,6 +221,9 @@ func cmdNodeUsage(cmd *cobra.Command, args []string) (err error) {
 		return errs.New("Invalid date format. Please use YYYY-MM-DD")
 	}
 
+	//Adding one day to properly account for the entire end day
+	end = end.Add(time.Hour * 24)
+
 	// Ensure that start date is not after end date
 	if start.After(end) {
 		return errs.New("Invalid time period (%v) - (%v)", start, end)


### PR DESCRIPTION
What: Add 24 hours to the end day to account properly

Why: It is weird to account from 01st to 01st of the next month.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
