### PR TITLE
satellite/dbcleanup: delete expired serials from satellite

### DIFF
--- a/internal/testplanet/satellite.go
+++ b/internal/testplanet/satellite.go
@@ -24,6 +24,7 @@ import (
 	"storj.io/storj/satellite/audit"
 	"storj.io/storj/satellite/console"
 	"storj.io/storj/satellite/console/consoleweb"
+	"storj.io/storj/satellite/dbcleanup"
 	"storj.io/storj/satellite/discovery"
 	"storj.io/storj/satellite/gc"
 	"storj.io/storj/satellite/mailservice"
@@ -173,6 +174,9 @@ func (planet *Planet) newSatellites(count int) ([]*satellite.Peer, error) {
 				InitialPieces:     10,
 				FalsePositiveRate: 0.1,
 				ConcurrentSends:   1,
+			},
+			DBCleanup: dbcleanup.Config{
+				SerialsInterval: time.Hour,
 			},
 			Tally: tally.Config{
 				Interval: 30 * time.Second,

--- a/satellite/dbcleanup/service.go
+++ b/satellite/dbcleanup/service.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package dbcleanup
+
+import (
+	"context"
+	"time"
+
+	"github.com/zeebo/errs"
+	"go.uber.org/zap"
+	"gopkg.in/spacemonkeygo/monkit.v2"
+
+	"storj.io/storj/internal/sync2"
+	"storj.io/storj/satellite/orders"
+)
+
+var (
+	// Error the default orders errs class
+	Error = errs.Class("dbcleanup error")
+
+	mon = monkit.Package()
+)
+
+// Config defines configuration struct for dbcleanup service
+type Config struct {
+	SerialsInterval time.Duration `help:"how often to delete expired serial numbers" default:"24h"`
+}
+
+// Service for deleting DB entries that are no longer needed.
+type Service struct {
+	log    *zap.Logger
+	orders orders.DB
+
+	Serials sync2.Cycle
+}
+
+// NewService creates new service for deleting DB entries.
+func NewService(log *zap.Logger, orders orders.DB, config Config) *Service {
+	return &Service{
+		log:    log,
+		orders: orders,
+
+		Serials: *sync2.NewCycle(config.SerialsInterval),
+	}
+}
+
+// Run starts the db cleanup service
+func (service *Service) Run(ctx context.Context) (err error) {
+	defer mon.Task()(&ctx)(&err)
+	return service.Serials.Run(ctx, service.deleteExpiredSerials)
+}
+
+func (service *Service) deleteExpiredSerials(ctx context.Context) (err error) {
+	defer mon.Task()(&ctx)(&err)
+	service.log.Debug("deleting expired serial numbers")
+
+	deleted, err := service.orders.DeleteExpiredSerials(ctx)
+	if err != nil {
+		service.log.Error("deleting expired serial numbers", zap.Error(err))
+		return nil
+	}
+
+	service.log.Debug("expired serials deleted", zap.Int("items deleted", deleted))
+	return nil
+}
+
+// Close stops the
+func (service *Service) Close() error {
+	service.Serials.Close()
+	return nil
+}

--- a/satellite/dbcleanup/service_test.go
+++ b/satellite/dbcleanup/service_test.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package dbcleanup_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"storj.io/storj/internal/testcontext"
+	"storj.io/storj/internal/testplanet"
+	"storj.io/storj/pkg/storj"
+)
+
+func TestDeleteExpiredSerials(t *testing.T) {
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1, StorageNodeCount: 1, UplinkCount: 0,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		satellite := planet.Satellites[0]
+		node := planet.StorageNodes[0].ID()
+		satellite.DBCleanup.Service.Serials.Pause()
+
+		var expiredSerials []storj.SerialNumber
+		for i := 0; i < 5; i++ {
+			expiredSerials = append(expiredSerials, storj.SerialNumber{byte(i)})
+		}
+
+		var freshSerials []storj.SerialNumber
+		for i := 5; i < 10; i++ {
+			freshSerials = append(freshSerials, storj.SerialNumber{byte(i)})
+		}
+
+		yesterday := time.Now().UTC().Add(-24 * time.Hour)
+		for i := 0; i < 5; i++ {
+			err := satellite.DB.Orders().CreateSerialInfo(ctx, expiredSerials[i], []byte("bucket"), yesterday)
+			require.NoError(t, err)
+
+			_, err = satellite.DB.Orders().UseSerialNumber(ctx, expiredSerials[i], node)
+			require.NoError(t, err)
+		}
+
+		tomorrow := yesterday.Add(48 * time.Hour)
+		for i := 0; i < 5; i++ {
+			err := satellite.DB.Orders().CreateSerialInfo(ctx, freshSerials[i], []byte("bucket"), tomorrow)
+			require.NoError(t, err)
+
+			_, err = satellite.DB.Orders().UseSerialNumber(ctx, freshSerials[i], node)
+			require.NoError(t, err)
+		}
+
+		// trigger expired serial number deletion
+		satellite.DBCleanup.Service.Serials.TriggerWait()
+
+		// check expired serial numbers have been deleted from serial_numbers and used_serials
+		for i := 0; i < 5; i++ {
+			_, err := satellite.DB.Orders().UseSerialNumber(ctx, expiredSerials[i], node)
+			require.EqualError(t, err, "serial number: serial number not found")
+		}
+
+		// check fresh serial numbers have not been deleted
+		for i := 0; i < 5; i++ {
+			_, err := satellite.DB.Orders().UseSerialNumber(ctx, freshSerials[i], node)
+			require.EqualError(t, err, "serial number: serial number already used")
+		}
+	})
+}

--- a/satellite/orders/endpoint.go
+++ b/satellite/orders/endpoint.go
@@ -29,6 +29,8 @@ type DB interface {
 	UseSerialNumber(ctx context.Context, serialNumber storj.SerialNumber, storageNodeID storj.NodeID) ([]byte, error)
 	// UnuseSerialNumber removes pair serial number -> storage node id from database
 	UnuseSerialNumber(ctx context.Context, serialNumber storj.SerialNumber, storageNodeID storj.NodeID) error
+	// DeleteExpiredSerials deletes all expired serials in serial_number and used_serials table
+	DeleteExpiredSerials(ctx context.Context) (_ int, err error)
 
 	// UpdateBucketBandwidthAllocation updates 'allocated' bandwidth for given bucket
 	UpdateBucketBandwidthAllocation(ctx context.Context, projectID uuid.UUID, bucketName []byte, action pb.PieceAction, amount int64, intervalStart time.Time) error

--- a/satellite/orders/serials_test.go
+++ b/satellite/orders/serials_test.go
@@ -48,5 +48,13 @@ func TestSerialNumbers(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, orders.ErrUsingSerialNumber.Has(err))
 		require.Empty(t, bucketID)
+
+		deleted, err := ordersDB.DeleteExpiredSerials(ctx)
+		require.NoError(t, err)
+		require.Equal(t, deleted, 1)
+
+		// check serial number has been deleted from serial_numbers and used_serials
+		_, err = ordersDB.UseSerialNumber(ctx, storj.SerialNumber{1}, storj.NodeID{1})
+		require.EqualError(t, err, "serial number: serial number not found")
 	})
 }

--- a/satellite/satellitedb/locked.go
+++ b/satellite/satellitedb/locked.go
@@ -759,6 +759,13 @@ func (m *lockedOrders) CreateSerialInfo(ctx context.Context, serialNumber storj.
 	return m.db.CreateSerialInfo(ctx, serialNumber, bucketID, limitExpiration)
 }
 
+// DeleteExpiredSerials deletes all expired serials in serial_number and used_serials table
+func (m *lockedOrders) DeleteExpiredSerials(ctx context.Context) (_ int, err error) {
+	m.Lock()
+	defer m.Unlock()
+	return m.db.DeleteExpiredSerials(ctx)
+}
+
 // GetBucketBandwidth gets total bucket bandwidth from period of time
 func (m *lockedOrders) GetBucketBandwidth(ctx context.Context, projectID uuid.UUID, bucketName []byte, from time.Time, to time.Time) (int64, error) {
 	m.Lock()
@@ -771,6 +778,13 @@ func (m *lockedOrders) GetStorageNodeBandwidth(ctx context.Context, nodeID storj
 	m.Lock()
 	defer m.Unlock()
 	return m.db.GetStorageNodeBandwidth(ctx, nodeID, from, to)
+}
+
+// ProcessOrders takes a list of order requests and processes them in a batch
+func (m *lockedOrders) ProcessOrders(ctx context.Context, requests []*orders.ProcessOrderRequest) (responses []*orders.ProcessOrderResponse, err error) {
+	m.Lock()
+	defer m.Unlock()
+	return m.db.ProcessOrders(ctx, requests)
 }
 
 // UnuseSerialNumber removes pair serial number -> storage node id from database
@@ -820,12 +834,6 @@ func (m *lockedOrders) UseSerialNumber(ctx context.Context, serialNumber storj.S
 	m.Lock()
 	defer m.Unlock()
 	return m.db.UseSerialNumber(ctx, serialNumber, storageNodeID)
-}
-
-func (m *lockedOrders) ProcessOrders(ctx context.Context, requests []*orders.ProcessOrderRequest) (responses []*orders.ProcessOrderResponse, err error) {
-	m.Lock()
-	defer m.Unlock()
-	return m.db.ProcessOrders(ctx, requests)
 }
 
 // OverlayCache returns database for caching overlay information


### PR DESCRIPTION
This PR creates a new service, `dbcleanup`, which can be used for routine deletion of items from the satellite database. Currently, it is used for deletion of expired serial numbers

Why: because there is no means of programmatically deleting serial numbers. The satellite operator must do it manually

https://storjlabs.atlassian.net/browse/V3-2384

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
