### PR TITLE
satellite/repair: Use k+1 pieces instead of k for repair

### DIFF
--- a/satellite/repair/checker/checker.go
+++ b/satellite/repair/checker/checker.go
@@ -161,10 +161,10 @@ func (checker *Checker) updateIrreparableSegmentStatus(ctx context.Context, poin
 	numHealthy := int32(len(pieces) - len(missingPieces))
 	redundancy := pointer.Remote.Redundancy
 
-	// we repair when the number of healthy pieces is less than or equal to the repair threshold and is greater or equal to
+	// we repair when the number of healthy pieces is less than or equal to the repair threshold and is greater than
 	// minimum required pieces in redundancy
 	// except for the case when the repair and success thresholds are the same (a case usually seen during testing)
-	if numHealthy >= redundancy.MinReq && numHealthy <= redundancy.RepairThreshold && numHealthy < redundancy.SuccessThreshold {
+	if numHealthy > redundancy.MinReq && numHealthy <= redundancy.RepairThreshold && numHealthy < redundancy.SuccessThreshold {
 		if len(missingPieces) == 0 {
 			checker.logger.Error("Missing pieces is zero in checker, but this should be impossible -- bad redundancy scheme:",
 				zap.String("path", path),
@@ -188,7 +188,7 @@ func (checker *Checker) updateIrreparableSegmentStatus(ctx context.Context, poin
 		if err != nil {
 			checker.logger.Error("error deleting entry from irreparable db: ", zap.Error(err))
 		}
-	} else if numHealthy < redundancy.MinReq && numHealthy < redundancy.RepairThreshold {
+	} else if numHealthy <= redundancy.MinReq && numHealthy < redundancy.RepairThreshold {
 
 		// make an entry into the irreparable table
 		segmentInfo := &pb.IrreparableSegment{
@@ -240,10 +240,10 @@ func (obs *checkerObserver) RemoteSegment(ctx context.Context, path storj.Path, 
 
 	redundancy := pointer.Remote.Redundancy
 
-	// we repair when the number of healthy pieces is less than or equal to the repair threshold and is greater or equal to
+	// we repair when the number of healthy pieces is less than or equal to the repair threshold and is greater than
 	// minimum required pieces in redundancy
 	// except for the case when the repair and success thresholds are the same (a case usually seen during testing)
-	if numHealthy >= redundancy.MinReq && numHealthy <= redundancy.RepairThreshold && numHealthy < redundancy.SuccessThreshold {
+	if numHealthy > redundancy.MinReq && numHealthy <= redundancy.RepairThreshold && numHealthy < redundancy.SuccessThreshold {
 		if len(missingPieces) == 0 {
 			obs.log.Error("Missing pieces is zero in checker, but this should be impossible -- bad redundancy scheme:",
 				zap.String("path", path),
@@ -270,7 +270,7 @@ func (obs *checkerObserver) RemoteSegment(ctx context.Context, path storj.Path, 
 			obs.log.Error("error deleting entry from irreparable db", zap.Error(err))
 			return nil
 		}
-	} else if numHealthy < redundancy.MinReq && numHealthy < redundancy.RepairThreshold {
+	} else if numHealthy <= redundancy.MinReq && numHealthy < redundancy.RepairThreshold {
 		pathElements := storj.SplitPath(path)
 
 		// check to make sure there are at least *4* path elements. the first three


### PR DESCRIPTION
What: 
Go back to using k+1 minimum pieces for repair so that we can take advantage of RS error detection until we can design a system that supports k pieces.

Why:
Since we can't rely on uplink signing keys being the same on all storagenodes for a segment (https://github.com/storj/storj/pull/2975), even if we are checking signed hashes, there is nothing preventing a storagenode from generating its own "uplink public key", signing a hash of incorrect data with that, updating its original order limit, and sending the incorrect data as a response to `GET_REPAIR`.
This pull request still allows us to take advantage of the hash checking of repair, which will allow us to detect failed audits during repair in the future, and to discard data that does not match the signed hash provided, but it will still decode with error correction in case any pieces are incorrect.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
