### PR TITLE
satellite/gc: Service run must call mon.Task

### DIFF
--- a/satellite/gc/service.go
+++ b/satellite/gc/service.go
@@ -70,6 +70,7 @@ func NewService(log *zap.Logger, config Config, transport transport.Client, over
 
 // Run starts the gc loop service
 func (service *Service) Run(ctx context.Context) (err error) {
+	defer mon.Task()(&ctx)(&err)
 
 	if !service.config.Enabled {
 		return nil


### PR DESCRIPTION
What: Monkit must be called on chore `Run` functions

Why: Because it causes only a little overhead, the opposite that I thought and I reported in the review of the GC, so it was removed due to my fault.
See conversation in https://storj.slack.com/archives/CAQV0AE2Z/p1566923238294400

Please describe the tests: N/A
Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
