### PR TITLE
satellie/gc: enable garbage collection on the satellite

### DIFF
--- a/satellite/gc/service.go
+++ b/satellite/gc/service.go
@@ -29,8 +29,8 @@ var (
 
 // Config contains configurable values for garbage collection
 type Config struct {
-	Interval time.Duration `help:"the time between each send of garbage collection filters to storage nodes" releaseDefault:"168h" devDefault:"10m"`
-	Enabled  bool          `help:"set if garbage collection is enabled or not" releaseDefault:"false" devDefault:"true"`
+	Interval time.Duration `help:"the time between each send of garbage collection filters to storage nodes" releaseDefault:"120h" devDefault:"10m"`
+	Enabled  bool          `help:"set if garbage collection is enabled or not" releaseDefault:"true" devDefault:"true"`
 	// value for InitialPieces currently based on average pieces per node
 	InitialPieces     int     `help:"the initial number of pieces expected for a storage node to have, used for creating a filter" releaseDefault:"400000" devDefault:"10"`
 	FalsePositiveRate float64 `help:"the false positive rate used for creating a garbage collection bloom filter" releaseDefault:"0.1" devDefault:"0.1"`

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -74,7 +74,7 @@
 # garbage-collection.concurrent-sends: 1
 
 # set if garbage collection is enabled or not
-# garbage-collection.enabled: false
+# garbage-collection.enabled: true
 
 # the false positive rate used for creating a garbage collection bloom filter
 # garbage-collection.false-positive-rate: 0.1
@@ -83,7 +83,7 @@
 # garbage-collection.initial-pieces: 400000
 
 # the time between each send of garbage collection filters to storage nodes
-# garbage-collection.interval: 168h0m0s
+# garbage-collection.interval: 120h0m0s
 
 # help for setup
 # help: false


### PR DESCRIPTION
What: Enable garbage collection on the satellite side. Don't enable it on the storage node.

Why: Garbage collection is working great on the satellite side. We don't see any performance impact. We can go ahead and enable it on all satellites. On the storage node side we can't because there is an annoying timeout issue.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
