### PR TITLE
prototype: separate repair service from satellite

### DIFF
--- a/internal/testplanet/planet.go
+++ b/internal/testplanet/planet.go
@@ -27,6 +27,8 @@ import (
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/satellite"
 	"storj.io/storj/satellite/overlay"
+	"storj.io/storj/satellite/repair/checker"
+	"storj.io/storj/satellite/repair/repairer"
 	"storj.io/storj/storagenode"
 	"storj.io/storj/versioncontrol"
 )
@@ -82,7 +84,10 @@ type Planet struct {
 // SatelliteSystem contains all the processes needed to run a full Satellite setup
 type SatelliteSystem struct {
 	satellite.Peer
-	RepairProcess *satellite.RepairProcess
+	Repair struct {
+		Checker  *checker.Checker
+		Repairer *repairer.Service
+	}
 }
 
 type closablePeer struct {

--- a/internal/testplanet/planet.go
+++ b/internal/testplanet/planet.go
@@ -68,7 +68,7 @@ type Planet struct {
 
 	Bootstrap      *bootstrap.Peer
 	VersionControl *versioncontrol.Peer
-	Satellites     []*satellite.Peer
+	Satellites     []*SatelliteSystem
 	StorageNodes   []*storagenode.Peer
 	Uplinks        []*Uplink
 
@@ -77,6 +77,12 @@ type Planet struct {
 
 	run    errgroup.Group
 	cancel func()
+}
+
+// SatelliteSystem contains all the processes needed to run a full Satellite setup
+type SatelliteSystem struct {
+	satellite.Peer
+	RepairProcess *satellite.RepairProcess
 }
 
 type closablePeer struct {

--- a/internal/testplanet/satellite.go
+++ b/internal/testplanet/satellite.go
@@ -228,7 +228,9 @@ func (planet *Planet) newSatellites(count int) ([]*SatelliteSystem, error) {
 		log.Debug("id=" + peer.ID().String() + " addr=" + peer.Addr())
 
 		system := SatelliteSystem{Peer: *peer}
-		system.RepairProcess, err = planet.newRepairProcess(i, storageDir)
+		repairProcess, err := planet.newRepairProcess(i, storageDir)
+		system.Repair.Checker = repairProcess.Repair.Checker
+		system.Repair.Repairer = repairProcess.Repair.Repairer
 
 		xs = append(xs, &system)
 	}

--- a/internal/testplanet/uplink.go
+++ b/internal/testplanet/uplink.go
@@ -24,7 +24,6 @@ import (
 	"storj.io/storj/pkg/peertls/tlsopts"
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/pkg/transport"
-	"storj.io/storj/satellite"
 	"storj.io/storj/satellite/console"
 	"storj.io/storj/uplink"
 	"storj.io/storj/uplink/metainfo"
@@ -156,22 +155,22 @@ func (client *Uplink) DialPiecestore(ctx context.Context, destination Peer) (*pi
 }
 
 // Upload data to specific satellite
-func (client *Uplink) Upload(ctx context.Context, satellite *satellite.Peer, bucket string, path storj.Path, data []byte) error {
+func (client *Uplink) Upload(ctx context.Context, satellite *SatelliteSystem, bucket string, path storj.Path, data []byte) error {
 	return client.UploadWithExpiration(ctx, satellite, bucket, path, data, time.Time{})
 }
 
 // UploadWithExpiration data to specific satellite and expiration time
-func (client *Uplink) UploadWithExpiration(ctx context.Context, satellite *satellite.Peer, bucket string, path storj.Path, data []byte, expiration time.Time) error {
+func (client *Uplink) UploadWithExpiration(ctx context.Context, satellite *SatelliteSystem, bucket string, path storj.Path, data []byte, expiration time.Time) error {
 	return client.UploadWithExpirationAndConfig(ctx, satellite, nil, bucket, path, data, expiration)
 }
 
 // UploadWithConfig uploads data to specific satellite with configured values
-func (client *Uplink) UploadWithConfig(ctx context.Context, satellite *satellite.Peer, redundancy *uplink.RSConfig, bucket string, path storj.Path, data []byte) error {
+func (client *Uplink) UploadWithConfig(ctx context.Context, satellite *SatelliteSystem, redundancy *uplink.RSConfig, bucket string, path storj.Path, data []byte) error {
 	return client.UploadWithExpirationAndConfig(ctx, satellite, redundancy, bucket, path, data, time.Time{})
 }
 
 // UploadWithExpirationAndConfig uploads data to specific satellite with configured values and expiration time
-func (client *Uplink) UploadWithExpirationAndConfig(ctx context.Context, satellite *satellite.Peer, redundancy *uplink.RSConfig, bucketName string, path storj.Path, data []byte, expiration time.Time) (err error) {
+func (client *Uplink) UploadWithExpirationAndConfig(ctx context.Context, satellite *SatelliteSystem, redundancy *uplink.RSConfig, bucketName string, path storj.Path, data []byte, expiration time.Time) (err error) {
 	config := client.GetConfig(satellite)
 	if redundancy != nil {
 		if redundancy.MinThreshold > 0 {
@@ -211,7 +210,7 @@ func (client *Uplink) UploadWithExpirationAndConfig(ctx context.Context, satelli
 }
 
 // Download data from specific satellite
-func (client *Uplink) Download(ctx context.Context, satellite *satellite.Peer, bucketName string, path storj.Path) ([]byte, error) {
+func (client *Uplink) Download(ctx context.Context, satellite *SatelliteSystem, bucketName string, path storj.Path) ([]byte, error) {
 	project, bucket, err := client.GetProjectAndBucket(ctx, satellite, bucketName, client.GetConfig(satellite))
 	if err != nil {
 		return nil, err
@@ -237,7 +236,7 @@ func (client *Uplink) Download(ctx context.Context, satellite *satellite.Peer, b
 }
 
 // DownloadStream returns stream for downloading data
-func (client *Uplink) DownloadStream(ctx context.Context, satellite *satellite.Peer, bucketName string, path storj.Path) (_ io.ReadCloser, cleanup func() error, err error) {
+func (client *Uplink) DownloadStream(ctx context.Context, satellite *SatelliteSystem, bucketName string, path storj.Path) (_ io.ReadCloser, cleanup func() error, err error) {
 	project, bucket, err := client.GetProjectAndBucket(ctx, satellite, bucketName, client.GetConfig(satellite))
 	if err != nil {
 		return nil, nil, err
@@ -256,7 +255,7 @@ func (client *Uplink) DownloadStream(ctx context.Context, satellite *satellite.P
 }
 
 // DownloadStreamRange returns stream for downloading data
-func (client *Uplink) DownloadStreamRange(ctx context.Context, satellite *satellite.Peer, bucketName string, path storj.Path, start, limit int64) (_ io.ReadCloser, cleanup func() error, err error) {
+func (client *Uplink) DownloadStreamRange(ctx context.Context, satellite *SatelliteSystem, bucketName string, path storj.Path, start, limit int64) (_ io.ReadCloser, cleanup func() error, err error) {
 	project, bucket, err := client.GetProjectAndBucket(ctx, satellite, bucketName, client.GetConfig(satellite))
 	if err != nil {
 		return nil, nil, err
@@ -275,7 +274,7 @@ func (client *Uplink) DownloadStreamRange(ctx context.Context, satellite *satell
 }
 
 // Delete deletes an object at the path in a bucket
-func (client *Uplink) Delete(ctx context.Context, satellite *satellite.Peer, bucketName string, path storj.Path) error {
+func (client *Uplink) Delete(ctx context.Context, satellite *SatelliteSystem, bucketName string, path storj.Path) error {
 	project, bucket, err := client.GetProjectAndBucket(ctx, satellite, bucketName, client.GetConfig(satellite))
 	if err != nil {
 		return err
@@ -290,7 +289,7 @@ func (client *Uplink) Delete(ctx context.Context, satellite *satellite.Peer, buc
 }
 
 // CreateBucket creates a new bucket
-func (client *Uplink) CreateBucket(ctx context.Context, satellite *satellite.Peer, bucketName string) error {
+func (client *Uplink) CreateBucket(ctx context.Context, satellite *SatelliteSystem, bucketName string) error {
 	project, err := client.GetProject(ctx, satellite)
 	if err != nil {
 		return err
@@ -312,7 +311,7 @@ func (client *Uplink) CreateBucket(ctx context.Context, satellite *satellite.Pee
 }
 
 // GetConfig returns a default config for a given satellite.
-func (client *Uplink) GetConfig(satellite *satellite.Peer) uplink.Config {
+func (client *Uplink) GetConfig(satellite *SatelliteSystem) uplink.Config {
 	config := getDefaultConfig()
 
 	apiKey, err := libuplink.ParseAPIKey(client.APIKey[satellite.ID()])
@@ -384,7 +383,7 @@ func (client *Uplink) NewLibuplink(ctx context.Context) (*libuplink.Uplink, erro
 }
 
 // GetProject returns a libuplink.Project which allows interactions with a specific project
-func (client *Uplink) GetProject(ctx context.Context, satellite *satellite.Peer) (*libuplink.Project, error) {
+func (client *Uplink) GetProject(ctx context.Context, satellite *SatelliteSystem) (*libuplink.Project, error) {
 	testLibuplink, err := client.NewLibuplink(ctx)
 	if err != nil {
 		return nil, err
@@ -404,7 +403,7 @@ func (client *Uplink) GetProject(ctx context.Context, satellite *satellite.Peer)
 }
 
 // GetProjectAndBucket returns a libuplink.Project and Bucket which allows interactions with a specific project and its buckets
-func (client *Uplink) GetProjectAndBucket(ctx context.Context, satellite *satellite.Peer, bucketName string, clientCfg uplink.Config) (_ *libuplink.Project, _ *libuplink.Bucket, err error) {
+func (client *Uplink) GetProjectAndBucket(ctx context.Context, satellite *SatelliteSystem, bucketName string, clientCfg uplink.Config) (_ *libuplink.Project, _ *libuplink.Bucket, err error) {
 	project, err := client.GetProject(ctx, satellite)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/kademlia/merge_test.go
+++ b/pkg/kademlia/merge_test.go
@@ -15,7 +15,6 @@ import (
 	"storj.io/storj/bootstrap"
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testplanet"
-	"storj.io/storj/satellite"
 	"storj.io/storj/storagenode"
 )
 
@@ -53,7 +52,7 @@ func TestMergePlanets(t *testing.T) {
 	alpha.Start(ctx)
 	beta.Start(ctx)
 
-	allSatellites := []*satellite.Peer{}
+	allSatellites := []*testplanet.SatelliteSystem{}
 	allSatellites = append(allSatellites, alpha.Satellites...)
 	allSatellites = append(allSatellites, beta.Satellites...)
 
@@ -71,7 +70,7 @@ func TestMergePlanets(t *testing.T) {
 	}
 	_ = group.Wait()
 
-	test := func(tag string, satellites []*satellite.Peer, storageNodes []*storagenode.Peer) string {
+	test := func(tag string, satellites []*testplanet.SatelliteSystem, storageNodes []*storagenode.Peer) string {
 		found, missing := 0, 0
 		for _, satellite := range satellites {
 			for _, storageNode := range storageNodes {

--- a/satellite/audit/disqualification_test.go
+++ b/satellite/audit/disqualification_test.go
@@ -234,13 +234,13 @@ func TestDisqualifiedNodeRemainsDisqualified(t *testing.T) {
 	})
 }
 
-func isDisqualified(t *testing.T, ctx *testcontext.Context, satellite *satellite.Peer, nodeID storj.NodeID) bool {
+func isDisqualified(t *testing.T, ctx *testcontext.Context, satellite *testplanet.SatelliteSystem, nodeID storj.NodeID) bool {
 	node, err := satellite.Overlay.Service.Get(ctx, nodeID)
 	require.NoError(t, err)
 
 	return node.Disqualified != nil
 }
-func disqualifyNode(t *testing.T, ctx *testcontext.Context, satellite *satellite.Peer, nodeID storj.NodeID) {
+func disqualifyNode(t *testing.T, ctx *testcontext.Context, satellite *testplanet.SatelliteSystem, nodeID storj.NodeID) {
 	_, err := satellite.DB.OverlayCache().BatchUpdateStats(ctx, []*overlay.UpdateRequest{{
 		NodeID:       nodeID,
 		IsUp:         true,

--- a/satellite/gc/gc_test.go
+++ b/satellite/gc/gc_test.go
@@ -117,7 +117,7 @@ func TestGarbageCollection(t *testing.T) {
 	})
 }
 
-func getPointer(ctx *testcontext.Context, t *testing.T, satellite *satellite.Peer, upl *testplanet.Uplink, bucket, path string) (lastSegPath string, pointer *pb.Pointer) {
+func getPointer(ctx *testcontext.Context, t *testing.T, satellite *testplanet.SatelliteSystem, upl *testplanet.Uplink, bucket, path string) (lastSegPath string, pointer *pb.Pointer) {
 	projects, err := satellite.DB.Console().Projects().GetAll(ctx)
 	require.NoError(t, err)
 	require.Len(t, projects, 1)

--- a/satellite/repair.go
+++ b/satellite/repair.go
@@ -91,9 +91,8 @@ type RepairProcess struct {
 	}
 
 	Repair struct {
-		Checker   *checker.Checker
-		Repairer  *repairer.Service
-		Inspector *irreparable.Inspector
+		Checker  *checker.Checker
+		Repairer *repairer.Service
 	}
 }
 
@@ -175,7 +174,6 @@ func NewRepairProcess(log *zap.Logger, full *identity.FullIdentity, db RepairPro
 			peer.Orders.Service,
 			peer.Overlay.Service,
 		)
-		peer.Repair.Inspector = irreparable.NewInspector(peer.DB.Irreparable())
 	}
 
 	return peer, nil

--- a/satellite/repair.go
+++ b/satellite/repair.go
@@ -1,0 +1,220 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package satellite
+
+import (
+	"context"
+
+	"github.com/zeebo/errs"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+
+	"storj.io/storj/internal/errs2"
+	"storj.io/storj/pkg/identity"
+	"storj.io/storj/pkg/pb"
+	"storj.io/storj/pkg/peertls/extensions"
+	"storj.io/storj/pkg/peertls/tlsopts"
+	"storj.io/storj/pkg/server"
+	"storj.io/storj/pkg/signing"
+	"storj.io/storj/pkg/storj"
+	"storj.io/storj/pkg/transport"
+	"storj.io/storj/satellite/metainfo"
+	"storj.io/storj/satellite/orders"
+	"storj.io/storj/satellite/overlay"
+	"storj.io/storj/satellite/repair/checker"
+	"storj.io/storj/satellite/repair/irreparable"
+	"storj.io/storj/satellite/repair/queue"
+	"storj.io/storj/satellite/repair/repairer"
+	"storj.io/storj/storage"
+)
+
+// RepairProcessDB is the interface to connect to the master database for the satellite's RepairProcess
+type RepairProcessDB interface {
+	// CreateTables initializes the database
+	CreateTables() error
+	// Close closes the database
+	Close() error
+
+	// CreateSchema sets the schema
+	CreateSchema(schema string) error
+	// DropSchema drops the schema
+	DropSchema(schema string) error
+
+	// OverlayCache returns database for caching overlay information
+	OverlayCache() overlay.DB
+	// RepairQueue returns queue for segments that need repairing
+	RepairQueue() queue.RepairQueue
+	// Irreparable returns database for failed repairs
+	Irreparable() irreparable.DB
+	// Orders returns database for orders
+	Orders() orders.DB
+	// Buckets returns the database to interact with buckets
+	Buckets() metainfo.BucketsDB
+}
+
+// RepairProcessConfig is the config used for RepairProcess
+type RepairProcessConfig struct {
+	Identity identity.Config
+	Server   server.Config
+	Overlay  overlay.Config
+	Metainfo metainfo.Config
+	Orders   orders.Config
+	Checker  checker.Config
+	Repairer repairer.Config
+}
+
+// RepairProcess is the repair subsystem for the satellite
+type RepairProcess struct {
+	Log      *zap.Logger
+	Identity *identity.FullIdentity
+	DB       RepairProcessDB
+
+	Transport transport.Client
+
+	Overlay struct {
+		DB        overlay.DB
+		Service   *overlay.Service
+		Inspector *overlay.Inspector
+	}
+
+	Metainfo struct {
+		Database  storage.KeyValueStore
+		Service   *metainfo.Service
+		Endpoint2 *metainfo.Endpoint
+		Loop      *metainfo.Loop
+	}
+
+	Orders struct {
+		Endpoint *orders.Endpoint
+		Service  *orders.Service
+	}
+
+	Repair struct {
+		Checker   *checker.Checker
+		Repairer  *repairer.Service
+		Inspector *irreparable.Inspector
+	}
+}
+
+// NewRepairProcess creates a new repair subsystem process for the satellite
+func NewRepairProcess(log *zap.Logger, full *identity.FullIdentity, db RepairProcessDB,
+	revDB extensions.RevocationDB, config *RepairProcessConfig) (*RepairProcess, error) {
+	peer := &RepairProcess{
+		Log:      log,
+		Identity: full,
+		DB:       db,
+	}
+
+	{ // setup transport client
+		log.Debug("Starting transport client for repair process")
+		sc := config.Server
+		options, err := tlsopts.NewOptions(peer.Identity, sc.Config, revDB)
+		if err != nil {
+			return nil, errs.Combine(err, peer.Close())
+		}
+		peer.Transport = transport.NewClient(options)
+	}
+
+	{ // setup overlay
+		log.Debug("Starting overlay for repair process")
+		peer.Overlay.DB = overlay.NewCombinedCache(peer.DB.OverlayCache())
+		peer.Overlay.Service = overlay.NewService(peer.Log.Named("overlay"), peer.Overlay.DB, config.Overlay)
+	}
+
+	{ // setup orders
+		log.Debug("Setting up orders for repair process")
+		peer.Orders.Service = orders.NewService(
+			peer.Log.Named("orders:service"),
+			signing.SignerFromFullIdentity(peer.Identity),
+			peer.Overlay.Service,
+			peer.DB.Orders(),
+			config.Orders.Expiration,
+			&pb.NodeAddress{
+				Transport: pb.NodeTransport_TCP_TLS_GRPC,
+				// TODO: we need the SA address here
+				// Address:   config.Kademlia.ExternalAddress,
+			},
+			config.Repairer.MaxExcessRateOptimalThreshold,
+		)
+	}
+
+	{ // setup metainfo
+		log.Debug("Setting up metainfo for repair process")
+		db, err := metainfo.NewStore(peer.Log.Named("metainfo:store"), config.Metainfo.DatabaseURL)
+		if err != nil {
+			return nil, errs.Combine(err, peer.Close())
+		}
+		peer.Metainfo.Database = db
+		peer.Metainfo.Service = metainfo.NewService(peer.Log.Named("metainfo:service"),
+			peer.Metainfo.Database,
+			peer.DB.Buckets(),
+		)
+		peer.Metainfo.Loop = metainfo.NewLoop(config.Metainfo.Loop, peer.Metainfo.Service)
+	}
+
+	{ // setup datarepair
+		log.Debug("Setting up datarepair")
+		peer.Repair.Checker = checker.NewChecker(
+			peer.Log.Named("checker"),
+			peer.DB.RepairQueue(),
+			peer.DB.Irreparable(),
+			peer.Metainfo.Service,
+			peer.Metainfo.Loop,
+			peer.Overlay.Service,
+			config.Checker)
+
+		peer.Repair.Repairer = repairer.NewService(
+			peer.Log.Named("repairer"),
+			peer.DB.RepairQueue(),
+			&config.Repairer,
+			config.Repairer.Interval,
+			config.Repairer.MaxRepair,
+			peer.Transport,
+			peer.Metainfo.Service,
+			peer.Orders.Service,
+			peer.Overlay.Service,
+		)
+		peer.Repair.Inspector = irreparable.NewInspector(peer.DB.Irreparable())
+	}
+
+	return peer, nil
+}
+
+// Run the satellite's RepairProcess until it is closed or it errors.
+func (peer *RepairProcess) Run(ctx context.Context) (err error) {
+	defer mon.Task()(&ctx)(&err)
+	group, ctx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		return errs2.IgnoreCanceled(peer.Repair.Checker.Run(ctx))
+	})
+	group.Go(func() error {
+		return errs2.IgnoreCanceled(peer.Metainfo.Loop.Run(ctx))
+	})
+	group.Go(func() error {
+		return errs2.IgnoreCanceled(peer.Repair.Repairer.Run(ctx))
+	})
+	return group.Wait()
+}
+
+// Close closes all the resources.
+// close services in reverse initialization order
+func (peer *RepairProcess) Close() error {
+	var errlist errs.Group
+	if peer.Repair.Repairer != nil {
+		errlist.Add(peer.Repair.Repairer.Close())
+	}
+	if peer.Repair.Checker != nil {
+		errlist.Add(peer.Repair.Checker.Close())
+	}
+	if peer.Metainfo.Database != nil {
+		errlist.Add(peer.Metainfo.Database.Close())
+	}
+	if peer.Overlay.Service != nil {
+		errlist.Add(peer.Overlay.Service.Close())
+	}
+	return errlist.Err()
+}
+
+// ID returns the peer ID
+func (peer *RepairProcess) ID() storj.NodeID { return peer.Identity.ID }

--- a/satellite/repair/repair_test.go
+++ b/satellite/repair/repair_test.go
@@ -485,14 +485,14 @@ func TestDataRepairUploadLimit(t *testing.T) {
 	})
 }
 
-func isDisqualified(t *testing.T, ctx *testcontext.Context, satellite *satellite.Peer, nodeID storj.NodeID) bool {
+func isDisqualified(t *testing.T, ctx *testcontext.Context, satellite *testplanet.SatelliteSystem, nodeID storj.NodeID) bool {
 	node, err := satellite.Overlay.Service.Get(ctx, nodeID)
 	require.NoError(t, err)
 
 	return node.Disqualified != nil
 }
 
-func disqualifyNode(t *testing.T, ctx *testcontext.Context, satellite *satellite.Peer, nodeID storj.NodeID) {
+func disqualifyNode(t *testing.T, ctx *testcontext.Context, satellite *testplanet.SatelliteSystem, nodeID storj.NodeID) {
 	_, err := satellite.DB.OverlayCache().UpdateStats(ctx, &overlay.UpdateRequest{
 		NodeID:       nodeID,
 		IsUp:         true,
@@ -511,7 +511,7 @@ func disqualifyNode(t *testing.T, ctx *testcontext.Context, satellite *satellite
 // getRemoteSegment returns a remote pointer its path from satellite.
 // nolint:golint
 func getRemoteSegment(
-	t *testing.T, ctx context.Context, satellite *satellite.Peer,
+	t *testing.T, ctx context.Context, satellite *testplanet.SatelliteSystem,
 ) (_ *pb.Pointer, path string) {
 	t.Helper()
 

--- a/uplink/ecclient/client_planet_test.go
+++ b/uplink/ecclient/client_planet_test.go
@@ -23,7 +23,6 @@ import (
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/signing"
 	"storj.io/storj/pkg/storj"
-	"storj.io/storj/satellite"
 	"storj.io/storj/storagenode"
 	"storj.io/storj/uplink/ecclient"
 	"storj.io/storj/uplink/eestream"
@@ -151,7 +150,7 @@ func testDelete(ctx context.Context, t *testing.T, planet *testplanet.Planet, ec
 	require.NoError(t, err)
 }
 
-func newAddressedOrderLimit(ctx context.Context, action pb.PieceAction, satellite *satellite.Peer, piecePublicKey storj.PiecePublicKey, storageNode *storagenode.Peer, pieceID storj.PieceID) (*pb.AddressedOrderLimit, error) {
+func newAddressedOrderLimit(ctx context.Context, action pb.PieceAction, satellite *testplanet.SatelliteSystem, piecePublicKey storj.PiecePublicKey, storageNode *storagenode.Peer, pieceID storj.PieceID) (*pb.AddressedOrderLimit, error) {
 	// TODO refactor to avoid OrderLimit duplication
 	serialNumber := testrand.SerialNumber()
 


### PR DESCRIPTION
What/Why:
We are currently working on a design doc to separate the satellite into many services. See that doc [here](https://github.com/storj/storj/pull/2815).  This PR serves as a prototype to walk through an example of how to do this separation. 

This PR does the following things to separate out the repair service:
1. Create a `RepairProcess` struct and move repair setup from satellite/peer.go over to satellite/repair.go.
2. Add a subcommand to the satellite binary so now this command can be executed:
`satellite run repair`
3. Update testplanet with these changes

Please describe the tests:
Add a new struct to testplanet called `SatelliteSystem` that contains all the satellite services as we separate them out and updated existing tests to use this new struct. The unit/integration tests should all still pass.
 
Please describe the performance impact:
wip

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
