### PR TITLE
C require macros improvements

### DIFF
--- a/lib/uplinkc/testdata/require.h
+++ b/lib/uplinkc/testdata/require.h
@@ -4,7 +4,7 @@
 #define require(test) \
 do { \
     if(!(test)) { \
-        printf("failed:\n\t%s:%d: %s", __FILE__, __LINE__, #test);\
+        printf("failed:\n\t%s:%d: %s\n", __FILE__, __LINE__, #test);\
         exit(1);\
     }\
 } while (0)
@@ -13,7 +13,7 @@ do { \
 do { \
     if(!(test)) { \
         printf(msg, ##__VA_ARGS__);\
-        printf("failed:\n\t%s:%d: %s", __FILE__, __LINE__, #test);\
+        printf("failed:\n\t%s:%d: %s\n", __FILE__, __LINE__, #test);\
         exit(1);\
     }\
 } while (0)
@@ -21,7 +21,7 @@ do { \
 #define require_noerror(err) \
 do { \
     if(strcmp("", err) != 0) { \
-        printf("failed:\n\t%s:%d: %s", __FILE__, __LINE__, err);\
+        printf("failed:\n\t%s:%d: %s\n", __FILE__, __LINE__, err);\
         exit(1);\
     }\
 } while (0)


### PR DESCRIPTION
What: Add a new line the require macros' print statements.

Why: So that the shell prompt starts on a new line when a require assertion fails.

Please describe the tests:
N/A
 
Please describe the performance impact:
N/A

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
