### PR TITLE
satellite/repair: fix data race in tests

### DIFF
--- a/satellite/repair/repair_test.go
+++ b/satellite/repair/repair_test.go
@@ -32,7 +32,7 @@ import (
 // - Downloads the data from those left nodes and check that it's the same than
 //   the uploaded one
 func TestDataRepair(t *testing.T) {
-	var repairMaxExcessRateOptimalThreshold float64
+	const RepairMaxExcessRateOptimalThreshold = 0.05
 
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount:   1,
@@ -41,7 +41,7 @@ func TestDataRepair(t *testing.T) {
 		Reconfigure: testplanet.Reconfigure{
 			Satellite: func(log *zap.Logger, index int, config *satellite.Config) {
 				config.Overlay.Node.OnlineWindow = 0
-				repairMaxExcessRateOptimalThreshold = config.Repairer.MaxExcessRateOptimalThreshold
+				config.Repairer.MaxExcessRateOptimalThreshold = RepairMaxExcessRateOptimalThreshold
 			},
 		},
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
@@ -83,7 +83,7 @@ func TestDataRepair(t *testing.T) {
 		require.True(t, toKill >= 1)
 		maxNumRepairedPieces := int(
 			math.Ceil(
-				float64(successThreshold) * (1 + repairMaxExcessRateOptimalThreshold),
+				float64(successThreshold) * (1 + RepairMaxExcessRateOptimalThreshold),
 			),
 		)
 		numStorageNodes := len(planet.StorageNodes)
@@ -365,7 +365,7 @@ func TestRepairMultipleDisqualified(t *testing.T) {
 // - Verify that the number of pieces which repaired has uploaded don't overpass
 //	 the established limit (success threshold + % of excess)
 func TestDataRepairUploadLimit(t *testing.T) {
-	var repairMaxExcessRateOptimalThreshold float64
+	const RepairMaxExcessRateOptimalThreshold = 0.05
 
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount:   1,
@@ -373,7 +373,7 @@ func TestDataRepairUploadLimit(t *testing.T) {
 		UplinkCount:      1,
 		Reconfigure: testplanet.Reconfigure{
 			Satellite: func(log *zap.Logger, index int, config *satellite.Config) {
-				repairMaxExcessRateOptimalThreshold = config.Repairer.MaxExcessRateOptimalThreshold
+				config.Repairer.MaxExcessRateOptimalThreshold = RepairMaxExcessRateOptimalThreshold
 			},
 		},
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
@@ -394,7 +394,7 @@ func TestDataRepairUploadLimit(t *testing.T) {
 		var (
 			maxRepairUploadThreshold = int(
 				math.Ceil(
-					float64(successThreshold) * (1 + repairMaxExcessRateOptimalThreshold),
+					float64(successThreshold) * (1 + RepairMaxExcessRateOptimalThreshold),
 				),
 			)
 			ul       = planet.Uplinks[0]


### PR DESCRIPTION
What: `testplanet.Run` is running concurrently and hence there might be concurrent writes to `repairMaxExcessRateOptimalThreshold`.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
