### PR TITLE
satellite/marketingweb: WriteHeader should only be called once

### DIFF
--- a/satellite/marketingweb/server.go
+++ b/satellite/marketingweb/server.go
@@ -99,7 +99,6 @@ func (s *Server) GetOffers(w http.ResponseWriter, req *http.Request) {
 
 	if err := s.templates.home.ExecuteTemplate(w, "base", offers.OrganizeOffersByType()); err != nil {
 		s.log.Error("failed to execute template", zap.Error(err))
-		s.serveInternalError(w, req, err)
 	}
 }
 


### PR DESCRIPTION
What: WriteHeader should only be called once, see https://golang.org/pkg/net/http/#ResponseWriter

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
