### PR TITLE
storagenode/orders: add ordersDB method CleanArchive

### DIFF
--- a/storagenode/orders/db_test.go
+++ b/storagenode/orders/db_test.go
@@ -126,6 +126,15 @@ func TestDB(t *testing.T) {
 			},
 		}, archived, cmp.Comparer(pb.Equal)))
 
+		// with 1 hour ttl, archived order should not be deleted
+		n, err := db.Orders().CleanArchive(ctx, time.Hour)
+		require.NoError(t, err)
+		require.Equal(t, 0, n)
+
+		// with 1 nanosecond ttl, archived order should be deleted
+		n, err = db.Orders().CleanArchive(ctx, time.Nanosecond)
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
 	})
 }
 
@@ -171,6 +180,11 @@ func TestDB_Trivial(t *testing.T) {
 			infos, err := db.Orders().ListArchived(ctx, 1)
 			require.NoError(t, err)
 			require.Len(t, infos, 1)
+		}
+		{ // Ensure CleanArchive works at all
+			n, err := db.Orders().CleanArchive(ctx, time.Nanosecond)
+			require.NoError(t, err)
+			require.Equal(t, 1, n)
 		}
 	})
 }

--- a/storagenode/orders/sender.go
+++ b/storagenode/orders/sender.go
@@ -72,6 +72,8 @@ type DB interface {
 	Archive(ctx context.Context, requests ...ArchiveRequest) error
 	// ListArchived returns orders that have been sent.
 	ListArchived(ctx context.Context, limit int) ([]*ArchivedInfo, error)
+	// CleanArchive deletes all entries older than ttl
+	CleanArchive(ctx context.Context, ttl time.Duration) (int, error)
 }
 
 // SenderConfig defines configuration for sending orders.


### PR DESCRIPTION
What: A new method on the ordersDB to delete items in the archive that are older than a specific time.Duration

Why: Currently there is no deletion from the order_archive_ table. It will continue to grow indefinitely unless the user manually deletes items 

https://storjlabs.atlassian.net/browse/V3-1979

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
