### PR TITLE
satellite/audit: set devDefaults for ChoreInterval and QueueInterval to 1m

### DIFF
--- a/satellite/audit/worker.go
+++ b/satellite/audit/worker.go
@@ -25,8 +25,8 @@ type Config struct {
 	MinDownloadTimeout time.Duration `help:"the minimum duration for downloading a share from storage nodes before timing out" default:"25s"`
 	MaxReverifyCount   int           `help:"limit above which we consider an audit is failed" default:"3"`
 
-	ChoreInterval     time.Duration `help:"how often to run the reservoir chore" default:"24h"`
-	QueueInterval     time.Duration `help:"how often to recheck an empty audit queue" default:"1h"`
+	ChoreInterval     time.Duration `help:"how often to run the reservoir chore" releaseDefault:"24h" devDefault:"1m"`
+	QueueInterval     time.Duration `help:"how often to recheck an empty audit queue" releaseDefault:"1h" devDefault:"1m"`
 	Slots             int           `help:"number of reservoir slots allotted for nodes, currently capped at 3" default:"3"`
 	WorkerConcurrency int           `help:"number of workers to run audits on paths" default:"1"`
 }


### PR DESCRIPTION
What: 
- set devDefaults for ChoreInterval and QueueInterval to 1m

Why:
- they were respectively set to 24h and 1h in storj-sim which led to some unhelpful testing

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
