### PR TITLE
uplink/ecclient: performance - do not call Downloader.Close()

### DIFF
--- a/uplink/ecclient/client.go
+++ b/uplink/ecclient/client.go
@@ -494,10 +494,7 @@ type clientCloser struct {
 }
 
 func (client *clientCloser) Close() error {
-	return errs.Combine(
-		client.Downloader.Close(),
-		client.client.Close(),
-	)
+	return client.client.Close()
 }
 
 func nonNilCount(limits []*pb.AddressedOrderLimit) int {


### PR DESCRIPTION
What: 
Instead of closing the grpc ClientStream for a download, and waiting for that to finish, close the underlying grpc ClientConn so we don't have to wait. This has the following performance benefit:

Downloading a 10mb file is on average 3 seconds faster with the change.

`time uplink cp sj://test/10mb.txt ./10mb.txt`

10 downloads with `client.Downloader.Close()` and `client.client.Close()`:
```
real    0m11.046s	0m12.344s 	0m10.895s	0m9.467s	0m11.216s 	0m9.912s	0m11.586s 	0m11.112s 	0m11.634s	0m10.171s
user    0m1.239s	0m1.439s	0m1.541s	0m1.410s	0m1.629s  	0m1.397s	0m1.517s	0m1.439s 	0m1.314s 	0m1.456s
sys     0m0.502s	0m0.566s 	0m0.618s	0m0.645s 	0m0.544s 	0m0.536s 	0m0.586s	0m0.509s	0m0.654s 	0m0.576s

min
real	0m9.467s	
user	0m1.410s	
sys	0m0.544s

max
real	0m12.344s
user	0m1.439s
sys	0m0.566s

avg
real	0m10.938s
user	0m1.438s
sys	0m0.574s
```

10 downloads with only `client.client.Close()`:
```
real    0m7.022s	0m8.467s	0m10.365s	0m9.284s	0m6.775s	0m7.959s	0m4.815s 	0m8.179s	0m7.671s	0m7.756s
user    0m1.501s	0m1.428s 	0m1.350s	0m1.255s	0m1.450s	0m1.260s	0m1.441s	0m1.396s	0m1.531s	0m1.508s
sys     0m0.549s	0m0.438s	0m0.459s	0m0.544s	0m0.523s	0m0.472s	0m0.508s	0m0.470s	0m0.560s	0m0.461s


min
real	0m4.815s
user	0m1.441s
sys	0m0.508s

max
real	0m10.365s
user	0m1.350s
sys	0m0.459s

avg
real	0m7.829s
user	0m1.412s
sys	0m0.498s
```

Why: https://storjlabs.atlassian.net/browse/V3-2245

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
