### PR TITLE
scripts: Fix warn message update sat config lock

### DIFF
--- a/scripts/update-satellite-config-lock.sh
+++ b/scripts/update-satellite-config-lock.sh
@@ -5,7 +5,7 @@
 
 set -ueo pipefail
 
-read -p "Have you warned about these changes in #config-changes Slack before updating this file? " -n 1 -r
+read -p "Have you warned about these changes in #config-changes Slack channel before updating this file? " -n 1 -r
 echo    # (optional) move to a new line
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then


### PR DESCRIPTION
What: Fix the warning message to indicate the Slack channel where the satellite
configuration changes must be posted.

Why: It was outdated.

Please describe the tests: N/A
 
Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
