### PR TITLE
lib/uplinkc: fix flaky download test

### DIFF
--- a/lib/uplinkc/testdata/object_test.c
+++ b/lib/uplinkc/testdata/object_test.c
@@ -168,7 +168,7 @@ void handle_project(ProjectRef project) {
             size_t downloaded_total = 0;
 
             size_t size_to_read = 256 + i;
-            while (true) {
+            while (downloaded_total < data_len) {
                 size_t read_size = download_read(downloader, &downloaded_data[downloaded_total], size_to_read, err);
                 require_noerror(*err);
 


### PR DESCRIPTION
The download driver code loops through the downloaded_data buffer
but doesn't ensure that it always passes a valid pointer to the
Go side. In particular, if the malloc'd memory ends against an
unmapped page, and the test passes a pointer one past the end
of the memory region, and since the Go side always dereferences
the pointer when creating a slice, it will attempt to read
unmapped memory, causing a segfault.

This bug doesn't always present. Indeed, it depends on the details
of your system's memory allocator. I validated that this could be
a cause of observed crashes on OS X by using mmap and mprotect
to do the allocations ensuring that the page directly after the
memory we use was unmapped/protected. The crash happened exactly
as seen, and was fixed by changing this condition in the while
loop.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
