### PR TITLE
cmd/certificates: ensure we can bind config values

### DIFF
--- a/cmd/certificates/main.go
+++ b/cmd/certificates/main.go
@@ -15,7 +15,8 @@ import (
 	"storj.io/storj/pkg/server"
 )
 
-type batchCfg struct {
+// BatchCfg defines configuration for batching
+type BatchCfg struct {
 	EmailsPath string `help:"optional path to a list of emails, delimited by <delimiter>, for batch processing"`
 	Delimiter  string `help:"delimiter to split emails loaded from <emails-path> on (e.g. comma, new-line)" default:"\n"`
 }
@@ -33,7 +34,7 @@ var (
 	}
 
 	config struct {
-		batchCfg
+		BatchCfg
 		CA       identity.CASetupConfig
 		Identity identity.SetupConfig
 		Server   struct { // workaround server.Config change

--- a/pkg/cfgstruct/bind.go
+++ b/pkg/cfgstruct/bind.go
@@ -138,7 +138,16 @@ func bindConfig(flags FlagSet, prefix string, val reflect.Value, vars map[string
 			continue
 		}
 
-		fieldaddr := fieldval.Addr().Interface()
+		if !fieldval.CanAddr() {
+			panic(fmt.Sprintf("cannot addr field %s in %s", field.Name, typ))
+		}
+
+		fieldref := fieldval.Addr()
+		if !fieldref.CanInterface() {
+			panic(fmt.Sprintf("cannot get interface of field %s in %s", field.Name, typ))
+		}
+
+		fieldaddr := fieldref.Interface()
 		if fieldvalue, ok := fieldaddr.(pflag.Value); ok {
 			help := field.Tag.Get("help")
 			var def string


### PR DESCRIPTION
What: certificates binary was panicking due to private field.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
