### PR TITLE
[use-drpc 5] storagenode/piecestore: port to add drpc support

### DIFF
--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -299,6 +299,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 			return nil, errs.Combine(err, peer.Close())
 		}
 		pb.RegisterPiecestoreServer(peer.Server.GRPC(), peer.Storage2.Endpoint)
+		peer.Server.DRPC().Register(peer.Storage2.Endpoint, new(pb.DRPCPiecestoreDescription))
 
 		sc := config.Server
 		options, err := tlsopts.NewOptions(peer.Identity, sc.Config, revocationDB)


### PR DESCRIPTION
What: Adds drpc methods to the piecestore endpoints.

Why: So that the piecestore is accessible over drpc.

Please describe the tests:
 - Test 1:
 - Test 2:

Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?