### PR TITLE
[use-drpc 2] pkg/listenmux: multiplexing listener for drpc

### DIFF
--- a/pkg/listenmux/listener.go
+++ b/pkg/listenmux/listener.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package listenmux
+
+import (
+	"net"
+	"sync"
+
+	"github.com/zeebo/errs"
+)
+
+type listener struct {
+	addr  net.Addr
+	conns chan net.Conn
+	once  sync.Once
+	done  chan struct{}
+	err   error
+}
+
+func newListener(addr net.Addr) *listener {
+	return &listener{
+		addr:  addr,
+		conns: make(chan net.Conn),
+		done:  make(chan struct{}),
+	}
+}
+
+func (l *listener) Conns() chan net.Conn { return l.conns }
+
+// Accept waits for and returns the next connection to the listener.
+func (l *listener) Accept() (conn net.Conn, err error) {
+	select {
+	case <-l.done:
+		return nil, l.err
+	default:
+	}
+	select {
+	case <-l.done:
+		return nil, l.err
+	case conn = <-l.conns:
+		return conn, nil
+	}
+}
+
+// Close closes the listener.
+// Any blocked Accept operations will be unblocked and return errors.
+func (l *listener) Close() error {
+	l.once.Do(func() {
+		l.err = errs.New("listener closed")
+		close(l.done)
+	})
+	return nil
+}
+
+// Addr returns the listener's network address.
+func (l *listener) Addr() net.Addr {
+	return l.addr
+}

--- a/pkg/listenmux/listener.go
+++ b/pkg/listenmux/listener.go
@@ -26,6 +26,7 @@ func newListener(addr net.Addr) *listener {
 	}
 }
 
+// Conns returns the channel of net.Conn that the listener reads from.
 func (l *listener) Conns() chan net.Conn { return l.conns }
 
 // Accept waits for and returns the next connection to the listener.

--- a/pkg/listenmux/mux.go
+++ b/pkg/listenmux/mux.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 )
 
+// Mux lets one multiplex a listener into different listeners based on the first
+// bytes sent on the connection.
 type Mux struct {
 	base      net.Listener
 	prefixLen int
@@ -25,6 +27,8 @@ type Mux struct {
 	err  error
 }
 
+// New creates a mux that reads the prefixLen bytes from any connections Accepted by the
+// passed in listener and dispatches to the appropriate route.
 func New(base net.Listener, prefixLen int) *Mux {
 	addr := base.Addr()
 	return &Mux{
@@ -43,8 +47,11 @@ func New(base net.Listener, prefixLen int) *Mux {
 // set up the routes
 //
 
+// Default returns the net.Listener that is used if no route matches.
 func (m *Mux) Default() net.Listener { return m.def }
 
+// Route returns a listener that will be used if the first bytes are the given prefix. The
+// length of the prefix must match the original passed in prefixLen.
 func (m *Mux) Route(prefix string) net.Listener {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -66,6 +73,8 @@ func (m *Mux) Route(prefix string) net.Listener {
 // run the muxer
 //
 
+// Run calls listen on the provided listener and passes connections to the routed
+// listeners.
 func (m *Mux) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/listenmux/mux.go
+++ b/pkg/listenmux/mux.go
@@ -1,0 +1,159 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package listenmux
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+)
+
+type Mux struct {
+	base      net.Listener
+	prefixLen int
+	addr      net.Addr
+	def       *listener
+
+	mu     sync.Mutex
+	routes map[string]*listener
+
+	once sync.Once
+	done chan struct{}
+	err  error
+}
+
+func New(base net.Listener, prefixLen int) *Mux {
+	addr := base.Addr()
+	return &Mux{
+		base:      base,
+		prefixLen: prefixLen,
+		addr:      addr,
+		def:       newListener(addr),
+
+		routes: make(map[string]*listener),
+
+		done: make(chan struct{}),
+	}
+}
+
+//
+// set up the routes
+//
+
+func (m *Mux) Default() net.Listener { return m.def }
+
+func (m *Mux) Route(prefix string) net.Listener {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(prefix) != m.prefixLen {
+		panic(fmt.Sprintf("invalid prefix: has %d but needs %d bytes", len(prefix), m.prefixLen))
+	}
+
+	lis, ok := m.routes[prefix]
+	if !ok {
+		lis = newListener(m.addr)
+		m.routes[prefix] = lis
+		go m.monitorListener(prefix, lis)
+	}
+	return lis
+}
+
+//
+// run the muxer
+//
+
+func (m *Mux) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go m.monitorBase()
+	go m.monitorSignal()
+	go m.monitorContext(ctx)
+
+	<-m.done
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, lis := range m.routes {
+		<-lis.done
+	}
+
+	return m.err
+}
+
+func (m *Mux) monitorSignal() {
+	<-m.done
+	// TODO(jeff): do we care about this error?
+	_ = m.base.Close()
+}
+
+func (m *Mux) monitorContext(ctx context.Context) {
+	<-ctx.Done()
+	m.once.Do(func() {
+		m.err = ctx.Err()
+		close(m.done)
+	})
+}
+
+func (m *Mux) monitorListener(prefix string, lis *listener) {
+	select {
+	case <-m.done:
+		lis.once.Do(func() {
+			lis.err = m.err
+			close(lis.done)
+		})
+	case <-lis.done:
+	}
+	m.mu.Lock()
+	delete(m.routes, prefix)
+	m.mu.Unlock()
+}
+
+func (m *Mux) monitorBase() {
+	for {
+		conn, err := m.base.Accept()
+		switch {
+		case err != nil:
+			// TODO(jeff): temporary errors?
+			m.once.Do(func() {
+				m.err = err
+				close(m.done)
+			})
+			return
+		case conn == nil:
+			<-m.done
+			return
+		}
+		go m.routeConn(conn)
+	}
+}
+
+func (m *Mux) routeConn(conn net.Conn) {
+	buf := make([]byte, m.prefixLen)
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		// TODO(jeff): how to handle this error?
+		return
+	}
+
+	m.mu.Lock()
+	lis, ok := m.routes[string(buf)]
+	if !ok {
+		lis = m.def
+		conn = newPrefixConn(buf, conn)
+	}
+	m.mu.Unlock()
+
+	// TODO(jeff): a timeout for the listener to get to the conn?
+
+	select {
+	case <-lis.done:
+		// TODO(jeff): better way to signal to the caller the listener is closed?
+		_ = conn.Close()
+	case lis.Conns() <- conn:
+	}
+}

--- a/pkg/listenmux/mux_test.go
+++ b/pkg/listenmux/mux_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package listenmux
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+type fakeListener []*prefixConn
+
+func (fl *fakeListener) Close() error   { return nil }
+func (fl *fakeListener) Addr() net.Addr { return nil }
+
+func (fl *fakeListener) Accept() (c net.Conn, err error) {
+	if len(*fl) == 0 {
+		return nil, nil
+	}
+	c, *fl = (*fl)[0], (*fl)[1:]
+	return c, nil
+}
+
+func TestMux(t *testing.T) {
+	expect := func(lis net.Listener, data string) func() error {
+		return func() error {
+			conn, err := lis.Accept()
+			if err != nil {
+				return err
+			}
+
+			buf := make([]byte, len(data))
+			_, err = io.ReadFull(conn, buf)
+			if err != nil {
+				return err
+			}
+
+			require.Equal(t, data, string(buf))
+			return nil
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lis := &fakeListener{
+		newPrefixConn([]byte("prefix1data1"), nil),
+		newPrefixConn([]byte("prefix2data2"), nil),
+		newPrefixConn([]byte("prefix3data3"), nil),
+	}
+
+	mux := New(lis, len("prefixN"))
+
+	var muxGroup errgroup.Group
+	muxGroup.Go(func() error { return mux.Run(ctx) })
+
+	var lisGroup errgroup.Group
+	lisGroup.Go(expect(mux.Route("prefix1"), "data1"))
+	lisGroup.Go(expect(mux.Route("prefix2"), "data2"))
+	lisGroup.Go(expect(mux.Default(), "prefix3data3"))
+	require.NoError(t, lisGroup.Wait())
+
+	cancel()
+	require.Equal(t, context.Canceled, muxGroup.Wait())
+}

--- a/pkg/listenmux/mux_test.go
+++ b/pkg/listenmux/mux_test.go
@@ -66,5 +66,5 @@ func TestMux(t *testing.T) {
 	require.NoError(t, lisGroup.Wait())
 
 	cancel()
-	require.Equal(t, context.Canceled, muxGroup.Wait())
+	require.Equal(t, nil, muxGroup.Wait())
 }

--- a/pkg/listenmux/prefixconn.go
+++ b/pkg/listenmux/prefixconn.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package listenmux
+
+import (
+	"bytes"
+	"io"
+	"net"
+)
+
+type prefixConn struct {
+	io.Reader
+	net.Conn
+}
+
+func newPrefixConn(data []byte, conn net.Conn) *prefixConn {
+	return &prefixConn{
+		Reader: io.MultiReader(bytes.NewReader(data), conn),
+		Conn:   conn,
+	}
+}
+
+func (pc *prefixConn) Read(p []byte) (n int, err error) {
+	return pc.Reader.Read(p)
+}


### PR DESCRIPTION
What: Adds a package that allows us to host multiple protocols on the same port

Why: So that we can have servers speak grpc normally, but we can add some special bytes to the front of a dial to get drpc

Please describe the tests:
 - Test 1:
 - Test 2:

Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?