### PR TITLE
pkg/process: reduce noise in storj-sim

### DIFF
--- a/pkg/process/exec_conf.go
+++ b/pkg/process/exec_conf.go
@@ -5,6 +5,7 @@ package process
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -245,7 +246,8 @@ func cleanup(cmd *cobra.Command) {
 
 		err = initDebug(logger, monkit.Default)
 		if err != nil {
-			logger.Error("failed to start debug endpoints", zap.Error(err))
+			withoutStack := errors.New(err.Error())
+			logger.Debug("failed to start debug endpoints", zap.Error(withoutStack))
 		}
 
 		var workErr error

--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -43,8 +43,9 @@ func flagDefault(dev, release string) string {
 // InitMetrics initializes telemetry reporting. Makes a telemetry.Client and calls
 // its Run() method in a goroutine.
 func InitMetrics(ctx context.Context, log *zap.Logger, r *monkit.Registry, instanceID string) (err error) {
+	log = log.Named("telemetry")
 	if *metricCollector == "" || *metricInterval == 0 {
-		log.Named("metrics").Info("disabled")
+		log.Info("disabled")
 		return nil
 	}
 	if r == nil {

--- a/pkg/process/metrics.go
+++ b/pkg/process/metrics.go
@@ -44,7 +44,8 @@ func flagDefault(dev, release string) string {
 // its Run() method in a goroutine.
 func InitMetrics(ctx context.Context, log *zap.Logger, r *monkit.Registry, instanceID string) (err error) {
 	if *metricCollector == "" || *metricInterval == 0 {
-		return Error.New("telemetry disabled")
+		log.Named("metrics").Info("disabled")
+		return nil
 	}
 	if r == nil {
 		r = monkit.Default

--- a/pkg/telemetry/client.go
+++ b/pkg/telemetry/client.go
@@ -105,7 +105,7 @@ func NewClient(log *zap.Logger, remoteAddr string, opts ClientOpts) (rv *Client,
 
 // Run calls Report roughly every Interval
 func (c *Client) Run(ctx context.Context) {
-	c.log.Sugar().Debugf("Initialized telemetry batcher with id = %q", c.opts.InstanceId)
+	c.log.Sugar().Debugf("Initialized batcher with id = %q", c.opts.InstanceId)
 	for {
 		time.Sleep(jitter(c.interval))
 		if ctx.Err() != nil {
@@ -114,7 +114,7 @@ func (c *Client) Run(ctx context.Context) {
 
 		err := c.Report(ctx)
 		if err != nil {
-			c.log.Sugar().Errorf("failed sending telemetry report: %v", err)
+			c.log.Sugar().Errorf("failed sending report: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
What: Currently both failing to start telemetry and failing to start debug ports displays huge messages about not being able to start. This disables stack trace for these messages since it's cleaner. 

There shouldn't be a problem in trying to figure out where the error came from since there's only one place where it can happen for a given process.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
