### PR TITLE
pkg/process: remove prometheus help

### DIFF
--- a/pkg/process/debug.go
+++ b/pkg/process/debug.go
@@ -84,8 +84,6 @@ func prometheus(w http.ResponseWriter, r *http.Request) {
 	// (https://prometheus.io/docs/concepts/metric_types/)
 	monkit.Default.Stats(func(name string, val float64) {
 		metric := sanitize(name)
-		_, _ = fmt.Fprintf(w, "# HELP %s %s\n%s %g\n",
-			metric, strings.ReplaceAll(name, "\n", " "),
-			metric, val)
+		_, _ = fmt.Fprintf(w, "%s %g\n", metric, val)
 	})
 }


### PR DESCRIPTION
what: take prometheus help messages out

why: the current prometheus help messages have enough unexpected characters that they are breaking prometheus parsing. they may also be triggering prometheus to expect more from us (type annotations) than we have to offer.

we're really not adding a lot of value with these help messages, so just take them out

Please describe the tests: no tests, because i don't want to import prometheus as a dependency just to test this one thing.
 
Please describe the performance impact: none

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
