### PR TITLE
pkg/process prometheus: forgot digits

### DIFF
--- a/pkg/process/debug.go
+++ b/pkg/process/debug.go
@@ -72,6 +72,8 @@ func sanitize(val string) string {
 			return r
 		case 'A' <= r && r <= 'Z':
 			return r
+		case '0' <= r && r <= '9':
+			return r
 		default:
 			return '_'
 		}


### PR DESCRIPTION
What: also allow digits during metric name sanitation

Why: cause they're totally valid to allow

Please describe the tests: don't want to include prometheus in tests just for this
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
