### PR TITLE
[use-drpc 6] storagenode/contact: port to add drpc support

### DIFF
--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -245,7 +245,10 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 
 	{ // setup contact service
 		peer.Contact.Service = contact.NewService(peer.Log.Named("contact"), peer.Kademlia.RoutingTable.Local(), peer.Transport)
+
 		peer.Contact.Endpoint = contact.NewEndpoint(peer.Log.Named("contact:endpoint"), peer.Contact.Service)
+		pb.RegisterContactServer(peer.Server.GRPC(), peer.Contact.Endpoint)
+		peer.Server.DRPC().Register(peer.Contact.Endpoint, new(pb.DRPCContactDescription))
 	}
 
 	{ // setup storage


### PR DESCRIPTION
What: Adds drpc methods to the contact endpoint.

Why: So that the contact service is accessible over drpc.

It also registers the service so that it's available.

Please describe the tests:
 - Test 1:
 - Test 2:

Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?