### PR TITLE
cmd/*: Change loglevel from error to warn

### DIFF
--- a/cmd/bootstrap/main.go
+++ b/cmd/bootstrap/main.go
@@ -109,7 +109,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	if err := process.InitMetricsWithCertPath(ctx, log, nil, runCfg.Identity.CertPath); err != nil {
-		zap.S().Error("Failed to initialize telemetry batcher: ", err)
+		zap.S().Warn("Failed to initialize telemetry batcher: ", err)
 	}
 
 	err = db.CreateTables()

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -137,7 +137,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	ctx := process.Ctx(cmd)
 
 	if err := process.InitMetrics(ctx, zap.L(), nil, ""); err != nil {
-		zap.S().Error("Failed to initialize telemetry batcher: ", err)
+		zap.S().Warn("Failed to initialize telemetry batcher: ", err)
 	}
 
 	err = version.CheckProcessVersion(ctx, zap.L(), runCfg.Version, version.Build, "Gateway")

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -152,7 +152,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	if err := process.InitMetricsWithCertPath(ctx, log, nil, runCfg.Identity.CertPath); err != nil {
-		zap.S().Error("Failed to initialize telemetry batcher: ", err)
+		zap.S().Warn("Failed to initialize telemetry batcher: ", err)
 	}
 
 	err = db.CreateTables()

--- a/cmd/storagenode/main.go
+++ b/cmd/storagenode/main.go
@@ -161,7 +161,7 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	if err := process.InitMetricsWithCertPath(ctx, log, nil, runCfg.Identity.CertPath); err != nil {
-		zap.S().Error("Failed to initialize telemetry batcher: ", err)
+		zap.S().Warn("Failed to initialize telemetry batcher: ", err)
 	}
 
 	err = db.CreateTables()


### PR DESCRIPTION
What: Changes the Log Level from Error to Warn for disabled telemetry sending.

Why: Its makes error finding much harder when spammed with Error Messages

Please describe the tests:
 - Test 1: N/A
 - Test 2: N/A
 
Please describe the performance impact: _Improves Debug Speed_

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
