### PR TITLE
satellite/contact + satellite/discovery: Populate PeerIdentities table in satellitedb

### DIFF
--- a/satellite/contact/endpoint.go
+++ b/satellite/contact/endpoint.go
@@ -43,13 +43,20 @@ func (endpoint *Endpoint) Checkin(ctx context.Context, req *pb.CheckinRequest) (
 	if err != nil {
 		return nil, Error.Wrap(err)
 	}
-	pingNodeSuccess, pingErrorMessage, err := endpoint.pingBack(ctx, req, peerID)
+	nodeID := peerID.ID
+
+	pingNodeSuccess, pingErrorMessage, err := endpoint.pingBack(ctx, req, nodeID)
 	if err != nil {
 		return nil, Error.Wrap(err)
 	}
 
-	err = endpoint.service.overlay.Put(ctx, peerID, pb.Node{
-		Id: peerID,
+	err = endpoint.service.peerids.Set(ctx, nodeID, peerID)
+	if err != nil {
+		return nil, Error.Wrap(err)
+	}
+
+	err = endpoint.service.overlay.Put(ctx, nodeID, pb.Node{
+		Id: nodeID,
 		Address: &pb.NodeAddress{
 			Transport: pb.NodeTransport_TCP_TLS_GRPC,
 			Address:   req.GetAddress().GetAddress(),
@@ -62,13 +69,13 @@ func (endpoint *Endpoint) Checkin(ctx context.Context, req *pb.CheckinRequest) (
 	// TODO(jg): We are making 2 requests to the database, one to update uptime and
 	// the other to update the capacity and operator info. We should combine these into
 	// one to reduce db connections. Consider adding batching and using a stored procedure.
-	_, err = endpoint.service.overlay.UpdateUptime(ctx, peerID, pingNodeSuccess)
+	_, err = endpoint.service.overlay.UpdateUptime(ctx, nodeID, pingNodeSuccess)
 	if err != nil {
 		return nil, Error.Wrap(err)
 	}
 
 	nodeInfo := pb.InfoResponse{Operator: req.GetOperator(), Capacity: req.GetCapacity()}
-	_, err = endpoint.service.overlay.UpdateNodeInfo(ctx, peerID, &nodeInfo)
+	_, err = endpoint.service.overlay.UpdateNodeInfo(ctx, nodeID, &nodeInfo)
 	if err != nil {
 		return nil, Error.Wrap(err)
 	}
@@ -113,14 +120,14 @@ func (endpoint *Endpoint) pingBack(ctx context.Context, req *pb.CheckinRequest, 
 	return pingNodeSuccess, pingErrorMessage, nil
 }
 
-func peerIDFromContext(ctx context.Context) (storj.NodeID, error) {
+func peerIDFromContext(ctx context.Context) (*identity.PeerIdentity, error) {
 	p, ok := peer.FromContext(ctx)
 	if !ok {
-		return storj.NodeID{}, Error.New("unable to get grpc peer from contex")
+		return nil, Error.New("unable to get grpc peer from contex")
 	}
 	peerIdentity, err := identity.PeerIdentityFromPeer(p)
 	if err != nil {
-		return storj.NodeID{}, err
+		return nil, err
 	}
-	return peerIdentity.ID, nil
+	return peerIdentity, nil
 }

--- a/satellite/contact/service.go
+++ b/satellite/contact/service.go
@@ -23,14 +23,16 @@ var mon = monkit.Package()
 type Service struct {
 	log       *zap.Logger
 	overlay   *overlay.Service
+	peerids   overlay.PeerIdentities
 	transport transport.Client
 }
 
 // NewService creates a new contact service
-func NewService(log *zap.Logger, overlay *overlay.Service, transport transport.Client) *Service {
+func NewService(log *zap.Logger, overlay *overlay.Service, peerids overlay.PeerIdentities, transport transport.Client) *Service {
 	return &Service{
 		log:       log,
 		overlay:   overlay,
+		peerids:   peerids,
 		transport: transport,
 	}
 }

--- a/satellite/discovery/service.go
+++ b/satellite/discovery/service.go
@@ -38,9 +38,10 @@ type Config struct {
 //
 // architecture: Chore
 type Discovery struct {
-	log   *zap.Logger
-	cache *overlay.Service
-	kad   *kademlia.Kademlia
+	log    *zap.Logger
+	cache  *overlay.Service
+	peerid overlay.PeerIdentities
+	kad    *kademlia.Kademlia
 
 	refreshLimit       int
 	refreshConcurrency int
@@ -50,11 +51,12 @@ type Discovery struct {
 }
 
 // New returns a new discovery service.
-func New(logger *zap.Logger, ol *overlay.Service, kad *kademlia.Kademlia, config Config) *Discovery {
+func New(logger *zap.Logger, ol *overlay.Service, peerid overlay.PeerIdentities, kad *kademlia.Kademlia, config Config) *Discovery {
 	discovery := &Discovery{
-		log:   logger,
-		cache: ol,
-		kad:   kad,
+		log:    logger,
+		cache:  ol,
+		peerid: peerid,
+		kad:    kad,
 
 		refreshLimit:       config.RefreshLimit,
 		refreshConcurrency: config.RefreshConcurrency,
@@ -133,6 +135,10 @@ func (discovery *Discovery) refresh(ctx context.Context) (err error) {
 				if _, err = discovery.cache.UpdateNodeInfo(ctx, node.Id, info); err != nil {
 					discovery.log.Warn("could not update node info", zap.Stringer("ID", node.GetAddress()))
 				}
+
+				// TODO(moby): switch after kad removal completed
+				nodePeerID, err := discovery.kad.FetchPeerIdentity(ctx, node.Id)
+				discovery.peerid.Set(ctx, node.Id, nodePeerID)
 			})
 		}
 

--- a/satellite/discovery/service_test.go
+++ b/satellite/discovery/service_test.go
@@ -22,6 +22,11 @@ func TestCache_Refresh(t *testing.T) {
 			node, err := satellite.Overlay.Service.Get(ctx, storageNode.ID())
 			if assert.NoError(t, err) {
 				assert.Equal(t, storageNode.Addr(), node.Address.Address)
+
+				peerCert, err := satellite.DB.PeerIdentities().Get(ctx, storageNode.ID())
+				if assert.NoError(t, err) {
+					assert.Equal(t, storageNode.Identity.PeerIdentity(), peerCert)
+				}
 			}
 		}
 	})

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -366,7 +366,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 
 	{ // setup contact service
 		log.Debug("Setting up contact service")
-		peer.Contact.Service = contact.NewService(peer.Log.Named("contact"), peer.Overlay.Service, peer.Transport)
+		peer.Contact.Service = contact.NewService(peer.Log.Named("contact"), peer.Overlay.Service, peer.DB.PeerIdentities(), peer.Transport)
 		peer.Contact.Endpoint = contact.NewEndpoint(peer.Log.Named("contact:endpoint"), peer.Contact.Service)
 		pb.RegisterNodeServer(peer.Server.GRPC(), peer.Contact.Endpoint)
 	}

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -374,7 +374,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 	{ // setup discovery
 		log.Debug("Setting up discovery")
 		config := config.Discovery
-		peer.Discovery.Service = discovery.New(peer.Log.Named("discovery"), peer.Overlay.Service, peer.Kademlia.Service, config)
+		peer.Discovery.Service = discovery.New(peer.Log.Named("discovery"), peer.Overlay.Service, peer.DB.PeerIdentities(), peer.Kademlia.Service, config)
 	}
 
 	{ // setup vouchers


### PR DESCRIPTION
What: 
Whenever the satellite contacts a node (satellite discovery refresh) or a node contacts the satellite (satellite contact checkin), update the peer identities table with that node's peer identity.

Why:
This will allow us to have an up to date identity for each node, and allow us to properly check storagenode signatures in #2985
https://storjlabs.atlassian.net/browse/V3-1992

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
