### PR TITLE
storagenode/orderarchive: Reduce TTL from 45 to 7 days

### DIFF
--- a/storagenode/orders/service.go
+++ b/storagenode/orders/service.go
@@ -83,7 +83,7 @@ type Config struct {
 	SenderInterval  time.Duration `help:"duration between sending" default:"1h0m0s"`
 	SenderTimeout   time.Duration `help:"timeout for sending" default:"1h0m0s"`
 	CleanupInterval time.Duration `help:"duration between archive cleanups" default:"24h0m0s"`
-	ArchiveTTL      time.Duration `help:"length of time to archive orders before deletion" default:"1080h0m0s"` // 45 days
+	ArchiveTTL      time.Duration `help:"length of time to archive orders before deletion" default:"168h0m0s"` // 7 days
 }
 
 // Service sends every interval unsent orders to the satellite.


### PR DESCRIPTION
What: Reduce orderarchive TTL from 45 to 7 days.

Why: Because we reduced the order expire date from 45 to 7 days on the satellite side and storing it for 45 days is wasting too much space (info.db)

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
