### PR TITLE
satellite/audit: rm Verify and Reverify prefix from debug logs

### DIFF
--- a/satellite/audit/verifier.go
+++ b/satellite/audit/verifier.go
@@ -198,7 +198,7 @@ func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[
 	// remove failed audit pieces from the pointer so as to only penalize once for failed audits
 	err = verifier.removeFailedPieces(ctx, path, pointer, failedNodes)
 	if err != nil {
-		verifier.log.Warn(" failed to delete failed pieces", zap.String("Segment Path", path), zap.Error(err))
+		verifier.log.Warn("failed to delete failed pieces", zap.String("Segment Path", path), zap.Error(err))
 	}
 
 	successNodes := getSuccessNodes(ctx, shares, failedNodes, offlineNodes, containedNodes)


### PR DESCRIPTION
What:
- rm Verify and Reverify prefix from debug logs

Why:
- the log should already have the proper scope so the prefix shouldn't be necessary -@egonelbre

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
