### PR TITLE
pkg/server: Don't use Sugared logger

### DIFF
--- a/pkg/server/interceptors.go
+++ b/pkg/server/interceptors.go
@@ -29,7 +29,7 @@ func (server *Server) logOnErrorStreamInterceptor(srv interface{}, ss grpc.Serve
 			err == io.EOF {
 			return err
 		}
-		server.log.Sugar().Errorf("%+v", err)
+		server.log.Error("gRPC stream error response", zap.Error(err))
 	}
 	return err
 }
@@ -41,7 +41,7 @@ func (server *Server) logOnErrorUnaryInterceptor(ctx context.Context, req interf
 		if status.Code(err) == codes.NotFound {
 			return resp, err
 		}
-		server.log.Sugar().Errorf("%+v", err)
+		server.log.Error("gRPC unary error response", zap.Error(err))
 	}
 	return resp, err
 }
@@ -91,7 +91,9 @@ func UnaryMessageLoggingInterceptor(log *zap.Logger) grpc.UnaryServerInterceptor
 		if jsonReq, err := prepareRequestLog(ctx, req, info.Server, info.FullMethod); err == nil {
 			log.Info(string(jsonReq))
 		} else {
-			log.Sugar().Errorf("Failed to marshal %q request to JSON: %v", info.FullMethod, err)
+			log.Error("Failed to marshal request to JSON.",
+				zap.String("method", info.FullMethod), zap.Error(err),
+			)
 		}
 		return handler(ctx, req)
 	}
@@ -106,7 +108,9 @@ func StreamMessageLoggingInterceptor(log *zap.Logger) grpc.StreamServerIntercept
 		if jsonReq, err := prepareRequestLog(ss.Context(), srv, nil, info.FullMethod); err == nil {
 			log.Info(string(jsonReq))
 		} else {
-			log.Sugar().Errorf("Failed to marshal %q request to JSON: %v", info.FullMethod, err)
+			log.Error("Failed to marshal request to JSON.",
+				zap.String("method", info.FullMethod), zap.Error(err),
+			)
 		}
 		return handler(srv, ss)
 	}


### PR DESCRIPTION
What: Replace the usage of the Sugared logger by the normal one.

Why: Sugared logger performs worse and it isn't structured.

Please describe the tests: N/A 
Please describe the performance impact: Not measured, but it should perform faster when logging the messages.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
