### PR TITLE
Updates the pkg/identity support encode and decode functionality of Peer Identity information

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -9,6 +9,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -526,4 +527,42 @@ func backupPath(path string) string {
 		strconv.Itoa(int(time.Now().Unix())),
 		pathExt,
 	)
+}
+
+// EncodePeerIdentity encodes the complete idenitity chain to bytes
+func EncodePeerIdentity(pi *PeerIdentity) []byte {
+	var chain []byte
+	chain = append(chain, pi.Leaf.Raw...)
+	chain = append(chain, pi.CA.Raw...)
+	for _, cert := range pi.RestChain {
+		chain = append(chain, cert.Raw...)
+	}
+	return chain
+}
+
+// DecodePeerIdentity Decodes the bytes into complete idenitity chain
+func DecodePeerIdentity(ctx context.Context, chain []byte) (_ *PeerIdentity, err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	var certs []*x509.Certificate
+	for len(chain) > 0 {
+		var raw asn1.RawValue
+		var err error
+
+		chain, err = asn1.Unmarshal(chain, &raw)
+		if err != nil {
+			return nil, Error.Wrap(err)
+		}
+
+		cert, err := pkcrypto.CertFromDER(raw.FullBytes)
+		if err != nil {
+			return nil, Error.Wrap(err)
+		}
+
+		certs = append(certs, cert)
+	}
+	if len(certs) < 2 {
+		return nil, Error.New("not enough certificates")
+	}
+	return PeerIdentityFromChain(certs)
 }

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -304,3 +304,22 @@ func TestManageableFullIdentity_Revoke(t *testing.T) {
 	err = rev.Verify(manageableFullIdentity.CA.Cert)
 	require.NoError(t, err)
 }
+
+func TestEncodeDecodePeerIdentity(t *testing.T) {
+	ctx := testcontext.New(t)
+	defer ctx.Cleanup()
+
+	peerID, err := testidentity.NewTestIdentity(ctx)
+	require.NoError(t, err)
+	pi := peerID.PeerIdentity()
+
+	// encode the peer identity
+	encodedPiBytes := identity.EncodePeerIdentity(pi)
+	assert.NotNil(t, encodedPiBytes)
+	// decode the peer identity
+	decodedPi, err := identity.DecodePeerIdentity(ctx, encodedPiBytes)
+	assert.NoError(t, err)
+	// again encode the above decoded peer identity and compare
+	decodedPiBytes := identity.EncodePeerIdentity(decodedPi)
+	assert.Equal(t, encodedPiBytes, decodedPiBytes)
+}


### PR DESCRIPTION
What: Updates the Identity packet to support encoding/decoding of the peer Identity to/From bytes, which can be used to save the whole chain of peer identities in database that stores these information. 
Why:
This PR  is a sub task of the a big feature as described in V3-1992 epic. The V3-1992 will be divided into 6 PRs. This is the first of the 6 PRs.

**The 6 PRs would be as shown below:**
1.  make the encode /decode changes  into the pkg/identities ( PR #2754 )
2. remove certdb (because the design changed quite drastically)
3. implement new certdb (dbx and interface and tests)
4. fix those bootstrap error outputting debug info
5. fix the segment debug outputing info (edited) 
6. wire up the new certdb (edited) 

Please describe the tests:
 - Test 1:adds test function to encode
 - Test 2:adds test function to decode
 - Test 3: compares the peer identities by first encodes, then decodes,  and then compares decoded data with the original information used in encoding. 
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
