### PR TITLE
all: use fewer storage nodes to improve test memory usage

### DIFF
--- a/lib/uplinkc/testdata/helpers.h
+++ b/lib/uplinkc/testdata/helpers.h
@@ -15,10 +15,10 @@ BucketConfig test_bucket_config() {
 
     config.redundancy_scheme.algorithm = STORJ_REED_SOLOMON;
     config.redundancy_scheme.share_size = 256;
-    config.redundancy_scheme.required_shares = 4;
-    config.redundancy_scheme.repair_shares = 6;
-    config.redundancy_scheme.optimal_shares = 8;
-    config.redundancy_scheme.total_shares = 10;
+    config.redundancy_scheme.required_shares = 2;
+    config.redundancy_scheme.repair_shares = 3;
+    config.redundancy_scheme.optimal_shares = 4;
+    config.redundancy_scheme.total_shares = 5;
 
     return config;
 }

--- a/lib/uplinkc/testdata_test.go
+++ b/lib/uplinkc/testdata_test.go
@@ -26,7 +26,7 @@ func RunPlanet(t *testing.T, run func(ctx *testcontext.Context, planet *testplan
 		zaptest.NewLogger(t, zaptest.Level(zapcore.WarnLevel)),
 		testplanet.Config{
 			SatelliteCount:   1,
-			StorageNodeCount: 10,
+			StorageNodeCount: 5,
 			UplinkCount:      1,
 			Reconfigure:      testplanet.DisablePeerCAWhitelist,
 		},

--- a/storagenode/inspector/inspector_test.go
+++ b/storagenode/inspector/inspector_test.go
@@ -22,7 +22,7 @@ func TestInspectorStats(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()
 
-	planet, err := testplanet.New(t, 1, 10, 1)
+	planet, err := testplanet.New(t, 1, 5, 1)
 	require.NoError(t, err)
 	defer ctx.Check(planet.Shutdown)
 
@@ -52,9 +52,9 @@ func TestInspectorStats(t *testing.T) {
 
 	rs := &uplink.RSConfig{
 		MinThreshold:     2,
-		RepairThreshold:  4,
-		SuccessThreshold: 6,
-		MaxThreshold:     10,
+		RepairThreshold:  3,
+		SuccessThreshold: 4,
+		MaxThreshold:     5,
 	}
 
 	err = planet.Uplinks[0].UploadWithConfig(ctx, planet.Satellites[0], rs, "testbucket", "test/path", expectedData)
@@ -94,7 +94,7 @@ func TestInspectorDashboard(t *testing.T) {
 	testStartedTime := time.Now()
 
 	testplanet.Run(t, testplanet.Config{
-		SatelliteCount: 1, StorageNodeCount: 6, UplinkCount: 1,
+		SatelliteCount: 1, StorageNodeCount: 1, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 		for _, storageNode := range planet.StorageNodes {
 			response, err := storageNode.Storage2.Inspector.Dashboard(ctx, &pb.DashboardRequest{})


### PR DESCRIPTION
What: Currently tests using a lot of storage nodes end up consuming a lot of memory. These were worst offenders. These changes reduce memory usage from ~3GB -> ~1.5GB, for each.

Why: These tests don't need that many storage-nodes.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
