### PR TITLE
storagenode/console: remove kademlia

### DIFF
--- a/storagenode/console/service.go
+++ b/storagenode/console/service.go
@@ -14,7 +14,6 @@ import (
 	"storj.io/storj/internal/date"
 	"storj.io/storj/internal/memory"
 	"storj.io/storj/internal/version"
-	"storj.io/storj/pkg/kademlia"
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/storagenode/bandwidth"
 	"storj.io/storj/storagenode/pieces"
@@ -46,20 +45,20 @@ type Service struct {
 	reputationDB   reputation.DB
 	storageUsageDB storageusage.DB
 	pieceStore     *pieces.Store
-	kademlia       *kademlia.Kademlia
 	version        *version.Service
 
 	allocatedBandwidth memory.Size
 	allocatedDiskSpace memory.Size
+	nodeID             storj.NodeID
 	walletAddress      string
 	startedAt          time.Time
 	versionInfo        version.Info
 }
 
 // NewService returns new instance of Service.
-func NewService(log *zap.Logger, consoleDB DB, bandwidth bandwidth.DB, pieceStore *pieces.Store, kademlia *kademlia.Kademlia, version *version.Service,
+func NewService(log *zap.Logger, consoleDB DB, bandwidth bandwidth.DB, pieceStore *pieces.Store, version *version.Service,
 	allocatedBandwidth, allocatedDiskSpace memory.Size, walletAddress string, versionInfo version.Info, trust *trust.Pool,
-	reputationDB reputation.DB, storageUsageDB storageusage.DB) (*Service, error) {
+	reputationDB reputation.DB, storageUsageDB storageusage.DB, myNodeID storj.NodeID) (*Service, error) {
 	if log == nil {
 		return nil, errs.New("log can't be nil")
 	}
@@ -80,10 +79,6 @@ func NewService(log *zap.Logger, consoleDB DB, bandwidth bandwidth.DB, pieceStor
 		return nil, errs.New("version can't be nil")
 	}
 
-	if kademlia == nil {
-		return nil, errs.New("kademlia can't be nil")
-	}
-
 	return &Service{
 		log:                log,
 		trust:              trust,
@@ -92,10 +87,10 @@ func NewService(log *zap.Logger, consoleDB DB, bandwidth bandwidth.DB, pieceStor
 		reputationDB:       reputationDB,
 		storageUsageDB:     storageUsageDB,
 		pieceStore:         pieceStore,
-		kademlia:           kademlia,
 		version:            version,
 		allocatedBandwidth: allocatedBandwidth,
 		allocatedDiskSpace: allocatedDiskSpace,
+		nodeID:             myNodeID,
 		walletAddress:      walletAddress,
 		startedAt:          time.Now(),
 		versionInfo:        versionInfo,
@@ -121,7 +116,7 @@ func (s *Service) GetDashboardData(ctx context.Context) (_ *Dashboard, err error
 	defer mon.Task()(&ctx)(&err)
 	data := new(Dashboard)
 
-	data.NodeID = s.kademlia.Local().Id
+	data.NodeID = s.nodeID
 	data.Wallet = s.walletAddress
 	data.Version = s.versionInfo.Version
 	data.UpToDate = s.version.IsAllowed()

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -334,7 +334,6 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 			peer.DB.Console(),
 			peer.DB.Bandwidth(),
 			peer.Storage2.Store,
-			peer.Kademlia.Service,
 			peer.Version,
 			config.Storage.AllocatedBandwidth,
 			config.Storage.AllocatedDiskSpace,
@@ -342,7 +341,8 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 			versionInfo,
 			peer.Storage2.Trust,
 			peer.DB.Reputation(),
-			peer.DB.StorageUsage())
+			peer.DB.StorageUsage(),
+			peer.Local().Id)
 
 		if err != nil {
 			return nil, errs.Combine(err, peer.Close())


### PR DESCRIPTION
this is a trivial operation for storagenode/console, as it doesn't
really need or use kademlia in the first place.

What: 

Removes kademlia from storagenode/console

Why:

We are in the process of getting rid of kademlia, and this is one place where it's particularly easy.

Please describe the tests:
 - Existing tests exercise storagenode/console behavior; if they continue to work, everything here should be tested satisfactorily.
 
Please describe the performance impact:

None

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
