### PR TITLE
storagenode: Add more test assertions

### DIFF
--- a/storagenode/orders/db_test.go
+++ b/storagenode/orders/db_test.go
@@ -149,13 +149,17 @@ func TestDB_Trivial(t *testing.T) {
 		}
 
 		{ // Ensure ListUnsent works at all
-			_, err := db.Orders().ListUnsent(ctx, 1)
+			infos, err := db.Orders().ListUnsent(ctx, 1)
 			require.NoError(t, err)
+			require.Len(t, infos, 1)
 		}
 
 		{ // Ensure ListUnsentBySatellite works at all
-			_, err := db.Orders().ListUnsentBySatellite(ctx)
+			infos, err := db.Orders().ListUnsentBySatellite(ctx)
 			require.NoError(t, err)
+			require.Len(t, infos, 1)
+			require.Contains(t, infos, satelliteID)
+			require.Len(t, infos[satelliteID], 1)
 		}
 
 		{ // Ensure Archive works at all
@@ -164,8 +168,9 @@ func TestDB_Trivial(t *testing.T) {
 		}
 
 		{ // Ensure ListArchived works at all
-			_, err := db.Orders().ListArchived(ctx, 1)
+			infos, err := db.Orders().ListArchived(ctx, 1)
 			require.NoError(t, err)
+			require.Len(t, infos, 1)
 		}
 	})
 }

--- a/storagenode/piecestore/endpoint_test.go
+++ b/storagenode/piecestore/endpoint_test.go
@@ -130,11 +130,6 @@ func TestUpload(t *testing.T) {
 			err:           "",
 		},
 		{ // should err with piece ID not specified
-			contentLength: 1 * memory.KiB,
-			action:        pb.PieceAction_PUT,
-			err:           "missing piece id",
-		},
-		{ // should err with piece ID not specified
 			pieceID:       storj.PieceID{},
 			contentLength: 1 * memory.KiB,
 			action:        pb.PieceAction_PUT,
@@ -237,10 +232,6 @@ func TestDownload(t *testing.T) {
 		{ // should successfully download data
 			pieceID: orderLimit.PieceId,
 			action:  pb.PieceAction_GET,
-		},
-		{ // should err with piece ID not specified
-			action: pb.PieceAction_GET,
-			errs:   []string{"missing piece id"},
 		},
 		{ // should err with piece ID not specified
 			pieceID: storj.PieceID{},
@@ -358,10 +349,6 @@ func TestDelete(t *testing.T) {
 			pieceID: storj.PieceID{},
 			action:  pb.PieceAction_DELETE,
 			err:     "missing piece id",
-		},
-		{ // should err with piece ID not specified
-			action: pb.PieceAction_DELETE,
-			err:    "missing piece id",
 		},
 		{ // should err due to incorrect action
 			pieceID: orderLimit.PieceId,


### PR DESCRIPTION
What: Add more test cases for empty piece ID.

Why:
Because we have a reported issue from one Storage Node Operator which cannot list the unsent order limits and it looks that the issue is that there is one order limit in the DB which has an empty piece ID.

The new tests pass without any change in the implementation but it's good to have them.

The goal was trying to find out the root of the problem of the ticket [V3-2400](https://storjlabs.atlassian.net/browse/V3-2400) but I ended up also adding a bit more assertions not related to it.

Please describe the tests: Added more assertions to current tests, there is no change in the implementation so there are no new tests.
 
Please describe the performance impact: none.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
