### PR TITLE
storagenode/orders: set custom request timeout for orders sending

### DIFF
--- a/internal/testplanet/storagenode.go
+++ b/internal/testplanet/storagenode.go
@@ -106,10 +106,11 @@ func (planet *Planet) newStorageNodes(count int, whitelistedSatellites storj.Nod
 				MaxConcurrentRequests: 100,
 				OrderLimitGracePeriod: time.Hour,
 				Orders: orders.Config{
-					SenderInterval:  time.Hour,
-					SenderTimeout:   time.Hour,
-					CleanupInterval: time.Hour,
-					ArchiveTTL:      time.Hour,
+					SenderInterval:       time.Hour,
+					SenderTimeout:        time.Hour,
+					SenderRequestTimeout: time.Hour,
+					CleanupInterval:      time.Hour,
+					ArchiveTTL:           time.Hour,
 				},
 				Monitor: monitor.Config{
 					MinimumBandwidth: 100 * memory.MB,

--- a/pkg/transport/timeout.go
+++ b/pkg/transport/timeout.go
@@ -4,9 +4,23 @@
 package transport
 
 import (
+	"context"
 	"net"
 	"time"
+
+	"google.golang.org/grpc"
 )
+
+// WithRequestTimeout defines request timeout (read/write) for grpc call
+func WithRequestTimeout(timeout time.Duration) grpc.DialOption {
+	return grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+		conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		return &timeoutConn{conn: conn, timeout: timeout}, nil
+	})
+}
 
 type timeoutConn struct {
 	conn    net.Conn

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -87,13 +87,7 @@ func (transport *Transport) DialNode(ctx context.Context, node *pb.Node, opts ..
 		dialOption,
 		grpc.WithBlock(),
 		grpc.FailOnNonTempDialError(true),
-		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
-			conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
-			if err != nil {
-				return nil, err
-			}
-			return &timeoutConn{conn: conn, timeout: transport.timeouts.Request}, nil
-		}),
+		WithRequestTimeout(transport.timeouts.Request),
 	}, opts...)
 
 	timedCtx, cancel := context.WithTimeout(ctx, transport.timeouts.Dial)

--- a/storagenode/orders/service.go
+++ b/storagenode/orders/service.go
@@ -254,7 +254,11 @@ func (service *Service) settle(ctx context.Context, log *zap.Logger, satelliteID
 		},
 	}
 
-	conn, err := service.transport.DialNode(ctx, &satellite)
+	conn, err := service.transport.DialNode(
+		ctx,
+		&satellite,
+		transport.WithRequestTimeout(service.config.SenderRequestTimeout),
+	)
 	if err != nil {
 		return OrderError.New("unable to connect to the satellite: %v", err)
 	}

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -290,20 +290,9 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 		}
 		pb.RegisterPiecestoreServer(peer.Server.GRPC(), peer.Storage2.Endpoint)
 
-		sc := config.Server
-		options, err := tlsopts.NewOptions(peer.Identity, sc.Config, revocationDB)
-		if err != nil {
-			return nil, errs.Combine(err, peer.Close())
-		}
-
-		// TODO workaround for custom timeout for order sending request (read/write)
-		ordersTransport := transport.NewClientWithTimeouts(options, transport.Timeouts{
-			Request: config.Storage2.Orders.SenderRequestTimeout,
-		})
-
 		peer.Storage2.Orders = orders.NewService(
 			log.Named("orders"),
-			ordersTransport,
+			peer.Transport,
 			peer.DB.Orders(),
 			peer.Storage2.Trust,
 			config.Storage2.Orders,


### PR DESCRIPTION
What: Set custom request timeout for storage node orders sending. This is a cleaner approach (in my opinion) comparing to #2930. 

Why: https://storjlabs.atlassian.net/browse/V3-2558

Please describe the tests:
 - Test 1: none
 
Please describe the performance impact: none

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
