### PR TITLE
storagenode/nodestats: fix issue on 32 bit platforms

### DIFF
--- a/storagenode/nodestats/cache.go
+++ b/storagenode/nodestats/cache.go
@@ -146,7 +146,7 @@ func (cache *Cache) sleep(ctx context.Context) error {
 		return nil
 	}
 
-	jitter := time.Duration(rand.Intn(int(cache.maxSleep)))
+	jitter := time.Duration(rand.Int63n(int64(cache.maxSleep)))
 	if !sync2.Sleep(ctx, jitter) {
 		return ctx.Err()
 	}

--- a/storagenode/nodestats/cache_test.go
+++ b/storagenode/nodestats/cache_test.go
@@ -14,5 +14,5 @@ func TestCacheSleep32bitBug(t *testing.T) {
 	defer cancel()
 
 	// Ensure that a large maxSleep doesn't roll over to negative values on 32 bit systems.
-	(&Cache{maxSleep: 1 << 32}).sleep(ctx)
+	_ = (&Cache{maxSleep: 1 << 32}).sleep(ctx)
 }

--- a/storagenode/nodestats/cache_test.go
+++ b/storagenode/nodestats/cache_test.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package nodestats
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCacheSleep32bitBug(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	// Ensure that a large maxSleep doesn't roll over to negative values on 32 bit systems.
+	(&Cache{maxSleep: 1 << 32}).sleep(ctx)
+}


### PR DESCRIPTION
What: time.Duration is an int64, so casting it down to an int can cause it to become negative, causing a panic.

Why: We have panics on arm :(

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
