### PR TITLE
Handle migration for split storagenodedbs

### DIFF
--- a/storagenode/storagenodedb/bandwidthdb.go
+++ b/storagenode/storagenodedb/bandwidthdb.go
@@ -21,7 +21,10 @@ import (
 // ErrBandwidth represents errors from the bandwidthdb database.
 var ErrBandwidth = errs.Class("bandwidthdb error")
 
-var BandwidthDatabaseFilename = "bandwidth.db"
+const (
+	BandwidthDBName           = "bandwidth"
+	BandwidthDatabaseFilename = "bandwidth.db"
+)
 
 type bandwidthDB struct {
 	// Moved to top of struct to resolve alignment issue with atomic operations on ARM

--- a/storagenode/storagenodedb/database.go
+++ b/storagenode/storagenodedb/database.go
@@ -203,7 +203,7 @@ func (db *DB) openDatabases(databasesPath string) error {
 		db.pieceExpirationDB.SQLDB = pieceExpirationDB
 	}
 
-	v0PieceInfoDB, err := db.openDatabase(db.sqliteDriverInstanceKey, filepath.Join(databasesPath, v0PieceInfoDatabaseFilename))
+	v0PieceInfoDB, err := db.openDatabase(db.sqliteDriverInstanceKey, filepath.Join(databasesPath, V0PieceInfoDatabaseFilename))
 	if err != nil {
 		return err
 	}
@@ -384,7 +384,15 @@ func (db *DB) RoutingTable() (kdb, ndb, adb storage.KeyValueStore) {
 // RawDatabases are required for testing purposes
 func (db *DB) RawDatabases() map[string]SQLDB {
 	return map[string]SQLDB{
-		"versions": db.versionsDB,
+		BandwidthDBName:       db.bandwidthDB,
+		OrdersDBName:          db.ordersDB,
+		PieceExpirationDBName: db.pieceExpirationDB,
+		PieceSpaceUsedDBName:  db.pieceSpaceUsedDB,
+		ReputationDBName:      db.reputationDB,
+		StorageUsageDBName:    db.storageUsageDB,
+		UsedSerialsDBName:     db.usedSerialsDB,
+		PieceInfoDBName:       db.v0PieceInfoDB,
+		VersionsDBName:        db.versionsDB,
 	}
 }
 
@@ -815,10 +823,10 @@ func (db *DB) Migration() *migrate.Migration {
 						return ErrDatabase.Wrap(err)
 					}
 
-					if err := sqliteutil.MigrateToDatabase(ctx, db.sqliteConnections, db.sqliteDriverInstanceKey, VersionsDatabaseFilename, v0PieceInfoDatabaseFilename, "pieceinfo_"); err != nil {
+					if err := sqliteutil.MigrateToDatabase(ctx, db.sqliteConnections, db.sqliteDriverInstanceKey, VersionsDatabaseFilename, V0PieceInfoDatabaseFilename, "pieceinfo_"); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
-					if err := db.closeDatabase(v0PieceInfoDatabaseFilename); err != nil {
+					if err := db.closeDatabase(V0PieceInfoDatabaseFilename); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
 

--- a/storagenode/storagenodedb/migrations_test.go
+++ b/storagenode/storagenodedb/migrations_test.go
@@ -5,6 +5,7 @@ package storagenodedb_test
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -124,6 +125,17 @@ func TestMigrate(t *testing.T) {
 
 		// verify schema and data for each db in the expected snapshot
 		for dbName, dbSnapshot := range multiDBSnapshot.DBSnapshots {
+			// If the tables and indexes of the schema are empty, that's
+			// semantically the same as nil. Set to nil explicitly to help with
+			// comparison to snapshot.
+			schema, ok := schemas[dbName]
+			if ok && len(schema.Tables) == 0 {
+				schema.Tables = nil
+			}
+			if ok && len(schema.Indexes) == 0 {
+				schema.Indexes = nil
+			}
+
 			require.Equal(t, dbSnapshot.Schema, schemas[dbName], tag)
 			require.Equal(t, dbSnapshot.Data, data[dbName], tag)
 		}

--- a/storagenode/storagenodedb/orders.go
+++ b/storagenode/storagenodedb/orders.go
@@ -19,7 +19,10 @@ import (
 // ErrOrders represents errors from the ordersdb database.
 var ErrOrders = errs.Class("ordersdb error")
 
-var OrdersDatabaseFilename = "orders.db"
+const (
+	OrdersDBName           = "orders"
+	OrdersDatabaseFilename = "orders.db"
+)
 
 type ordersDB struct {
 	SQLDB

--- a/storagenode/storagenodedb/pieceexpiration.go
+++ b/storagenode/storagenodedb/pieceexpiration.go
@@ -16,7 +16,10 @@ import (
 // ErrPieceExpiration represents errors from the piece expiration database.
 var ErrPieceExpiration = errs.Class("piece expiration error")
 
-var PieceExpirationDatabaseFilename = "piece_expirations.db"
+const (
+	PieceExpirationDBName           = "piece_expiration"
+	PieceExpirationDatabaseFilename = "piece_expirations.db"
+)
 
 type pieceExpirationDB struct {
 	SQLDB

--- a/storagenode/storagenodedb/pieceinfo.go
+++ b/storagenode/storagenodedb/pieceinfo.go
@@ -21,7 +21,10 @@ import (
 // ErrPieceInfo represents errors from the piece info database.
 var ErrPieceInfo = errs.Class("v0pieceinfodb error")
 
-var v0PieceInfoDatabaseFilename = "pieceinfo.db"
+const (
+	PieceInfoDBName             = "pieceinfo"
+	V0PieceInfoDatabaseFilename = "pieceinfo.db"
+)
 
 type v0PieceInfoDB struct {
 	SQLDB

--- a/storagenode/storagenodedb/piecespaceused.go
+++ b/storagenode/storagenodedb/piecespaceused.go
@@ -15,7 +15,10 @@ import (
 // ErrPieceSpaceUsed represents errors from the piece spaced used database.
 var ErrPieceSpaceUsed = errs.Class("piece space used error")
 
-var PieceSpacedUsedDatabaseFilename = "piece_spaced_used.db"
+const (
+	PieceSpaceUsedDBName            = "piece_spaced_used"
+	PieceSpacedUsedDatabaseFilename = "piece_spaced_used.db"
+)
 
 type pieceSpaceUsedDB struct {
 	SQLDB

--- a/storagenode/storagenodedb/reputation.go
+++ b/storagenode/storagenodedb/reputation.go
@@ -16,7 +16,10 @@ import (
 // ErrReputation represents errors from the reputation database.
 var ErrReputation = errs.Class("reputation error")
 
-var ReputationDatabaseFilename = "reputation.db"
+const (
+	ReputationDBName           = "reputation"
+	ReputationDatabaseFilename = "reputation.db"
+)
 
 // reputation works with node reputation DB
 type reputationDB struct {

--- a/storagenode/storagenodedb/storageusage.go
+++ b/storagenode/storagenodedb/storageusage.go
@@ -14,7 +14,10 @@ import (
 	"storj.io/storj/storagenode/storageusage"
 )
 
-var StorageUsageDatabaseFilename = "storage_usage.db"
+const (
+	StorageUsageDBName           = "storage_usage"
+	StorageUsageDatabaseFilename = "storage_usage.db"
+)
 
 // storageusageDB storage usage DB
 type storageusageDB struct {

--- a/storagenode/storagenodedb/testdata/multidbsnapshot.go
+++ b/storagenode/storagenodedb/testdata/multidbsnapshot.go
@@ -34,6 +34,7 @@ var States = MultiDBStates{
 		&v18,
 		&v19,
 		&v20,
+		&v21,
 	},
 }
 

--- a/storagenode/storagenodedb/testdata/v0.go
+++ b/storagenode/storagenodedb/testdata/v0.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v0 = MultiDBState{
 	Version: 0,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial (
 					satellite_id  BLOB NOT NULL,

--- a/storagenode/storagenodedb/testdata/v1.go
+++ b/storagenode/storagenodedb/testdata/v1.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v1 = MultiDBState{
 	Version: 1,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial (

--- a/storagenode/storagenodedb/testdata/v10.go
+++ b/storagenode/storagenodedb/testdata/v10.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v10 = MultiDBState{
 	Version: 10,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial (

--- a/storagenode/storagenodedb/testdata/v11.go
+++ b/storagenode/storagenodedb/testdata/v11.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v11 = MultiDBState{
 	Version: 11,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial (

--- a/storagenode/storagenodedb/testdata/v12.go
+++ b/storagenode/storagenodedb/testdata/v12.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v12 = MultiDBState{
 	Version: 12,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial_ (

--- a/storagenode/storagenodedb/testdata/v15.go
+++ b/storagenode/storagenodedb/testdata/v15.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v15 = MultiDBState{
 	Version: 15,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial_ (

--- a/storagenode/storagenodedb/testdata/v17.go
+++ b/storagenode/storagenodedb/testdata/v17.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v17 = MultiDBState{
 	Version: 17,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial_ (

--- a/storagenode/storagenodedb/testdata/v18.go
+++ b/storagenode/storagenodedb/testdata/v18.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v18 = MultiDBState{
 	Version: 18,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial_ (

--- a/storagenode/storagenodedb/testdata/v19.go
+++ b/storagenode/storagenodedb/testdata/v19.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v19 = MultiDBState{
 	Version: 19,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial_ (

--- a/storagenode/storagenodedb/testdata/v2.go
+++ b/storagenode/storagenodedb/testdata/v2.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v2 = MultiDBState{
 	Version: 2,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial (

--- a/storagenode/storagenodedb/testdata/v20.go
+++ b/storagenode/storagenodedb/testdata/v20.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v20 = MultiDBState{
 	Version: 20,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial_ (

--- a/storagenode/storagenodedb/testdata/v21.go
+++ b/storagenode/storagenodedb/testdata/v21.go
@@ -5,10 +5,10 @@ package testdata
 
 import "storj.io/storj/storagenode/storagenodedb"
 
-var v16 = MultiDBState{
-	Version: 16,
+var v21 = MultiDBState{
+	Version: 21,
 	DBStates: DBStates{
-		storagenodedb.VersionsDBName: &DBState{
+		storagenodedb.UsedSerialsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial_ (
@@ -20,12 +20,58 @@ var v16 = MultiDBState{
 				CREATE UNIQUE INDEX pk_used_serial_ ON used_serial_(satellite_id, serial_number);
 				-- expiration index to allow fast deletion
 				CREATE INDEX idx_used_serial_ ON used_serial_(expiration);
-
-				-- certificate table for storing uplink/satellite certificates
-				CREATE TABLE certificate (
-					cert_id       INTEGER
+			`,
+		},
+		storagenodedb.StorageUsageDBName: &DBState{
+			SQL: `
+				CREATE TABLE storage_usage (
+					satellite_id BLOB NOT NULL,
+					at_rest_total REAL NOT NUll,
+					interval_start TIMESTAMP NOT NULL,
+					PRIMARY KEY (satellite_id, interval_start)
 				);
 
+				INSERT INTO storage_usage VALUES(X'0ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac3000',5.0,'2019-07-19 20:00:00+00:00');
+			`,
+		},
+		storagenodedb.ReputationDBName: &DBState{
+			SQL: `
+				-- tables to store nodestats cache
+				CREATE TABLE reputation (
+					satellite_id BLOB NOT NULL,
+					uptime_success_count INTEGER NOT NULL,
+					uptime_total_count INTEGER NOT NULL,
+					uptime_reputation_alpha REAL NOT NULL,
+					uptime_reputation_beta REAL NOT NULL,
+					uptime_reputation_score REAL NOT NULL,
+					audit_success_count INTEGER NOT NULL,
+					audit_total_count INTEGER NOT NULL,
+					audit_reputation_alpha REAL NOT NULL,
+					audit_reputation_beta REAL NOT NULL,
+					audit_reputation_score REAL NOT NULL,
+					disqualified TIMESTAMP,
+					updated_at TIMESTAMP NOT NULL,
+					PRIMARY KEY (satellite_id)
+				);
+
+				INSERT INTO reputation VALUES(X'0ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac3000',1,1,1.0,1.0,1.0,1,1,1.0,1.0,1.0,'2019-07-19 20:00:00+00:00','2019-08-23 20:00:00+00:00');
+			`,
+		},
+		storagenodedb.PieceSpaceUsedDBName: &DBState{
+			SQL: `
+				CREATE TABLE piece_space_used (
+					total INTEGER NOT NULL,
+					satellite_id BLOB
+				);
+				CREATE UNIQUE INDEX idx_piece_space_used_satellite_id ON piece_space_used(satellite_id);
+
+				INSERT INTO piece_space_used (total) VALUES (1337);
+
+				INSERT INTO piece_space_used (total, satellite_id) VALUES (1337, X'0ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac3000');
+			`,
+		},
+		storagenodedb.PieceInfoDBName: &DBState{
+			SQL: `
 				-- table for storing piece meta info
 				CREATE TABLE pieceinfo_ (
 					satellite_id     BLOB      NOT NULL,
@@ -47,16 +93,26 @@ var v16 = MultiDBState{
 				-- fast queries for expiration for pieces that have one
 				CREATE INDEX idx_pieceinfo__expiration ON pieceinfo_(piece_expiration) WHERE piece_expiration IS NOT NULL;
 
-				-- table for storing bandwidth usage
-				CREATE TABLE bandwidth_usage (
-					satellite_id  BLOB    NOT NULL,
-					action        INTEGER NOT NULL,
-					amount        BIGINT  NOT NULL,
-					created_at    TIMESTAMP NOT NULL
+				INSERT INTO pieceinfo_ VALUES(X'0ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac3000',X'd5e757fd8d207d1c46583fb58330f803dc961b71147308ff75ff1e72a0df6b0b',1000,'2019-05-09 00:00:00.000000+00:00', X'', X'0a20d5e757fd8d207d1c46583fb58330f803dc961b71147308ff75ff1e72a0df6b0b120501020304051a47304502201c16d76ecd9b208f7ad9f1edf66ce73dce50da6bde6bbd7d278415099a727421022100ca730450e7f6506c2647516f6e20d0641e47c8270f58dde2bb07d1f5a3a45673',1,NULL,'epoch');
+				INSERT INTO pieceinfo_ VALUES(X'2b3a5863a41f25408a8f5348839d7a1361dbd886d75786bb139a8ca0bdf41000',X'd5e757fd8d207d1c46583fb58330f803dc961b71147308ff75ff1e72a0df6b0b',337,'2019-05-09 00:00:00.000000+00:00', X'', X'0a20d5e757fd8d207d1c46583fb58330f803dc961b71147308ff75ff1e72a0df6b0b120501020304051a483046022100e623cf4705046e2c04d5b42d5edbecb81f000459713ad460c691b3361817adbf022100993da2a5298bb88de6c35b2e54009d1bf306cda5d441c228aa9eaf981ceb0f3d',2,NULL,'epoch');
+			`,
+		},
+		storagenodedb.PieceExpirationDBName: &DBState{
+			SQL: `
+				-- table to hold expiration data (and only expirations. no other pieceinfo)
+				CREATE TABLE piece_expirations (
+					satellite_id       BLOB      NOT NULL,
+					piece_id           BLOB      NOT NULL,
+					piece_expiration   TIMESTAMP NOT NULL, -- date when it can be deleted
+					deletion_failed_at TIMESTAMP,
+					PRIMARY KEY ( satellite_id, piece_id )
 				);
-				CREATE INDEX idx_bandwidth_usage_satellite ON bandwidth_usage(satellite_id);
-				CREATE INDEX idx_bandwidth_usage_created   ON bandwidth_usage(created_at);
-
+				CREATE INDEX idx_piece_expirations_piece_expiration ON piece_expirations(piece_expiration);
+				CREATE INDEX idx_piece_expirations_deletion_failed_at ON piece_expirations(deletion_failed_at);
+			`,
+		},
+		storagenodedb.OrdersDBName: &DBState{
+			SQL: `
 				-- table for storing all unsent orders
 				CREATE TABLE unsent_order (
 					satellite_id  BLOB NOT NULL,
@@ -88,12 +144,20 @@ var v16 = MultiDBState{
 					FOREIGN KEY(uplink_cert_id) REFERENCES certificate(cert_id)
 				);
 
-				-- table for storing vouchers
-				CREATE TABLE vouchers (
-					satellite_id BLOB PRIMARY KEY NOT NULL,
-					voucher_serialized BLOB NOT NULL,
-					expiration TIMESTAMP NOT NULL
+				INSERT INTO unsent_order VALUES(X'2b3a5863a41f25408a8f5348839d7a1361dbd886d75786bb139a8ca0bdf41000',X'1eddef484b4c03f01332279032796972',X'0a101eddef484b4c03f0133227903279697212202b3a5863a41f25408a8f5348839d7a1361dbd886d75786bb139a8ca0bdf410001a201968996e7ef170a402fdfd88b6753df792c063c07c555905ffac9cd3cbd1c00022200ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac30002a20d00cf14f3c68b56321ace04902dec0484eb6f9098b22b31c6b3f82db249f191630643802420c08dfeb88e50510a8c1a5b9034a0c08dfeb88e50510a8c1a5b9035246304402204df59dc6f5d1bb7217105efbc9b3604d19189af37a81efbf16258e5d7db5549e02203bb4ead16e6e7f10f658558c22b59c3339911841e8dbaae6e2dea821f7326894',X'0a101eddef484b4c03f0133227903279697210321a47304502206d4c106ddec88140414bac5979c95bdea7de2e0ecc5be766e08f7d5ea36641a7022100e932ff858f15885ffa52d07e260c2c25d3861810ea6157956c1793ad0c906284','2019-04-01 16:01:35.9254586+00:00',1);
+			`,
+		},
+		storagenodedb.BandwidthDBName: &DBState{
+			SQL: `
+				-- table for storing bandwidth usage
+				CREATE TABLE bandwidth_usage (
+					satellite_id  BLOB    NOT NULL,
+					action        INTEGER NOT NULL,
+					amount        BIGINT  NOT NULL,
+					created_at    TIMESTAMP NOT NULL
 				);
+				CREATE INDEX idx_bandwidth_usage_satellite ON bandwidth_usage(satellite_id);
+				CREATE INDEX idx_bandwidth_usage_created   ON bandwidth_usage(created_at);
 
 				CREATE TABLE bandwidth_usage_rollups (
 					interval_start	TIMESTAMP NOT NULL,
@@ -102,43 +166,6 @@ var v16 = MultiDBState{
 					amount        	BIGINT  NOT NULL,
 					PRIMARY KEY ( interval_start, satellite_id, action )
 				);
-
-				-- table to hold expiration data (and only expirations. no other pieceinfo)
-				CREATE TABLE piece_expirations (
-					satellite_id       BLOB      NOT NULL,
-					piece_id           BLOB      NOT NULL,
-					piece_expiration   TIMESTAMP NOT NULL, -- date when it can be deleted
-					deletion_failed_at TIMESTAMP,
-					PRIMARY KEY ( satellite_id, piece_id )
-				);
-				CREATE INDEX idx_piece_expirations_piece_expiration ON piece_expirations(piece_expiration);
-				CREATE INDEX idx_piece_expirations_deletion_failed_at ON piece_expirations(deletion_failed_at);
-
-				-- tables to store nodestats cache
-				CREATE TABLE reputation (
-					satellite_id BLOB NOT NULL,
-					uptime_success_count INTEGER NOT NULL,
-					uptime_total_count INTEGER NOT NULL,
-					uptime_reputation_alpha REAL NOT NULL,
-					uptime_reputation_beta REAL NOT NULL,
-					uptime_reputation_score REAL NOT NULL,
-					audit_success_count INTEGER NOT NULL,
-					audit_total_count INTEGER NOT NULL,
-					audit_reputation_alpha REAL NOT NULL,
-					audit_reputation_beta REAL NOT NULL,
-					audit_reputation_score REAL NOT NULL,
-					updated_at TIMESTAMP NOT NULL,
-					PRIMARY KEY (satellite_id)
-				);
-
-				CREATE TABLE storage_usage (
-					satellite_id BLOB NOT NULL,
-					at_rest_total REAL NOT NUll,
-					timestamp TIMESTAMP NOT NULL,
-					PRIMARY KEY (satellite_id, timestamp)
-				);
-
-				INSERT INTO unsent_order VALUES(X'2b3a5863a41f25408a8f5348839d7a1361dbd886d75786bb139a8ca0bdf41000',X'1eddef484b4c03f01332279032796972',X'0a101eddef484b4c03f0133227903279697212202b3a5863a41f25408a8f5348839d7a1361dbd886d75786bb139a8ca0bdf410001a201968996e7ef170a402fdfd88b6753df792c063c07c555905ffac9cd3cbd1c00022200ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac30002a20d00cf14f3c68b56321ace04902dec0484eb6f9098b22b31c6b3f82db249f191630643802420c08dfeb88e50510a8c1a5b9034a0c08dfeb88e50510a8c1a5b9035246304402204df59dc6f5d1bb7217105efbc9b3604d19189af37a81efbf16258e5d7db5549e02203bb4ead16e6e7f10f658558c22b59c3339911841e8dbaae6e2dea821f7326894',X'0a101eddef484b4c03f0133227903279697210321a47304502206d4c106ddec88140414bac5979c95bdea7de2e0ecc5be766e08f7d5ea36641a7022100e932ff858f15885ffa52d07e260c2c25d3861810ea6157956c1793ad0c906284','2019-04-01 16:01:35.9254586+00:00',1);
 
 				INSERT INTO bandwidth_usage VALUES(X'0ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac3000',0,0,'2019-04-01 18:51:24.1074772+00:00');
 				INSERT INTO bandwidth_usage VALUES(X'2b3a5863a41f25408a8f5348839d7a1361dbd886d75786bb139a8ca0bdf41000',0,0,'2019-04-01 20:51:24.1074772+00:00');
@@ -167,8 +194,6 @@ var v16 = MultiDBState{
 				INSERT INTO bandwidth_usage VALUES(X'0ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac3000',6,6,'2019-04-01 18:51:24.1074772+00:00');
 				INSERT INTO bandwidth_usage VALUES(X'2b3a5863a41f25408a8f5348839d7a1361dbd886d75786bb139a8ca0bdf41000',6,6,'2019-04-01 20:51:24.1074772+00:00');
 
-				INSERT INTO vouchers VALUES(X'2b3a5863a41f25408a8f5348839d7a1361dbd886d75786bb139a8ca0bdf41000', X'd5e757fd8d207d1c46583fb58330f803dc961b71147308ff75ff1e72a0df6b0b', '2019-07-04 00:00:00.000000+00:00');
-
 				INSERT INTO bandwidth_usage_rollups VALUES('2019-07-12 18:00:00+00:00',X'0ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac3000',0,0);
 				INSERT INTO bandwidth_usage_rollups VALUES('2019-07-12 20:00:00+00:00',X'2b3a5863a41f25408a8f5348839d7a1361dbd886d75786bb139a8ca0bdf41000',0,0);
 				INSERT INTO bandwidth_usage_rollups VALUES('2019-07-12 18:00:00+00:00',X'0ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac3000',1,1);
@@ -184,12 +209,9 @@ var v16 = MultiDBState{
 				INSERT INTO bandwidth_usage_rollups VALUES('2019-07-12 18:00:00+00:00',X'0ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac3000',6,6);
 				INSERT INTO bandwidth_usage_rollups VALUES('2019-07-12 20:00:00+00:00',X'2b3a5863a41f25408a8f5348839d7a1361dbd886d75786bb139a8ca0bdf41000',6,6);
 			`,
-			NewData: `
-				INSERT INTO reputation VALUES(X'0ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac3000',1,1,1.0,1.0,1.0,1,1,1.0,1.0,1.0,'2019-07-19 20:00:00+00:00');
-				INSERT INTO storage_usage VALUES(X'0ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac3000',5.0,'2019-07-19 20:00:00+00:00');
-				INSERT INTO pieceinfo_ VALUES(X'0ed28abb2813e184a1e98b0f6605c4911ea468c7e8433eb583e0fca7ceac3000',X'd5e757fd8d207d1c46583fb58330f803dc961b71147308ff75ff1e72a0df6b0b',1000,'2019-05-09 00:00:00.000000+00:00', X'', X'0a20d5e757fd8d207d1c46583fb58330f803dc961b71147308ff75ff1e72a0df6b0b120501020304051a47304502201c16d76ecd9b208f7ad9f1edf66ce73dce50da6bde6bbd7d278415099a727421022100ca730450e7f6506c2647516f6e20d0641e47c8270f58dde2bb07d1f5a3a45673',1,NULL,'epoch');
-				INSERT INTO pieceinfo_ VALUES(X'2b3a5863a41f25408a8f5348839d7a1361dbd886d75786bb139a8ca0bdf41000',X'd5e757fd8d207d1c46583fb58330f803dc961b71147308ff75ff1e72a0df6b0b',337,'2019-05-09 00:00:00.000000+00:00', X'', X'0a20d5e757fd8d207d1c46583fb58330f803dc961b71147308ff75ff1e72a0df6b0b120501020304051a483046022100e623cf4705046e2c04d5b42d5edbecb81f000459713ad460c691b3361817adbf022100993da2a5298bb88de6c35b2e54009d1bf306cda5d441c228aa9eaf981ceb0f3d',2,NULL,'epoch');
-			`,
+		},
+		storagenodedb.VersionsDBName: &DBState{
+			SQL: `-- This is intentionally left blank`,
 		},
 	},
 }

--- a/storagenode/storagenodedb/testdata/v3.go
+++ b/storagenode/storagenodedb/testdata/v3.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v3 = MultiDBState{
 	Version: 3,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial (

--- a/storagenode/storagenodedb/testdata/v4.go
+++ b/storagenode/storagenodedb/testdata/v4.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v4 = MultiDBState{
 	Version: 4,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial (

--- a/storagenode/storagenodedb/testdata/v6.go
+++ b/storagenode/storagenodedb/testdata/v6.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v6 = MultiDBState{
 	Version: 6,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial (

--- a/storagenode/storagenodedb/testdata/v7.go
+++ b/storagenode/storagenodedb/testdata/v7.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v7 = MultiDBState{
 	Version: 7,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial (

--- a/storagenode/storagenodedb/testdata/v8.go
+++ b/storagenode/storagenodedb/testdata/v8.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v8 = MultiDBState{
 	Version: 8,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial (

--- a/storagenode/storagenodedb/testdata/v9.go
+++ b/storagenode/storagenodedb/testdata/v9.go
@@ -3,10 +3,12 @@
 
 package testdata
 
+import "storj.io/storj/storagenode/storagenodedb"
+
 var v9 = MultiDBState{
 	Version: 9,
 	DBStates: DBStates{
-		"versions": &DBState{
+		storagenodedb.VersionsDBName: &DBState{
 			SQL: `
 				-- table for keeping serials that need to be verified against
 				CREATE TABLE used_serial (

--- a/storagenode/storagenodedb/usedserials.go
+++ b/storagenode/storagenodedb/usedserials.go
@@ -16,7 +16,10 @@ import (
 // ErrUsedSerials represents errors from the used serials database.
 var ErrUsedSerials = errs.Class("usedserialsdb error")
 
-var UsedSerialsDatabaseFilename = "used_serial.db"
+const (
+	UsedSerialsDBName           = "used_serial"
+	UsedSerialsDatabaseFilename = "used_serial.db"
+)
 
 type usedSerialsDB struct {
 	SQLDB

--- a/storagenode/storagenodedb/versions.go
+++ b/storagenode/storagenodedb/versions.go
@@ -3,7 +3,10 @@
 
 package storagenodedb
 
-var VersionsDatabaseFilename = "info.db"
+const (
+	VersionsDBName           = "info"
+	VersionsDatabaseFilename = "info.db"
+)
 
 // versions represents the database that contains the database schema version history.
 type versionsDB struct {


### PR DESCRIPTION
What: This extends the migration system for storagenodedb to handle the new split sqlite dbs. Going forward each separate db maintains its own list of migrations which are aggregated into a single group of storagenodedb migrations.

Why: Now that we are splitting the storagenodedb into separate sqlite dbs, we need a way to handle migration properly.

Please describe the tests:
 - Test 1: The migrations_test has been updated to cover new functionality.
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
