### PR TITLE
satellite/overlaycache: add missing audit and uptime success count

### DIFF
--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -974,7 +974,9 @@ func getNodeStats(dbNode *dbx.Node) *overlay.NodeStats {
 	nodeStats := &overlay.NodeStats{
 		Latency90:             dbNode.Latency90,
 		AuditCount:            dbNode.TotalAuditCount,
+		AuditSuccessCount:     dbNode.AuditSuccessCount,
 		UptimeCount:           dbNode.TotalUptimeCount,
+		UptimeSuccessCount:    dbNode.UptimeSuccessCount,
 		LastContactSuccess:    dbNode.LastContactSuccess,
 		LastContactFailure:    dbNode.LastContactFailure,
 		AuditReputationAlpha:  dbNode.AuditReputationAlpha,


### PR DESCRIPTION
What: Add missing audit and uptime success count to `overlay.NodeStats` struct while filling `overlay.NodeDossier` struct in `overlay.DB`

Why: That info is missing even thought it is defined. It is needed for displaying audit and uptime success ratio on SNO dashboard.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
