### PR TITLE
Add satellites database business objects.

### DIFF
--- a/storagenode/storagenodedb/database.go
+++ b/storagenode/storagenodedb/database.go
@@ -97,6 +97,7 @@ type DB struct {
 	reputationDB      *reputationDB
 	storageUsageDB    *storageusageDB
 	usedSerialsDB     *usedSerialsDB
+	satellitesDB      *satellitesDB
 
 	kdb, ndb, adb storage.KeyValueStore
 }
@@ -138,6 +139,7 @@ func New(log *zap.Logger, config Config) (*DB, error) {
 		reputationDB:      newReputationDB(versionsDB, versionsPath),
 		storageUsageDB:    newStorageusageDB(versionsDB, versionsPath),
 		usedSerialsDB:     newUsedSerialsDB(versionsDB, versionsPath),
+		satellitesDB:      newSatellitesDB(versionsDB, versionsPath),
 	}
 
 	return db, nil
@@ -175,6 +177,7 @@ func NewTest(log *zap.Logger, storageDir string) (*DB, error) {
 		reputationDB:      newReputationDB(versionsDB, versionsPath),
 		storageUsageDB:    newStorageusageDB(versionsDB, versionsPath),
 		usedSerialsDB:     newUsedSerialsDB(versionsDB, versionsPath),
+		satellitesDB:      newSatellitesDB(versionsDB, versionsPath),
 	}
 	return db, nil
 }
@@ -238,6 +241,7 @@ func (db *DB) Close() error {
 		db.reputationDB.Close(),
 		db.storageUsageDB.Close(),
 		db.usedSerialsDB.Close(),
+		db.satellitesDB.Close(),
 	)
 }
 

--- a/storagenode/storagenodedb/satellites.go
+++ b/storagenode/storagenodedb/satellites.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package storagenodedb
+
+import (
+	"github.com/zeebo/errs"
+)
+
+// ErrSatellites represents errors from the satellites database.
+var ErrSatellitesDB = errs.Class("satellitesdb error")
+
+// reputation works with node reputation DB
+type satellitesDB struct {
+	location string
+	SQLDB
+}
+
+// newSatellitesDB returns a new instance of satellitesDB initialized with the specified database.
+func newSatellitesDB(db SQLDB, location string) *satellitesDB {
+	return &satellitesDB{
+		location: location,
+		SQLDB:    db,
+	}
+}

--- a/storagenode/storagenodedb/satellites.go
+++ b/storagenode/storagenodedb/satellites.go
@@ -7,7 +7,7 @@ import (
 	"github.com/zeebo/errs"
 )
 
-// ErrSatellites represents errors from the satellites database.
+// ErrSatellitesDB represents errors from the satellites database.
 var ErrSatellitesDB = errs.Class("satellitesdb error")
 
 // reputation works with node reputation DB


### PR DESCRIPTION
**What:** Add business object placeholders for the new satellite tables `satellites` and `satellite_exit_progress`. This adds an empty placeholder object for the data access to the new tables and hooks it up to the initialization logic.

**Why:** I'm adding this before @VinozzZ has worked on the data access code because I have a parallel PR that splits up the storage node sqlite3 databases and it's going to be a lot less painful and easier for both of us to merge having this wired up ahead of time.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
