### PR TITLE
Fix flaky repair tests

### DIFF
--- a/satellite/repair/repair_test.go
+++ b/satellite/repair/repair_test.go
@@ -69,7 +69,7 @@ func TestDataRepair(t *testing.T) {
 			MinThreshold:     minThreshold,
 			RepairThreshold:  5,
 			SuccessThreshold: successThreshold,
-			MaxThreshold:     10,
+			MaxThreshold:     9,
 		}, "testbucket", "test/path", testData)
 		require.NoError(t, err)
 
@@ -202,7 +202,7 @@ func TestCorruptDataRepair(t *testing.T) {
 			MinThreshold:     3,
 			RepairThreshold:  5,
 			SuccessThreshold: 7,
-			MaxThreshold:     10,
+			MaxThreshold:     9,
 		}, "testbucket", "test/path", testData)
 		require.NoError(t, err)
 


### PR DESCRIPTION
What: 
Decrease the maximum threshold for uploads during repair tests.

Why:
We recently merged a PR which now only requires the minimum threshold number  of pieces to properly repair. However, we didn't update other values in the test, which means in some circumstances when the total number of pieces are uploaded to, there are not enough remaining nodes to repair on.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
