### PR TITLE
uplink/piecestore: handle Download errors better

### DIFF
--- a/satellite/orders/orders_test.go
+++ b/satellite/orders/orders_test.go
@@ -131,6 +131,9 @@ func TestUploadDownloadBandwidth(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expectedData, data)
 
+		//HACKFIX: We need enough time to pass after the download ends for storagenodes to save orders
+		time.Sleep(200 * time.Millisecond)
+
 		var expectedBucketBandwidth int64
 		expectedStorageBandwidth := make(map[storj.NodeID]int64)
 		for _, storageNode := range planet.StorageNodes {

--- a/uplink/piecestore/download.go
+++ b/uplink/piecestore/download.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/zeebo/errs"
 
+	"storj.io/storj/internal/errs2"
 	"storj.io/storj/pkg/identity"
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/signing"
@@ -41,6 +42,9 @@ type Download struct {
 	allocationStep int64
 
 	unread ReadBuffer
+
+	closed       bool
+	closingError error
 }
 
 // Download starts a new download using the specified order limit at the specified offset and size.
@@ -100,16 +104,24 @@ func (client *Client) Download(ctx context.Context, limit *pb.OrderLimit, pieceP
 func (client *Download) Read(data []byte) (read int, err error) {
 	ctx := client.ctx
 	defer mon.Task()(&ctx, "node: "+client.peer.ID.String()[0:8])(&err)
+
+	if client.closed {
+		return 0, io.ErrClosedPipe
+	}
+
 	for client.read < client.downloadSize {
 		// read from buffer
 		n, err := client.unread.Read(data)
 		client.read += int64(n)
 		read += n
 
-		// if we have an error or are pending for an error, avoid further communication
-		// however we should still finish reading the unread data.
-		if err != nil || client.unread.Errored() {
+		// if we have an error return the error
+		if err != nil {
 			return read, err
+		}
+		// if we are pending for an error, avoid further requests, but try to finish what's in unread buffer.
+		if client.unread.Errored() {
+			return read, nil
 		}
 
 		// do we need to send a new order to storagenode
@@ -133,7 +145,10 @@ func (client *Download) Read(data []byte) (read int, err error) {
 					Amount:       newAllocation,
 				})
 				if err != nil {
+					// we are signing so we shouldn't propagate this into close,
+					// however we should include this as a read error
 					client.unread.IncludeError(err)
+					client.closeWithError(nil)
 					return read, nil
 				}
 
@@ -141,16 +156,22 @@ func (client *Download) Read(data []byte) (read int, err error) {
 					Order: order,
 				})
 				if err != nil {
-					// other side doesn't want to talk to us anymore,
-					// or network went down
+					// other side doesn't want to talk to us anymore or network went down
 					client.unread.IncludeError(err)
+					// if it's a cancellation, then we'll just close with context.Canceled
+					if errs2.IsCanceled(err) {
+						client.closeWithError(err)
+						return read, err
+					}
+					// otherwise, something else happened and we should try to ask the other side
+					client.closeAndTryFetchError()
 					return read, nil
 				}
 
 				// update our allocation step
 				client.allocationStep = client.client.nextAllocationStep(client.allocationStep)
 			}
-		} // if end allocation sending
+		}
 
 		// we have data, no need to wait for a chunk
 		if read > 0 {
@@ -164,8 +185,12 @@ func (client *Download) Read(data []byte) (read int, err error) {
 			client.unread.Fill(response.Chunk.Data)
 		}
 
-		// we still need to continue until we have actually handled all of the errors
-		client.unread.IncludeError(err)
+		// we may have some data buffered, so we cannot immediately return the error
+		// we'll queue the error and use the received error as the closing error
+		if err != nil {
+			client.unread.IncludeError(err)
+			client.handleClosingError(err)
+		}
 	}
 
 	// all downloaded
@@ -173,6 +198,37 @@ func (client *Download) Read(data []byte) (read int, err error) {
 		return 0, io.EOF
 	}
 	return read, nil
+}
+
+// handleClosingError should be used for an error that also closed the stream.
+func (client *Download) handleClosingError(err error) {
+	if client.closed {
+		return
+	}
+	client.closed = true
+	client.closingError = err
+}
+
+// closeWithError is used when we include the err in the closing error and also close the stream.
+func (client *Download) closeWithError(err error) {
+	if client.closed {
+		return
+	}
+	client.closed = true
+	client.closingError = errs.Combine(err, client.stream.CloseSend())
+}
+
+// closeAndTryFetchError closes the stream and also tries to fetch the actual error from the stream.
+func (client *Download) closeAndTryFetchError() {
+	if client.closed {
+		return
+	}
+	client.closed = true
+
+	client.closingError = client.stream.CloseSend()
+	if client.closingError == nil || client.closingError == io.EOF {
+		_, client.closingError = client.stream.Recv()
+	}
 }
 
 // Close closes the downloading.
@@ -185,25 +241,8 @@ func (client *Download) Close() (err error) {
 		}
 	}()
 
-	alldone := client.read == client.downloadSize
-
-	// close our sending end
-	closeErr := client.stream.CloseSend()
-	// try to read any pending error message
-	_, recvErr := client.stream.Recv()
-
-	if alldone {
-		// if we are all done, then we expecte io.EOF, but don't care about them
-		return errs.Combine(ignoreEOF(closeErr), ignoreEOF(recvErr))
-	}
-
-	if client.unread.Errored() {
-		// something went wrong and we didn't manage to download all the content
-		return errs.Combine(client.unread.Error(), closeErr, recvErr)
-	}
-
-	// we probably closed download early, so we can ignore io.EOF-s
-	return errs.Combine(ignoreEOF(closeErr), ignoreEOF(recvErr))
+	client.closeWithError(nil)
+	return client.closingError
 }
 
 // ReadBuffer implements buffered reading with an error.


### PR DESCRIPTION
What: Handle errors better such that we can call close without context cancellation problems. This should also get rid of the potential double closing of download.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
