### PR TITLE
satellite,storagenode,bootstrap: add contact service to peer

### DIFF
--- a/bootstrap/peer.go
+++ b/bootstrap/peer.go
@@ -23,7 +23,6 @@ import (
 	"storj.io/storj/pkg/server"
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/pkg/transport"
-	"storj.io/storj/satellite/contact"
 	"storj.io/storj/satellite/overlay"
 	"storj.io/storj/storage"
 )
@@ -75,11 +74,6 @@ type Peer struct {
 		Service      *kademlia.Kademlia
 		Endpoint     *kademlia.Endpoint
 		Inspector    *kademlia.Inspector
-	}
-
-	Contact struct {
-		Service  *contact.Service
-		Endpoint *contact.Endpoint
 	}
 
 	// Web server with web UI
@@ -171,12 +165,6 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revDB extensions.R
 
 		peer.Kademlia.Inspector = kademlia.NewInspector(peer.Kademlia.Service, peer.Identity)
 		pb.RegisterKadInspectorServer(peer.Server.PrivateGRPC(), peer.Kademlia.Inspector)
-	}
-
-	{ // setup contact service
-		log.Debug("Setting up contact service")
-		peer.Contact.Service = contact.NewService(peer.Log.Named("contact"), peer.Overlay.Service, peer.Transport)
-		peer.Contact.Endpoint = contact.NewEndpoint(peer.Log.Named("contact:endpoint"), peer.Contact.Service)
 	}
 
 	{ // setup bootstrap web ui

--- a/bootstrap/peer.go
+++ b/bootstrap/peer.go
@@ -23,6 +23,7 @@ import (
 	"storj.io/storj/pkg/server"
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/pkg/transport"
+	"storj.io/storj/satellite/contact"
 	"storj.io/storj/satellite/overlay"
 	"storj.io/storj/storage"
 )
@@ -74,6 +75,11 @@ type Peer struct {
 		Service      *kademlia.Kademlia
 		Endpoint     *kademlia.Endpoint
 		Inspector    *kademlia.Inspector
+	}
+
+	Contact struct {
+		Service  *contact.Service
+		Endpoint *contact.Endpoint
 	}
 
 	// Web server with web UI
@@ -165,6 +171,12 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revDB extensions.R
 
 		peer.Kademlia.Inspector = kademlia.NewInspector(peer.Kademlia.Service, peer.Identity)
 		pb.RegisterKadInspectorServer(peer.Server.PrivateGRPC(), peer.Kademlia.Inspector)
+	}
+
+	{ // setup contact service
+		log.Debug("Setting up contact service")
+		peer.Contact.Service = contact.NewService(peer.Log.Named("contact"), peer.Overlay.Service, peer.Transport)
+		peer.Contact.Endpoint = contact.NewEndpoint(peer.Log.Named("contact:endpoint"), peer.Contact.Service)
 	}
 
 	{ // setup bootstrap web ui

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -40,6 +40,7 @@ import (
 	"storj.io/storj/satellite/console"
 	"storj.io/storj/satellite/console/consoleauth"
 	"storj.io/storj/satellite/console/consoleweb"
+	"storj.io/storj/satellite/contact"
 	"storj.io/storj/satellite/dbcleanup"
 	"storj.io/storj/satellite/discovery"
 	"storj.io/storj/satellite/gc"
@@ -157,6 +158,10 @@ type Peer struct {
 		Service      *kademlia.Kademlia
 		Endpoint     *kademlia.Endpoint
 		Inspector    *kademlia.Inspector
+	}
+
+	Contact struct {
+		Service *contact.Service
 	}
 
 	Overlay struct {
@@ -350,6 +355,11 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 
 		peer.Kademlia.Inspector = kademlia.NewInspector(peer.Kademlia.Service, peer.Identity)
 		pb.RegisterKadInspectorServer(peer.Server.PrivateGRPC(), peer.Kademlia.Inspector)
+	}
+
+	{ // setup contact service
+		log.Debug("Setting up contact service")
+		peer.Contact.Service = contact.NewService(peer.Log.Named("contact"), peer.Overlay.Service, peer.Transport)
 	}
 
 	{ // setup discovery

--- a/storagenode/contact/service.go
+++ b/storagenode/contact/service.go
@@ -20,7 +20,7 @@ var mon = monkit.Package()
 // Service is the contact service between storage nodes and satellites
 type Service struct {
 	log       *zap.Logger
-	self      *overlay.NodeDossier
+	self      overlay.NodeDossier
 	transport transport.Client
 
 	mu               sync.Mutex
@@ -30,7 +30,7 @@ type Service struct {
 }
 
 // NewService creates a new contact service
-func NewService(log *zap.Logger, self *overlay.NodeDossier, transport transport.Client) *Service {
+func NewService(log *zap.Logger, self overlay.NodeDossier, transport transport.Client) *Service {
 	return &Service{
 		log:       log,
 		self:      self,
@@ -56,5 +56,5 @@ func (service *Service) wasPinged(when time.Time, srcNodeID storj.NodeID, srcAdd
 
 // Local returns the local node
 func (service *Service) Local() overlay.NodeDossier {
-	return *service.self
+	return service.self
 }

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -29,6 +29,7 @@ import (
 	"storj.io/storj/storagenode/collector"
 	"storj.io/storj/storagenode/console"
 	"storj.io/storj/storagenode/console/consoleserver"
+	"storj.io/storj/storagenode/contact"
 	"storj.io/storj/storagenode/inspector"
 	"storj.io/storj/storagenode/monitor"
 	"storj.io/storj/storagenode/nodestats"
@@ -115,6 +116,11 @@ type Peer struct {
 		Service      *kademlia.Kademlia
 		Endpoint     *kademlia.Endpoint
 		Inspector    *kademlia.Inspector
+	}
+
+	Contact struct {
+		Service  *contact.Service
+		Endpoint *contact.Endpoint
 	}
 
 	Storage2 struct {
@@ -235,6 +241,11 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 
 		peer.Kademlia.Inspector = kademlia.NewInspector(peer.Kademlia.Service, peer.Identity)
 		pb.RegisterKadInspectorServer(peer.Server.PrivateGRPC(), peer.Kademlia.Inspector)
+	}
+
+	{ // setup contact service
+		peer.Contact.Service = contact.NewService(peer.Log.Named("contact"), peer.Kademlia.RoutingTable.Local(), peer.Transport)
+		peer.Contact.Endpoint = contact.NewEndpoint(peer.Log.Named("contact:endpoint"), peer.Contact.Service)
 	}
 
 	{ // setup storage


### PR DESCRIPTION
What: 

Adds contact services and endpoints as necessary to satellite and storagenode.

Why:

We will need these once we remove kademlia.

Please describe the tests:
 - There is not really any new behavior to test right now; if anything works at all once we start using these facilities, then this change works.
 
Please describe the performance impact:

None

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
