### PR TITLE
lib/uplink: remove Seek method

### DIFF
--- a/internal/testplanet/uplink.go
+++ b/internal/testplanet/uplink.go
@@ -251,7 +251,7 @@ func (client *Uplink) DownloadStream(ctx context.Context, satellite *satellite.P
 		return err
 	}
 
-	downloader, err := bucket.NewReader(ctx, path)
+	downloader, err := bucket.Download(ctx, path)
 	return downloader, cleanup, err
 }
 

--- a/internal/testplanet/uplink.go
+++ b/internal/testplanet/uplink.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"strconv"
 	"time"
@@ -236,7 +237,7 @@ func (client *Uplink) Download(ctx context.Context, satellite *satellite.Peer, b
 }
 
 // DownloadStream returns stream for downloading data
-func (client *Uplink) DownloadStream(ctx context.Context, satellite *satellite.Peer, bucketName string, path storj.Path) (_ libuplink.ReadSeekCloser, cleanup func() error, err error) {
+func (client *Uplink) DownloadStream(ctx context.Context, satellite *satellite.Peer, bucketName string, path storj.Path) (_ io.ReadCloser, cleanup func() error, err error) {
 	project, bucket, err := client.GetProjectAndBucket(ctx, satellite, bucketName, client.GetConfig(satellite))
 	if err != nil {
 		return nil, nil, err
@@ -251,6 +252,25 @@ func (client *Uplink) DownloadStream(ctx context.Context, satellite *satellite.P
 	}
 
 	downloader, err := bucket.NewReader(ctx, path)
+	return downloader, cleanup, err
+}
+
+// DownloadStreamRange returns stream for downloading data
+func (client *Uplink) DownloadStreamRange(ctx context.Context, satellite *satellite.Peer, bucketName string, path storj.Path, start, limit int64) (_ io.ReadCloser, cleanup func() error, err error) {
+	project, bucket, err := client.GetProjectAndBucket(ctx, satellite, bucketName, client.GetConfig(satellite))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cleanup = func() error {
+		err = errs.Combine(err,
+			project.Close(),
+			bucket.Close(),
+		)
+		return err
+	}
+
+	downloader, err := bucket.DownloadRange(ctx, path, start, limit)
 	return downloader, cleanup, err
 }
 

--- a/lib/uplink/bucket.go
+++ b/lib/uplink/bucket.go
@@ -192,7 +192,7 @@ func (b *Bucket) NewReader(ctx context.Context, path storj.Path) (_ io.ReadClose
 	return stream.NewDownload(ctx, segmentStream, b.streams), nil
 }
 
-// DownloadRange creates a new reader that downloads the object data.
+// DownloadRange creates a new reader that downloads the object data starting from start and upto start + limit.
 func (b *Bucket) DownloadRange(ctx context.Context, path storj.Path, start, limit int64) (_ io.ReadCloser, err error) {
 	defer mon.Task()(&ctx)(&err)
 

--- a/lib/uplink/bucket.go
+++ b/lib/uplink/bucket.go
@@ -181,7 +181,14 @@ func (b *Bucket) NewWriter(ctx context.Context, path storj.Path, opts *UploadOpt
 }
 
 // NewReader creates a new reader that downloads the object data.
+//
+// Deprecated: use Download or DownloadRange instead.
 func (b *Bucket) NewReader(ctx context.Context, path storj.Path) (_ io.ReadCloser, err error) {
+	return b.Download(ctx, path)
+}
+
+// Download creates a new reader that downloads the object data.
+func (b *Bucket) Download(ctx context.Context, path storj.Path) (_ io.ReadCloser, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	segmentStream, err := b.metainfo.GetObjectStream(ctx, b.Name, path)

--- a/lib/uplink/bucket.go
+++ b/lib/uplink/bucket.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/zeebo/errs"
 
-	"storj.io/storj/internal/readcloser"
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/uplink/metainfo/kvmetainfo"
 	"storj.io/storj/uplink/storage/streams"
@@ -190,7 +189,7 @@ func (b *Bucket) NewReader(ctx context.Context, path storj.Path) (_ io.ReadClose
 		return nil, err
 	}
 
-	return stream.NewDownload(ctx, segmentStream, b.streams, 0), nil
+	return stream.NewDownload(ctx, segmentStream, b.streams), nil
 }
 
 // DownloadRange creates a new reader that downloads the object data.
@@ -202,11 +201,7 @@ func (b *Bucket) DownloadRange(ctx context.Context, path storj.Path, start, limi
 		return nil, err
 	}
 
-	download := stream.NewDownload(ctx, segmentStream, b.streams, start)
-	if limit < 0 {
-		return download, nil
-	}
-	return readcloser.LimitReadCloser(download, limit), nil
+	return stream.NewDownloadRange(ctx, segmentStream, b.streams, start, limit), nil
 }
 
 // Close closes the Bucket session.

--- a/lib/uplink/list_test.go
+++ b/lib/uplink/list_test.go
@@ -215,7 +215,7 @@ func runTest(ctx context.Context, t *testing.T, apiKey, satelliteAddr string,
 
 	// Download all files, make sure they work
 	for _, path := range test.paths {
-		r, err := bu.NewReader(ctx, path)
+		r, err := bu.Download(ctx, path)
 		require.NoError(t, err)
 		downloaded, err := ioutil.ReadAll(r)
 		require.NoError(t, err)

--- a/lib/uplink/list_test.go
+++ b/lib/uplink/list_test.go
@@ -217,9 +217,12 @@ func runTest(ctx context.Context, t *testing.T, apiKey, satelliteAddr string,
 	for _, path := range test.paths {
 		r, err := bu.Download(ctx, path)
 		require.NoError(t, err)
+
 		downloaded, err := ioutil.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, fmt.Sprintf("%s%s", path, "hi"), string(downloaded))
+
+		require.NoError(t, r.Close())
 	}
 
 }

--- a/lib/uplink/object.go
+++ b/lib/uplink/object.go
@@ -88,12 +88,7 @@ func (o *Object) DownloadRange(ctx context.Context, offset, length int64) (_ io.
 		return nil, err
 	}
 
-	download := stream.NewDownload(ctx, readOnlyStream, o.streams)
-	_, err = download.Seek(offset, io.SeekStart)
-	if err != nil {
-		return nil, err
-	}
-
+	download := stream.NewDownload(ctx, readOnlyStream, o.streams, offset)
 	if length == -1 {
 		return download, nil
 	}

--- a/lib/uplink/object.go
+++ b/lib/uplink/object.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"time"
 
-	"storj.io/storj/internal/readcloser"
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/uplink/metainfo/kvmetainfo"
 	"storj.io/storj/uplink/storage/streams"
@@ -78,22 +77,16 @@ type Object struct {
 	streams    streams.Store
 }
 
-// DownloadRange returns an Object's data. A length of -1 will mean
-// (Object.Size - offset).
+// DownloadRange returns an Object's data. A length of -1 will mean (Object.Size - offset).
 func (o *Object) DownloadRange(ctx context.Context, offset, length int64) (_ io.ReadCloser, err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	readOnlyStream, err := o.metainfoDB.GetObjectStream(ctx, o.Meta.Bucket, o.Meta.Path)
+	segmentStream, err := o.metainfoDB.GetObjectStream(ctx, o.Meta.Bucket, o.Meta.Path)
 	if err != nil {
 		return nil, err
 	}
 
-	download := stream.NewDownload(ctx, readOnlyStream, o.streams, offset)
-	if length == -1 {
-		return download, nil
-	}
-
-	return readcloser.LimitReadCloser(download, length), nil
+	return stream.NewDownloadRange(ctx, segmentStream, o.streams, offset, length), nil
 }
 
 // Close closes the Object.

--- a/lib/uplinkc/object.go
+++ b/lib/uplinkc/object.go
@@ -264,7 +264,7 @@ func download(bucketRef C.BucketRef, path *C.char, cErr **C.char) C.DownloaderRe
 
 	scope := bucket.scope.child()
 
-	rc, err := bucket.NewReader(scope.ctx, C.GoString(path))
+	rc, err := bucket.Download(scope.ctx, C.GoString(path))
 	if err != nil {
 		if !errs2.IsCanceled(err) {
 			*cErr = C.CString(fmt.Sprintf("%+v", err))

--- a/lib/uplinkc/object.go
+++ b/lib/uplinkc/object.go
@@ -251,7 +251,6 @@ type Download struct {
 	scope
 	rc interface {
 		io.Reader
-		io.Seeker
 		io.Closer
 	}
 }

--- a/lib/uplinkc/object.go
+++ b/lib/uplinkc/object.go
@@ -249,10 +249,7 @@ func list_objects(bucketRef C.BucketRef, cListOpts *C.ListOptions, cErr **C.char
 // Download stores readcloser and context scope for downloading
 type Download struct {
 	scope
-	rc interface {
-		io.Reader
-		io.Closer
-	}
+	rc io.ReadCloser
 }
 
 //export download

--- a/mobile/bucket.go
+++ b/mobile/bucket.go
@@ -308,10 +308,7 @@ type ReaderOptions struct {
 type Reader struct {
 	scope
 	readError error
-	reader    interface {
-		io.Reader
-		io.Closer
-	}
+	reader    io.ReadCloser
 }
 
 // NewReader returns new reader for downloading object

--- a/mobile/bucket.go
+++ b/mobile/bucket.go
@@ -310,7 +310,6 @@ type Reader struct {
 	readError error
 	reader    interface {
 		io.Reader
-		io.Seeker
 		io.Closer
 	}
 }

--- a/mobile/bucket.go
+++ b/mobile/bucket.go
@@ -311,11 +311,11 @@ type Reader struct {
 	reader    io.ReadCloser
 }
 
-// NewReader returns new reader for downloading object
+// NewReader returns new reader for downloading object.
 func (bucket *Bucket) NewReader(path storj.Path, options *ReaderOptions) (*Reader, error) {
 	scope := bucket.scope.child()
 
-	reader, err := bucket.lib.NewReader(scope.ctx, path)
+	reader, err := bucket.lib.Download(scope.ctx, path)
 	if err != nil {
 		return nil, safeError(err)
 	}

--- a/storagenode/piecestore/endpoint_test.go
+++ b/storagenode/piecestore/endpoint_test.go
@@ -65,12 +65,9 @@ func TestUploadAndPartialDownload(t *testing.T) {
 			}
 			totalDownload += piecestore.DefaultConfig.InitialStep
 
-			download, cleanup, err := planet.Uplinks[0].DownloadStream(ctx, planet.Satellites[0], "testbucket", "test/path")
+			download, cleanup, err := planet.Uplinks[0].DownloadStreamRange(ctx, planet.Satellites[0], "testbucket", "test/path", tt.offset, -1)
 			require.NoError(t, err)
 			defer ctx.Check(cleanup)
-			pos, err := download.Seek(tt.offset, io.SeekStart)
-			require.NoError(t, err)
-			assert.Equal(t, pos, tt.offset)
 
 			data := make([]byte, tt.size)
 			n, err := io.ReadFull(download, data)

--- a/uplink/metainfo/kvmetainfo/objects_test.go
+++ b/uplink/metainfo/kvmetainfo/objects_test.go
@@ -198,7 +198,7 @@ func assertStream(ctx context.Context, t *testing.T, db *kvmetainfo.DB, streams 
 		assertInlineSegment(t, segments[0], content)
 	}
 
-	download := stream.NewDownload(ctx, readOnly, streams)
+	download := stream.NewDownload(ctx, readOnly, streams, 0)
 	defer func() {
 		err = download.Close()
 		assert.NoError(t, err)

--- a/uplink/metainfo/kvmetainfo/objects_test.go
+++ b/uplink/metainfo/kvmetainfo/objects_test.go
@@ -198,7 +198,7 @@ func assertStream(ctx context.Context, t *testing.T, db *kvmetainfo.DB, streams 
 		assertInlineSegment(t, segments[0], content)
 	}
 
-	download := stream.NewDownload(ctx, readOnly, streams, 0)
+	download := stream.NewDownload(ctx, readOnly, streams)
 	defer func() {
 		err = download.Close()
 		assert.NoError(t, err)

--- a/uplink/stream/download.go
+++ b/uplink/stream/download.go
@@ -32,7 +32,7 @@ func NewDownload(ctx context.Context, stream storj.ReadOnlyStream, streams strea
 	}
 }
 
-// NewDownloadRange creates new stream range download.
+// NewDownloadRange creates new stream range download with range from offset to offset+limit.
 func NewDownloadRange(ctx context.Context, stream storj.ReadOnlyStream, streams streams.Store, offset, limit int64) *Download {
 	return &Download{
 		ctx:     ctx,

--- a/uplink/stream/download.go
+++ b/uplink/stream/download.go
@@ -64,7 +64,7 @@ func (download *Download) Read(data []byte) (n int, err error) {
 	if download.limit == 0 {
 		return 0, io.EOF
 	}
-	if download.limit > 0 && download.limit > int64(len(data)) {
+	if download.limit > 0 && download.limit < int64(len(data)) {
 		data = data[:download.limit]
 	}
 	n, err = download.reader.Read(data)


### PR DESCRIPTION
We currently don't support an efficient Seek interface, so it is better to not expose it for the time being. This PR removes support for Seek.

Supersedes #2299, however, the object information addition would be a separate PR.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
