### PR TITLE
add type to prometheus metrics

### DIFF
--- a/pkg/process/debug.go
+++ b/pkg/process/debug.go
@@ -84,6 +84,7 @@ func prometheus(w http.ResponseWriter, r *http.Request) {
 	// (https://prometheus.io/docs/concepts/metric_types/)
 	monkit.Default.Stats(func(name string, val float64) {
 		metric := sanitize(name)
-		_, _ = fmt.Fprintf(w, "%s %g\n", metric, val)
+		_, _ = fmt.Fprintf(w, "# TYPE %s gauge\n%s %g\n",
+			metric, metric, val)
 	})
 }


### PR DESCRIPTION
what: add the type to prometheus messages

why: im trying to export prometheus metrics to stackdriver but it keeps erroring with an untyped error.

Please describe the tests: no tests, because i don't want to import prometheus as a dependency just to test this one thing.

Please describe the performance impact: none

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
