### PR TITLE
satellite/satellitedb: move tests near the interface

### DIFF
--- a/satellite/console/usercredits_test.go
+++ b/satellite/console/usercredits_test.go
@@ -1,25 +1,22 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-package satellitedb_test
+package console_test
 
 import (
-	"context"
 	"testing"
-	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"storj.io/storj/internal/currency"
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testrand"
 	"storj.io/storj/satellite"
 	"storj.io/storj/satellite/console"
-	"storj.io/storj/satellite/rewards"
 	"storj.io/storj/satellite/satellitedb/satellitedbtest"
 )
 
-func TestUsercredits(t *testing.T) {
+func TestUserCredits(t *testing.T) {
 	satellitedbtest.Run(t, func(t *testing.T, db satellite.DB) {
 		ctx := testcontext.New(t)
 		defer ctx.Cleanup()

--- a/satellite/console/usercredits_test.go
+++ b/satellite/console/usercredits_test.go
@@ -4,15 +4,18 @@
 package console_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"storj.io/storj/internal/currency"
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testrand"
 	"storj.io/storj/satellite"
 	"storj.io/storj/satellite/console"
+	"storj.io/storj/satellite/rewards"
 	"storj.io/storj/satellite/satellitedb/satellitedbtest"
 )
 

--- a/satellite/repair/queue/queue2_test.go
+++ b/satellite/repair/queue/queue2_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-package satellitedb_test
+package queue_test
 
 import (
 	"context"
@@ -21,7 +21,7 @@ import (
 	"storj.io/storj/storage"
 )
 
-func TestRepairQueue(t *testing.T) {
+func TestUntilEmpty(t *testing.T) {
 	satellitedbtest.Run(t, func(t *testing.T, db satellite.DB) {
 		ctx := testcontext.New(t)
 		defer ctx.Cleanup()
@@ -54,7 +54,7 @@ func TestRepairQueue(t *testing.T) {
 	})
 }
 
-func TestRepairQueueOrder(t *testing.T) {
+func TestOrder(t *testing.T) {
 	satellitedbtest.Run(t, func(t *testing.T, db satellite.DB) {
 		ctx := testcontext.New(t)
 		defer ctx.Cleanup()
@@ -72,6 +72,7 @@ func TestRepairQueueOrder(t *testing.T) {
 			require.NoError(t, err)
 		}
 
+		// TODO: remove dependency on *dbx.DB
 		dbAccess := db.(interface{ TestDBAccess() *dbx.DB }).TestDBAccess()
 		var timeConvertPrefix string
 		switch d := dbAccess.DB.Driver().(type) {
@@ -129,7 +130,7 @@ func TestRepairQueueOrder(t *testing.T) {
 	})
 }
 
-func TestRepairQueueCount(t *testing.T) {
+func TestCount(t *testing.T) {
 	satellitedbtest.Run(t, func(t *testing.T, db satellite.DB) {
 		ctx := testcontext.New(t)
 		defer ctx.Cleanup()


### PR DESCRIPTION
What: Database tests are about the interface that things provide and less about the database internals. Move tests near the interface.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
