### PR TITLE
pkg/certificate: properly close certificateclient.Client

### DIFF
--- a/cmd/identity/main.go
+++ b/cmd/identity/main.go
@@ -149,10 +149,10 @@ func cmdNewService(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func cmdAuthorize(cmd *cobra.Command, args []string) error {
+func cmdAuthorize(cmd *cobra.Command, args []string) (err error) {
 	ctx := process.Ctx(cmd)
 
-	err := version.CheckProcessVersion(ctx, zap.L(), config.Version, version.Build, "Identity")
+	err = version.CheckProcessVersion(ctx, zap.L(), config.Version, version.Build, "Identity")
 	if err != nil {
 		return err
 	}
@@ -204,6 +204,9 @@ func cmdAuthorize(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		err = errs.Combine(err, client.Close())
+	}()
 
 	signedChainBytes, err := client.Sign(ctx, authToken)
 	if err != nil {

--- a/pkg/certificate/certificateclient/client.go
+++ b/pkg/certificate/certificateclient/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/zeebo/errs"
 	"google.golang.org/grpc"
 	"gopkg.in/spacemonkeygo/monkit.v2"
 
@@ -65,6 +66,9 @@ func (config Config) Sign(ctx context.Context, ident *identity.FullIdentity, aut
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		err = errs.Combine(err, client.Close())
+	}()
 
 	return client.Sign(ctx, authToken)
 }

--- a/pkg/certificate/peer_test.go
+++ b/pkg/certificate/peer_test.go
@@ -92,6 +92,7 @@ func TestCertificateSigner_Sign_E2E(t *testing.T) {
 				client, err := certificateclient.New(ctx, clientTransport, peer.Server.Addr().String())
 				require.NoError(t, err)
 				require.NotNil(t, client)
+				defer ctx.Check(client.Close)
 
 				signedChainBytes, err := client.Sign(ctx, auths[0].Token.String())
 				require.NoError(t, err)


### PR DESCRIPTION
What: 

Adds .Close() calls to clean up certificateclient.Client instances where
necessary.

Why:

I came across certificateclient.New() while spelunking kademlia things,
and noticed a few places where the return value wasn't being Close()d
properly. I have added the Close() calls, for the sake of consistency in
our handling of Close()able objects, although I don't think the failure
to close is currently causing any problems (the cmd/identity code looks
like it only ever gets run once before the process ends, the peer_test
code only runs a handful of times before the process ends, and the
changed code in certificateclient/client.go doesn't get ever get called
in our codebase).

Still, resource leakage is an awful thing, and tracking it down can be
brutal.


Please describe the tests:
 - No tests added! I can not come up with a good cross-compatible way to check whether file descriptors are being leaked. Using mocks would maybe work, but (a) it would involve mocks and (b) it would be more code and more work than it's worth, given that we still wouldn't be testing whether connections are actually being closed.

Please describe the performance impact:

None in production, but a remote possibility of slowdown when running tests or when using the `certificate authorize` command. (Calling close on a connected stream socket can block for up to the configured linger time, if there is unsent data and if SO_LINGER is set to a nonzero interval.) But it does not look like we ever set socket linger time, and even if we do, if this slowdown does occur, it will only be in situations where blocking on close is arguably the right thing to do anyway.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
