### PR TITLE
Test uplink with unencrypted data type

### DIFF
--- a/scripts/test-sim.sh
+++ b/scripts/test-sim.sh
@@ -28,7 +28,15 @@ fi
 
 # run aws-cli tests
 storj-sim -x --satellites 2 --host $STORJ_NETWORK_HOST4 network test bash "$SCRIPTDIR"/test-sim-aws.sh
+
+echo "Uplink test for NOT encrypted content and metadata"
+export STORJ_ENC_DATA_TYPE=1
 storj-sim -x --satellites 2 --host $STORJ_NETWORK_HOST4 network test bash "$SCRIPTDIR"/test-uplink.sh
+
+echo "Uplink test for encrypted content and metadata"
+export STORJ_ENC_DATA_TYPE=2
+storj-sim -x --satellites 2 --host $STORJ_NETWORK_HOST4 network test bash "$SCRIPTDIR"/test-uplink.sh
+
 storj-sim -x --satellites 2 --host $STORJ_NETWORK_HOST4 network destroy
 
 # setup the network with ipv6


### PR DESCRIPTION
What: Run uplink `test-sim` tests also with `--enc.data-type` set to 1 (unencrypted)

Why: Currently `test-sim` is testing only `AES-GCM` (default one) encryption type

Please describe the tests:
 - Test 1: this is test
 
Please describe the performance impact: none

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
