### PR TITLE
satellite/satellitedb: always release savepoint in process orders

### DIFF
--- a/satellite/satellitedb/orders.go
+++ b/satellite/satellitedb/orders.go
@@ -285,7 +285,8 @@ func (db *ordersDB) ProcessOrders(ctx context.Context, requests []*orders.Proces
 					return nil, Error.Wrap(err)
 				}
 			} else {
-				return nil, Error.Wrap(err)
+				_, rerr := tx.Exec("rollback to savepoint sp")
+				return nil, errs.Combine(Error.Wrap(err), Error.Wrap(rerr))
 			}
 		}
 		_, err = tx.Exec("release savepoint sp")

--- a/satellite/satellitedb/orders.go
+++ b/satellite/satellitedb/orders.go
@@ -270,7 +270,7 @@ func (db *ordersDB) ProcessOrders(ctx context.Context, requests []*orders.Proces
 		// see https://www.postgresql.org/message-id/13131805-BCBB-42DF-953B-27EE36AAF213%40yahoo.com
 		_, err = tx.Exec("savepoint sp")
 		if err != nil {
-			return nil, err
+			return nil, Error.Wrap(err)
 		}
 
 		insert := "INSERT INTO used_serials (serial_number_id, storage_node_id) SELECT id, ? FROM serial_numbers WHERE serial_number = ?"
@@ -291,7 +291,7 @@ func (db *ordersDB) ProcessOrders(ctx context.Context, requests []*orders.Proces
 		}
 		_, err = tx.Exec("release savepoint sp")
 		if err != nil {
-			return nil, err
+			return nil, Error.Wrap(err)
 		}
 	}
 


### PR DESCRIPTION
What: Always release savepoints and wrap errors.

Why: Not releasing a savepoint can cause nasty deadlocks and not wrapping errors make difficult to identify from where they are generated.

Please describe the tests: No new tests. I haven't found a way how to have a test which could reproduce the problem of not releasing the savepoint. 

Please describe the performance impact: Wrapping errors always produce some performance impact, but it's necessary and the impact should be negligible.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
