### PR TITLE
migrate: Allow work on separate dbs

### DIFF
--- a/internal/migrate/versions_test.go
+++ b/internal/migrate/versions_test.go
@@ -62,6 +62,7 @@ func basicMigration(t *testing.T, db *sql.DB, testDB migrate.DB) {
 		Table: dbName,
 		Steps: []*migrate.Step{
 			{
+				DB:          testDB,
 				Description: "Initialize Table",
 				Version:     1,
 				Action: migrate.SQL{
@@ -70,6 +71,7 @@ func basicMigration(t *testing.T, db *sql.DB, testDB migrate.DB) {
 				},
 			},
 			{
+				DB:          testDB,
 				Description: "Move files",
 				Version:     2,
 				Action: migrate.Func(func(log *zap.Logger, _ migrate.DB, tx *sql.Tx) error {
@@ -79,7 +81,7 @@ func basicMigration(t *testing.T, db *sql.DB, testDB migrate.DB) {
 		},
 	}
 
-	err = m.Run(zap.NewNop(), testDB)
+	err = m.Run(zap.NewNop())
 	assert.NoError(t, err)
 
 	var version int
@@ -136,6 +138,7 @@ func multipleMigration(t *testing.T, db *sql.DB, testDB migrate.DB) {
 		Table: dbName,
 		Steps: []*migrate.Step{
 			{
+				DB:          testDB,
 				Description: "Step 1",
 				Version:     1,
 				Action: migrate.Func(func(log *zap.Logger, _ migrate.DB, tx *sql.Tx) error {
@@ -144,6 +147,7 @@ func multipleMigration(t *testing.T, db *sql.DB, testDB migrate.DB) {
 				}),
 			},
 			{
+				DB:          testDB,
 				Description: "Step 2",
 				Version:     2,
 				Action: migrate.Func(func(log *zap.Logger, _ migrate.DB, tx *sql.Tx) error {
@@ -154,11 +158,12 @@ func multipleMigration(t *testing.T, db *sql.DB, testDB migrate.DB) {
 		},
 	}
 
-	err := m.Run(zap.NewNop(), testDB)
+	err := m.Run(zap.NewNop())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, steps)
 
 	m.Steps = append(m.Steps, &migrate.Step{
+		DB:          testDB,
 		Description: "Step 3",
 		Version:     3,
 		Action: migrate.Func(func(log *zap.Logger, _ migrate.DB, tx *sql.Tx) error {
@@ -166,7 +171,7 @@ func multipleMigration(t *testing.T, db *sql.DB, testDB migrate.DB) {
 			return nil
 		}),
 	})
-	err = m.Run(zap.NewNop(), testDB)
+	err = m.Run(zap.NewNop())
 	assert.NoError(t, err)
 
 	var version int
@@ -208,6 +213,7 @@ func failedMigration(t *testing.T, db *sql.DB, testDB migrate.DB) {
 		Table: dbName,
 		Steps: []*migrate.Step{
 			{
+				DB:          testDB,
 				Description: "Step 1",
 				Version:     1,
 				Action: migrate.Func(func(log *zap.Logger, _ migrate.DB, tx *sql.Tx) error {
@@ -217,7 +223,7 @@ func failedMigration(t *testing.T, db *sql.DB, testDB migrate.DB) {
 		},
 	}
 
-	err := m.Run(zap.NewNop(), testDB)
+	err := m.Run(zap.NewNop())
 	require.Error(t, err, "migration failed")
 
 	var version sql.NullInt64

--- a/satellite/satellitedb/migrate.go
+++ b/satellite/satellitedb/migrate.go
@@ -38,7 +38,7 @@ func (db *DB) CreateTables() error {
 			}
 		}
 		migration := db.PostgresMigration()
-		return migration.Run(db.log.Named("migrate"), db.db)
+		return migration.Run(db.log.Named("migrate"))
 	default:
 		return migrate.Create("database", db.db)
 	}
@@ -51,6 +51,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 		Steps: []*migrate.Step{
 			{
 				// some databases may have already this done, although the version may not match
+				DB:          db.db,
 				Description: "Initial setup",
 				Version:     0,
 				Action: migrate.SQL{
@@ -171,6 +172,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 			},
 			{
 				// some databases may have already this done, although the version may not match
+				DB:          db.db,
 				Description: "Adjust table naming",
 				Version:     1,
 				Action: migrate.Func(func(log *zap.Logger, db migrate.DB, tx *sql.Tx) error {
@@ -255,6 +257,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 			},
 			{
 				// some databases may have already this done, although the version may not match
+				DB:          db.db,
 				Description: "Remove bucket infos",
 				Version:     2,
 				Action: migrate.SQL{
@@ -263,6 +266,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 			},
 			{
 				// some databases may have already this done, although the version may not match
+				DB:          db.db,
 				Description: "Add certificates table",
 				Version:     3,
 				Action: migrate.SQL{
@@ -276,6 +280,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 			},
 			{
 				// some databases may have already this done, although the version may not match
+				DB:          db.db,
 				Description: "Adjust users table",
 				Version:     4,
 				Action: migrate.Func(func(log *zap.Logger, db migrate.DB, tx *sql.Tx) error {
@@ -322,6 +327,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				}),
 			},
 			{
+				DB:          db.db,
 				Description: "Add wallet column",
 				Version:     5,
 				Action: migrate.SQL{
@@ -334,6 +340,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add bucket usage rollup table",
 				Version:     6,
 				Action: migrate.SQL{
@@ -356,6 +363,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add index on bwagreements",
 				Version:     7,
 				Action: migrate.SQL{
@@ -363,6 +371,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add registration_tokens table",
 				Version:     8,
 				Action: migrate.SQL{
@@ -377,6 +386,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add new tables for tracking used serials, bandwidth and storage",
 				Version:     9,
 				Action: migrate.SQL{
@@ -445,6 +455,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "users first_name to full_name, last_name to short_name",
 				Version:     10,
 				Action: migrate.SQL{
@@ -454,6 +465,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "drops interval seconds from storage_rollups, renames x_storage_rollups to x_storage_tallies, adds fields to bucket_storage_tallies",
 				Version:     11,
 				Action: migrate.SQL{
@@ -481,6 +493,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Merge overlay_cache_nodes into nodes table",
 				Version:     12,
 				Action: migrate.SQL{
@@ -509,6 +522,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Change bucket_id to bucket_name and project_id",
 				Version:     13,
 				Action: migrate.SQL{
@@ -545,6 +559,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add new Columns to store version information",
 				Version:     14,
 				Action: migrate.SQL{
@@ -557,6 +572,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Default Node Type should be invalid",
 				Version:     15,
 				Action: migrate.SQL{
@@ -564,6 +580,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add path to injuredsegment to prevent duplicates",
 				Version:     16,
 				Action: migrate.Func(func(log *zap.Logger, db migrate.DB, tx *sql.Tx) error {
@@ -617,6 +634,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				}),
 			},
 			{
+				DB:          db.db,
 				Description: "Fix audit and uptime ratios for new nodes",
 				Version:     17,
 				Action: migrate.SQL{`
@@ -625,6 +643,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Drops storagenode_storage_tally table, Renames accounting_raws to storagenode_storage_tally, and Drops data_type and created_at columns",
 				Version:     18,
 				Action: migrate.SQL{
@@ -635,6 +654,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Added new table to store reset password tokens",
 				Version:     19,
 				Action: migrate.SQL{`
@@ -648,6 +668,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Adds pending_audits table, adds 'contained' column to nodes table",
 				Version:     20,
 				Action: migrate.SQL{
@@ -667,6 +688,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add last_ip column and index",
 				Version:     21,
 				Action: migrate.SQL{
@@ -677,6 +699,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Create new tables for free credits program",
 				Version:     22,
 				Action: migrate.SQL{`
@@ -698,6 +721,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Drops and recreates api key table to handle macaroons and adds revocation table",
 				Version:     23,
 				Action: migrate.SQL{
@@ -716,6 +740,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add usage_limit column to projects table",
 				Version:     24,
 				Action: migrate.SQL{
@@ -723,6 +748,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add disqualified column to nodes table",
 				Version:     25,
 				Action: migrate.SQL{
@@ -730,6 +756,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add invitee_credit_in_gb and award_credit_in_gb columns, delete type and credit_in_cents columns",
 				Version:     26,
 				Action: migrate.SQL{
@@ -740,6 +767,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Create value attribution table",
 				Version:     27,
 				Action: migrate.SQL{
@@ -752,6 +780,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Remove agreements table",
 				Version:     28,
 				Action: migrate.SQL{
@@ -759,6 +788,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add userpaymentinfos, projectpaymentinfos, projectinvoicestamps",
 				Version:     29,
 				Action: migrate.SQL{
@@ -788,6 +818,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Alter value attribution table. Remove bucket_id. Add project_id and bucket_name as primary key",
 				Version:     30,
 				Action: migrate.SQL{
@@ -801,6 +832,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add user_credit table",
 				Version:     31,
 				Action: migrate.SQL{
@@ -818,6 +850,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Change type of disqualified column of nodes table to timestamp",
 				Version:     32,
 				Action: migrate.SQL{
@@ -832,6 +865,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add alpha and beta columns for reputations",
 				Version:     33,
 				Action: migrate.SQL{
@@ -842,6 +876,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Remove ratio columns from node reputations",
 				Version:     34,
 				Action: migrate.SQL{
@@ -850,6 +885,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Fix reputations to preserve a baseline",
 				Version:     35,
 				Action: migrate.SQL{
@@ -860,6 +896,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Update Last_IP column to be masked",
 				Version:     36,
 				Action: migrate.SQL{
@@ -869,6 +906,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Update project_id column from 36 byte string based UUID to 16 byte UUID",
 				Version:     37,
 				Action: migrate.SQL{
@@ -899,6 +937,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add bucket metadata table",
 				Version:     38,
 				Action: migrate.SQL{
@@ -923,6 +962,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Remove disqualification flag for failing uptime checks",
 				Version:     39,
 				Action: migrate.SQL{
@@ -930,6 +970,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add unique id for project payments. Add is_default property",
 				Version:     40,
 				Action: migrate.SQL{
@@ -946,6 +987,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Move InjuredSegment path from string to bytes",
 				Version:     41,
 				Action: migrate.SQL{
@@ -958,6 +1000,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Remove num_redeemed column in offers table",
 				Version:     42,
 				Action: migrate.SQL{
@@ -965,6 +1008,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Set default offer for each offer type in offers table",
 				Version:     43,
 				Action: migrate.SQL{
@@ -1005,6 +1049,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add index on InjuredSegments attempted column",
 				Version:     44,
 				Action: migrate.SQL{
@@ -1012,6 +1057,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add partner id field to support OSPP",
 				Version:     45,
 				Action: migrate.SQL{
@@ -1022,6 +1068,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add pending audit path",
 				Version:     46,
 				Action: migrate.SQL{
@@ -1031,6 +1078,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Modify default offers configuration",
 				Version:     47,
 				Action: migrate.SQL{
@@ -1050,6 +1098,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				// This partial unique index enforces uniqueness among (id, offer_id) pairs for users that have signed up
 				// but are not yet activated (credits_earned_in_cents=0).
 				// Among users that are activated, uniqueness of (id, offer_id) pairs is not required or desirable.
+				DB:          db.db,
 				Description: "Create partial index for user_credits table",
 				Version:     48,
 				Action: migrate.SQL{
@@ -1058,6 +1107,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add cascade to user_id for deleting an account",
 				Version:     49,
 				Action: migrate.SQL{
@@ -1073,6 +1123,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Changing the primary key constraint",
 				Version:     50,
 				Action: migrate.SQL{
@@ -1085,6 +1136,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				// Creating owner_id column for project.
 				// Removing projects without project members
 				// And populating this column with first project member id
+				DB:          db.db,
 				Description: "Creating owner_id column for projects table",
 				Version:     51,
 				Action: migrate.SQL{
@@ -1115,6 +1167,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Remove certRecords table",
 				Version:     52,
 				Action: migrate.SQL{
@@ -1122,6 +1175,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add piece_count column to nodes table",
 				Version:     53,
 				Action: migrate.SQL{
@@ -1129,6 +1183,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Add Peer Identities table",
 				Version:     54,
 				Action: migrate.SQL{
@@ -1142,6 +1197,7 @@ func (db *DB) PostgresMigration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.db,
 				Description: "Added normalized_email column to users table",
 				Version:     55,
 				Action: migrate.SQL{

--- a/satellite/satellitedb/migrate_postgres_test.go
+++ b/satellite/satellitedb/migrate_postgres_test.go
@@ -138,7 +138,7 @@ func TestMigratePostgres(t *testing.T) {
 				tag := fmt.Sprintf("#%d - v%d", i, step.Version)
 
 				// run migration up to a specific version
-				err := migrations.TargetVersion(step.Version).Run(log.Named("migrate"), rawdb)
+				err := migrations.TargetVersion(step.Version).Run(log.Named("migrate"))
 				require.NoError(t, err, tag)
 
 				// find the matching expected version

--- a/storagenode/storagenodedb/database.go
+++ b/storagenode/storagenodedb/database.go
@@ -219,7 +219,7 @@ func openTestDatabase() (*sql.DB, error) {
 // CreateTables creates any necessary tables.
 func (db *DB) CreateTables() error {
 	migration := db.Migration()
-	return migration.Run(db.log.Named("migration"), db.versionsDB)
+	return migration.Run(db.log.Named("migration"))
 }
 
 // Close closes any resources.
@@ -239,11 +239,6 @@ func (db *DB) Close() error {
 		db.storageUsageDB.Close(),
 		db.usedSerialsDB.Close(),
 	)
-}
-
-// VersionsMigration returns the instance of the versions database.
-func (db *DB) VersionsMigration() migrate.DB {
-	return db.versionsDB
 }
 
 // Versions returns the instance of the versions database.
@@ -307,6 +302,7 @@ func (db *DB) Migration() *migrate.Migration {
 		Table: "versions",
 		Steps: []*migrate.Step{
 			{
+				DB:          db.versionsDB,
 				Description: "Initial setup",
 				Version:     0,
 				Action: migrate.SQL{
@@ -388,6 +384,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Network Wipe #2",
 				Version:     1,
 				Action: migrate.SQL{
@@ -395,6 +392,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Add tracking of deletion failures.",
 				Version:     2,
 				Action: migrate.SQL{
@@ -402,6 +400,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Add vouchersDB for storing and retrieving vouchers.",
 				Version:     3,
 				Action: migrate.SQL{
@@ -413,6 +412,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Add index on pieceinfo expireation",
 				Version:     4,
 				Action: migrate.SQL{
@@ -421,6 +421,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Partial Network Wipe - Tardigrade Satellites",
 				Version:     5,
 				Action: migrate.SQL{
@@ -432,6 +433,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Add creation date.",
 				Version:     6,
 				Action: migrate.SQL{
@@ -439,6 +441,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Drop certificate table.",
 				Version:     7,
 				Action: migrate.SQL{
@@ -447,6 +450,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Drop old used serials and remove pieceinfo_deletion_failed index.",
 				Version:     8,
 				Action: migrate.SQL{
@@ -455,6 +459,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Add order limit table.",
 				Version:     9,
 				Action: migrate.SQL{
@@ -462,6 +467,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Optimize index usage.",
 				Version:     10,
 				Action: migrate.SQL{
@@ -472,6 +478,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Create bandwidth_usage_rollup table.",
 				Version:     11,
 				Action: migrate.SQL{
@@ -485,6 +492,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Clear Tables from Alpha data",
 				Version:     12,
 				Action: migrate.SQL{
@@ -532,6 +540,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Free Storagenodes from trash data",
 				Version:     13,
 				Action: migrate.Func(func(log *zap.Logger, mgdb migrate.DB, tx *sql.Tx) error {
@@ -561,6 +570,7 @@ func (db *DB) Migration() *migrate.Migration {
 				}),
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Free Storagenodes from orphaned tmp data",
 				Version:     14,
 				Action: migrate.Func(func(log *zap.Logger, mgdb migrate.DB, tx *sql.Tx) error {
@@ -578,6 +588,7 @@ func (db *DB) Migration() *migrate.Migration {
 				}),
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Start piece_expirations table, deprecate pieceinfo table",
 				Version:     15,
 				Action: migrate.SQL{
@@ -594,6 +605,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Add reputation and storage usage cache tables",
 				Version:     16,
 				Action: migrate.SQL{
@@ -621,6 +633,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Create piece_space_used table",
 				Version:     17,
 				Action: migrate.SQL{
@@ -634,6 +647,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Drop vouchers table",
 				Version:     18,
 				Action: migrate.SQL{
@@ -641,6 +655,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Add disqualified field to reputation",
 				Version:     19,
 				Action: migrate.SQL{
@@ -664,6 +679,7 @@ func (db *DB) Migration() *migrate.Migration {
 				},
 			},
 			{
+				DB:          db.versionsDB,
 				Description: "Empty storage_usage table, rename storage_usage.timestamp to interval_start",
 				Version:     20,
 				Action: migrate.SQL{

--- a/storagenode/storagenodedb/migrations_test.go
+++ b/storagenode/storagenodedb/migrations_test.go
@@ -99,7 +99,7 @@ func TestMigrate(t *testing.T) {
 		tag := fmt.Sprintf("#%d - v%d", i, step.Version)
 
 		// run migration up to a specific version
-		err := migrations.TargetVersion(step.Version).Run(log.Named("migrate"), db.VersionsMigration())
+		err := migrations.TargetVersion(step.Version).Run(log.Named("migrate"))
 		require.NoError(t, err, tag)
 
 		// find the matching expected version


### PR DESCRIPTION
What: This PR makes our migration code support separate dbs for each migration step.

Why: Now that we are splitting the storagenodedb into various databases, we need a way to migrate separate dbs on each step.

Please describe the tests:
 - Test 1: Existing tests are updated to ensure it works to embed the db in the step.
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
