### PR TITLE
pkg/transport: handle deadlines as two-way

### DIFF
--- a/pkg/transport/timeout.go
+++ b/pkg/transport/timeout.go
@@ -53,6 +53,12 @@ func (tc *timeoutConn) withDeadline(op func(deadline time.Time) (n int, err erro
 		if n > 0 {
 			// update progress time
 			tc.progressed = finished
+
+			if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
+				// clear if it's a timeout and we made progress
+				err = nil
+			}
+
 			tc.mu.Unlock()
 			break
 		}


### PR DESCRIPTION
When a write is succeeding, however the read times out, then we shouldn't consider it as a timeout, but rather we should wait until both read and write haven't made progress in the specified time.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
