### PR TITLE
architecture-owner codeowners for design docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
+# In general, PRs will be assigned random reviewers from the core team
 * @storj/core-pullassigner
+
+# Design docs will get a random architecture owner
+/docs/design/ @storj/arch-pullassigner

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # In general, PRs will be assigned random reviewers from the core team
-* @storj/core-pullassigner
+* @storj/reviewers-pullassigner
 
 # Design docs will get a random architecture owner
 /docs/design/ @storj/arch-pullassigner


### PR DESCRIPTION
specify architecture owners for design doc reviews