### PR TITLE
satellite/metainfo: make piece hashes nil before storing pointer in metainfo.UpdatePieces()

### DIFF
--- a/satellite/metainfo/service.go
+++ b/satellite/metainfo/service.go
@@ -93,8 +93,7 @@ func (s *Service) UpdatePieces(ctx context.Context, path string, ref *pb.Pointer
 			}
 			existing := pieceMap[piece.PieceNum]
 			if existing != nil &&
-				existing.NodeId == piece.NodeId &&
-				existing.Hash == piece.Hash {
+				existing.NodeId == piece.NodeId {
 				delete(pieceMap, piece.PieceNum)
 			}
 		}

--- a/satellite/metainfo/service.go
+++ b/satellite/metainfo/service.go
@@ -114,6 +114,8 @@ func (s *Service) UpdatePieces(ctx context.Context, path string, ref *pb.Pointer
 		// copy the pieces from the map back to the pointer
 		var pieces []*pb.RemotePiece
 		for _, piece := range pieceMap {
+			// clear hashes so we don't store them
+			piece.Hash = nil
 			pieces = append(pieces, piece)
 		}
 		pointer.GetRemote().RemotePieces = pieces

--- a/satellite/metainfo/service.go
+++ b/satellite/metainfo/service.go
@@ -92,8 +92,7 @@ func (s *Service) UpdatePieces(ctx context.Context, path string, ref *pb.Pointer
 				continue
 			}
 			existing := pieceMap[piece.PieceNum]
-			if existing != nil &&
-				existing.NodeId == piece.NodeId {
+			if existing != nil && existing.NodeId == piece.NodeId {
 				delete(pieceMap, piece.PieceNum)
 			}
 		}

--- a/satellite/repair/repair_test.go
+++ b/satellite/repair/repair_test.go
@@ -147,6 +147,8 @@ func TestDataRepair(t *testing.T) {
 			require.NotContains(t, nodesToKill, piece.NodeId, "there shouldn't be pieces in killed nodes")
 			require.NotContains(t, nodesToDisqualify, piece.NodeId, "there shouldn't be pieces in DQ nodes")
 
+			require.Nil(t, piece.Hash, "piece hashes should be set to nil")
+
 			// Kill the original nodes which were kept alive to ensure that we can
 			// download from the new nodes that the repaired pieces have been uploaded
 			if _, ok := nodesToKeepAlive[piece.NodeId]; ok && nodesToKillForMinThreshold > 0 {

--- a/uplink/storage/streams/store_test.go
+++ b/uplink/storage/streams/store_test.go
@@ -23,6 +23,7 @@ import (
 	"storj.io/storj/satellite/console"
 	"storj.io/storj/uplink/ecclient"
 	"storj.io/storj/uplink/eestream"
+	"storj.io/storj/uplink/metainfo"
 	"storj.io/storj/uplink/storage/meta"
 	"storj.io/storj/uplink/storage/segments"
 	"storj.io/storj/uplink/storage/streams"
@@ -107,6 +108,72 @@ func TestStreamsStoreDelete(t *testing.T) {
 	})
 }
 
+// TestStreamsInterruptedDelete tests a special case where the delete command is
+// interrupted before all segments are deleted. On subsequent calls to
+// streamStore.Delete we want to ensure it completes the delete without error,
+// even though some segments have already been deleted.
+func TestStreamsInterruptedDelete(t *testing.T) {
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+
+		metainfoClient, segmentStore, streamStore := storeTestSetup(t, ctx, planet, memory.KiB.Int64())
+		defer ctx.Check(metainfoClient.Close)
+
+		bucketName := "bucket-name"
+		err := planet.Uplinks[0].CreateBucket(ctx, planet.Satellites[0], bucketName)
+		require.NoError(t, err)
+
+		content := testrand.Bytes(2 * memory.KiB)
+		path := "mypath"
+		fullPath := storj.JoinPaths(bucketName, "mypath")
+
+		_, err = streamStore.Put(ctx, fullPath, storj.EncNull, bytes.NewReader(content), nil, time.Time{})
+		require.NoError(t, err)
+
+		// Ensure the item shows when we list
+		listItems, _, err := streamStore.List(ctx, bucketName, "", "", storj.EncNull, true, 10, meta.None)
+		require.NoError(t, err)
+		require.True(t, len(listItems) == 1)
+
+		streamID, err := metainfoClient.BeginDeleteObject(ctx, metainfo.BeginDeleteObjectParams{
+			Bucket:        []byte(bucketName),
+			EncryptedPath: []byte(path),
+		})
+		require.NoError(t, err)
+
+		segmentItems, _, err := metainfoClient.ListSegmentsNew(ctx, metainfo.ListSegmentsParams{
+			StreamID: streamID,
+			CursorPosition: storj.SegmentPosition{
+				Index: 0,
+			},
+		})
+		require.NoError(t, err)
+
+		// We need at least 2 items to do this test
+		require.True(t, len(segmentItems) > 1)
+
+		// Delete just the first item
+		require.NoError(t, segmentStore.Delete(ctx, streamID, segmentItems[0].Position.Index))
+
+		// It should *still* show when we list, as we've only deleted one
+		// segment
+		listItems, _, err = streamStore.List(ctx, bucketName, "", "", storj.EncNull, true, 10, meta.None)
+		require.NoError(t, err)
+		require.True(t, len(listItems) == 1)
+
+		// Now call the streamStore delete method. This should delete all
+		// remaining segments and the file pointer itself without failing
+		// because of the missing first segment.
+		_ = streamStore.Delete(ctx, fullPath, storj.EncNull)
+
+		// Now it should have 0 list items
+		listItems, _, err = streamStore.List(ctx, bucketName, "", "", storj.EncNull, true, 10, meta.None)
+		require.NoError(t, err)
+		require.True(t, len(listItems) == 0)
+	})
+}
+
 func TestStreamStoreList(t *testing.T) {
 	runTest(t, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet, streamStore streams.Store) {
 		expiration := time.Now().Add(10 * 24 * time.Hour)
@@ -179,50 +246,55 @@ func runTest(t *testing.T, test func(t *testing.T, ctx *testcontext.Context, pla
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		// TODO move apikey creation to testplanet
-		projects, err := planet.Satellites[0].DB.Console().Projects().GetAll(ctx)
-		require.NoError(t, err)
-
-		apiKey, err := macaroon.NewAPIKey([]byte("testSecret"))
-		require.NoError(t, err)
-
-		apiKeyInfo := console.APIKeyInfo{
-			ProjectID: projects[0].ID,
-			Name:      "testKey",
-			Secret:    []byte("testSecret"),
-		}
-
-		// add api key to db
-		_, err = planet.Satellites[0].DB.Console().APIKeys().Create(context.Background(), apiKey.Head(), apiKeyInfo)
-		require.NoError(t, err)
-
-		TestAPIKey := apiKey.Serialize()
-
-		metainfo, err := planet.Uplinks[0].DialMetainfo(context.Background(), planet.Satellites[0], TestAPIKey)
-		require.NoError(t, err)
+		metainfo, _, streamStore := storeTestSetup(t, ctx, planet, 64*memory.MiB.Int64())
 		defer ctx.Check(metainfo.Close)
-
-		ec := ecclient.NewClient(planet.Uplinks[0].Log.Named("ecclient"), planet.Uplinks[0].Transport, 0)
-
-		cfg := planet.Uplinks[0].GetConfig(planet.Satellites[0])
-		rs, err := eestream.NewRedundancyStrategyFromStorj(cfg.GetRedundancyScheme())
-		require.NoError(t, err)
-
-		segmentStore := segments.NewSegmentStore(metainfo, ec, rs, 4*memory.KiB.Int(), 8*memory.MiB.Int64())
-		assert.NotNil(t, segmentStore)
-
-		key := new(storj.Key)
-		copy(key[:], TestEncKey)
-
-		encStore := encryption.NewStore()
-		encStore.SetDefaultKey(key)
-
-		const stripesPerBlock = 2
-		blockSize := stripesPerBlock * rs.StripeSize()
-		inlineThreshold := 8 * memory.KiB.Int()
-		streamStore, err := streams.NewStreamStore(metainfo, segmentStore, 64*memory.MiB.Int64(), encStore, blockSize, storj.EncNull, inlineThreshold)
-		require.NoError(t, err)
-
 		test(t, ctx, planet, streamStore)
 	})
+}
+
+func storeTestSetup(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet, segmentSize int64) (*metainfo.Client, segments.Store, streams.Store) {
+	// TODO move apikey creation to testplanet
+	projects, err := planet.Satellites[0].DB.Console().Projects().GetAll(ctx)
+	require.NoError(t, err)
+
+	apiKey, err := macaroon.NewAPIKey([]byte("testSecret"))
+	require.NoError(t, err)
+
+	apiKeyInfo := console.APIKeyInfo{
+		ProjectID: projects[0].ID,
+		Name:      "testKey",
+		Secret:    []byte("testSecret"),
+	}
+
+	// add api key to db
+	_, err = planet.Satellites[0].DB.Console().APIKeys().Create(context.Background(), apiKey.Head(), apiKeyInfo)
+	require.NoError(t, err)
+
+	TestAPIKey := apiKey.Serialize()
+
+	metainfo, err := planet.Uplinks[0].DialMetainfo(context.Background(), planet.Satellites[0], TestAPIKey)
+	require.NoError(t, err)
+
+	ec := ecclient.NewClient(planet.Uplinks[0].Log.Named("ecclient"), planet.Uplinks[0].Transport, 0)
+
+	cfg := planet.Uplinks[0].GetConfig(planet.Satellites[0])
+	rs, err := eestream.NewRedundancyStrategyFromStorj(cfg.GetRedundancyScheme())
+	require.NoError(t, err)
+
+	segmentStore := segments.NewSegmentStore(metainfo, ec, rs, 4*memory.KiB.Int(), 8*memory.MiB.Int64())
+	assert.NotNil(t, segmentStore)
+
+	key := new(storj.Key)
+	copy(key[:], TestEncKey)
+
+	encStore := encryption.NewStore()
+	encStore.SetDefaultKey(key)
+
+	const stripesPerBlock = 2
+	blockSize := stripesPerBlock * rs.StripeSize()
+	inlineThreshold := 8 * memory.KiB.Int()
+	streamStore, err := streams.NewStreamStore(metainfo, segmentStore, segmentSize, encStore, blockSize, storj.EncNull, inlineThreshold)
+	require.NoError(t, err)
+
+	return metainfo, segmentStore, streamStore
 }


### PR DESCRIPTION
What: 
When we initially commit a segment (`satellite/metainfo/metainfo.go`), we iterate over all the pieces in the pointer and set `piece.Hash = nil` for each one before storing them in the database. This is to reduce overhead, since we only need the piece hashes for initial verification of the upload.

When we repair, it does not look like we are doing this anywhere. This PR sets those hashes to nil before replacing the pointer in metainfo.

**Unfortunately, this probably means that there are many pointers in metainfo that have been repaired that contain unnecessary piece hashes. We may want to run a migration at some point to get rid of these.**

This PR also removes a flawed check which compares `existingPiece.Hash` (which should always be `nil`) to `piece.Hash` (which will not necessarily be `nil`). We have probably unknowingly not deleted pieces that needed to be deleted as a result of this check.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
