### PR TITLE
look at delete object function

### DIFF
--- a/lib/uplink/bucket.go
+++ b/lib/uplink/bucket.go
@@ -108,6 +108,30 @@ func (b *Bucket) UploadObject(ctx context.Context, path storj.Path, data io.Read
 	return errs.Combine(err, upload.Close())
 }
 
+/*  TODO:
+
+
+// delete_object_custom removes a object(s) from a given Storj (V3) bucket path
+//export delete_object_custom
+func delete_object_custom(bucketRef C.BucketRef, path *C.char, cerr **C.char) {
+	bucket, ok := universe.Get(bucketRef._handle).(*Bucket)
+	if !ok {
+		*cerr = C.CString("invalid bucket")
+		return
+	}
+
+	scope := bucket.scope.child()
+
+	if err := bucket.DeleteObject(scope.ctx, C.GoString(path)); err != nil {
+		*cerr = C.CString(fmt.Sprintf("%+v", err))
+		return
+	}
+}
+
+
+*/
+
+
 // DeleteObject removes an object, if authorized.
 func (b *Bucket) DeleteObject(ctx context.Context, path storj.Path) (err error) {
 	defer mon.Task()(&ctx)(&err)

--- a/lib/uplink/bucket.go
+++ b/lib/uplink/bucket.go
@@ -108,29 +108,6 @@ func (b *Bucket) UploadObject(ctx context.Context, path storj.Path, data io.Read
 	return errs.Combine(err, upload.Close())
 }
 
-/*  TODO:
-
-
-// delete_object_custom removes a object(s) from a given Storj (V3) bucket path
-//export delete_object_custom
-func delete_object_custom(bucketRef C.BucketRef, path *C.char, cerr **C.char) {
-	bucket, ok := universe.Get(bucketRef._handle).(*Bucket)
-	if !ok {
-		*cerr = C.CString("invalid bucket")
-		return
-	}
-
-	scope := bucket.scope.child()
-
-	if err := bucket.DeleteObject(scope.ctx, C.GoString(path)); err != nil {
-		*cerr = C.CString(fmt.Sprintf("%+v", err))
-		return
-	}
-}
-
-
-*/
-
 
 // DeleteObject removes an object, if authorized.
 func (b *Bucket) DeleteObject(ctx context.Context, path storj.Path) (err error) {

--- a/lib/uplinkc/object.go
+++ b/lib/uplinkc/object.go
@@ -351,10 +351,14 @@ func delete_object(bucketRef C.BucketRef, path *C.char, cerr **C.char) {
 		return
 	}
 
-	if err := bucket.DeleteObject(bucket.ctx, C.GoString(path)); err != nil {
+	scope := bucket.scope.child()
+
+	if err := bucket.DeleteObject(scope.ctx, C.GoString(path)); err != nil {
 		*cerr = C.CString(fmt.Sprintf("%+v", err))
 		return
 	}
+	
+	
 }
 
 //export free_uploader


### PR DESCRIPTION
Is the correct context being used?  We're currently having to get the child's context to perform the delete:



	scope := bucket.scope.child()

	if err := bucket.DeleteObject(scope.ctx, C.GoString(path)); err != nil {
		*cerr = C.CString(fmt.Sprintf("%+v", err))
		return
	}


What: Is the default context being used the correct context to delete an object from?

Why: Accessing the correct context for object operations

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
