### PR TITLE
storagenode: add custom dial timeout for orders sending

### DIFF
--- a/storagenode/orders/service.go
+++ b/storagenode/orders/service.go
@@ -82,6 +82,7 @@ type DB interface {
 type Config struct {
 	SenderInterval       time.Duration `help:"duration between sending" default:"1h0m0s"`
 	SenderTimeout        time.Duration `help:"timeout for sending" default:"1h0m0s"`
+	SenderDialTimeout    time.Duration `help:"timeout for dialing satellite during sending orders" default:"1m0s"`
 	SenderRequestTimeout time.Duration `help:"timeout for read/write operations during sending" default:"1h0m0s"`
 	CleanupInterval      time.Duration `help:"duration between archive cleanups" default:"24h0m0s"`
 	ArchiveTTL           time.Duration `help:"length of time to archive orders before deletion" default:"168h0m0s"` // 7 days

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -298,6 +298,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 
 		// TODO workaround for custom timeout for order sending request (read/write)
 		ordersTransport := transport.NewClientWithTimeouts(options, transport.Timeouts{
+			Dial:    config.Storage2.Orders.SenderDialTimeout,
 			Request: config.Storage2.Orders.SenderRequestTimeout,
 		})
 


### PR DESCRIPTION
What: Set custom dial timeout for storage node orders sending (default changed from 20s to 1m). Also parameter for configuring this timeout added - ` --storage2.orders.sender-dial-timeout` .

Why: Some storage nodes are not able to send orders because 20s of dialing to the satellite is not enough for them.

Please describe the tests:
 - Test 1: none
 
Please describe the performance impact: none

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
