### PR TITLE
Script for deploying the Docker manifest for watchtower

### DIFF
--- a/scripts/deploy-watchtower.sh
+++ b/scripts/deploy-watchtower.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Usage: VERSION=0.3.8 scripts/deploy-watchtower.sh
+set -euo pipefail
+
+: "${VERSION:?Must be set to the release version}"
+
+docker manifest create storjlabs/watchtower:latest \
+storjlabs/watchtower:i386-${VERSION} \
+storjlabs/watchtower:amd64-${VERSION} \
+storjlabs/watchtower:arm64v8-${VERSION} \
+storjlabs/watchtower:armhf-${VERSION}
+
+docker manifest annotate storjlabs/watchtower:latest \
+storjlabs/watchtower:i386-${VERSION} --os linux --arch 386
+
+docker manifest annotate storjlabs/watchtower:latest \
+storjlabs/watchtower:amd64-${VERSION} --os linux --arch amd64
+
+docker manifest annotate storjlabs/watchtower:latest \
+storjlabs/watchtower:arm64v8-${VERSION} --os linux --arch arm64 --variant v8
+
+docker manifest annotate storjlabs/watchtower:latest \
+storjlabs/watchtower:armhf-${VERSION} --os linux --arch arm
+
+docker manifest push --purge storjlabs/watchtower:latest


### PR DESCRIPTION
What: Script for deploying the Docker manifest for the `storjlabs/watchtower` container on Docker Hub.

Why: Similar to the `deploy-storagenode.sh` script it makes it easier and less error-prone to create and deploy the Docker manifest.

Please describe the tests: N/A
 
Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
