### PR TITLE
uplink/satellite: fix for case when inline segment is last one

### DIFF
--- a/satellite/metainfo/loop.go
+++ b/satellite/metainfo/loop.go
@@ -232,11 +232,16 @@ waitformore:
 // handlePointer deals with a pointer for a single observer
 // if there is some error on the observer, handle the error and return false. Otherwise, return true
 func handlePointer(ctx context.Context, observer *observerContext, path ScopedPath, isLastSegment bool, pointer *pb.Pointer) bool {
-	if pointer.GetRemote() != nil {
+	switch pointer.GetType() {
+	case pb.Pointer_REMOTE:
 		if observer.HandleError(observer.RemoteSegment(ctx, path, pointer)) {
 			return false
 		}
-	} else if observer.HandleError(observer.InlineSegment(ctx, path, pointer)) {
+	case pb.Pointer_INLINE:
+		if observer.HandleError(observer.InlineSegment(ctx, path, pointer)) {
+			return false
+		}
+	default:
 		return false
 	}
 	if isLastSegment {

--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -1163,15 +1163,16 @@ func (endpoint *Endpoint) GetObject(ctx context.Context, req *pb.ObjectGetReques
 
 	if pointer.Remote != nil {
 		object.RedundancyScheme = pointer.Remote.Redundancy
-	} else if streamMeta.NumberOfSegments == 0 || streamMeta.NumberOfSegments > 1 {
-		// workaround
-		// new metainfo API redundancy scheme is on object level (not per segment) because
-		// of that RS is taken always from last segment, old implemetation were saving RS
-		// per segment and in some cases when for remote file last segment is inline segment
-		// then we are missing RS. This part will search for RS in othere segments than last one
 
 		// NumberOfSegments == 0 - pointer with encrypted num of segments
 		// NumberOfSegments > 1 - pointer with unencrypted num of segments and multiple segments
+	} else if streamMeta.NumberOfSegments == 0 || streamMeta.NumberOfSegments > 1 {
+		// workaround
+		// The new metainfo API redundancy scheme is on object level (not per segment).
+		// Because of that, RS is always taken from the last segment.
+		// The old implementation saves RS per segment, and in some cases
+		// when the remote file's last segment is an inline segment, we end up
+		// missing an RS scheme. This loop will search for RS in segments other than the last one.
 
 		index := int64(0)
 		for {

--- a/satellite/repair/checker/checker.go
+++ b/satellite/repair/checker/checker.go
@@ -145,7 +145,7 @@ func (checker *Checker) updateIrreparableSegmentStatus(ctx context.Context, poin
 	// TODO figure out how to reduce duplicate code between here and checkerObs.RemoteSegment
 	defer mon.Task()(&ctx)(&err)
 	remote := pointer.GetRemote()
-	if remote == nil {
+	if pointer.GetType() == pb.Pointer_INLINE || remote == nil {
 		return nil
 	}
 

--- a/satellite/repair/checker/checker_test.go
+++ b/satellite/repair/checker/checker_test.go
@@ -96,6 +96,7 @@ func TestIdentifyIrreparableSegments(t *testing.T) {
 		// when number of healthy piece is less than minimum required number of piece in redundancy,
 		// the piece is considered irreparable and will be put into irreparable DB
 		pointer := &pb.Pointer{
+			Type:         pb.Pointer_REMOTE,
 			CreationDate: time.Now(),
 			Remote: &pb.RemoteSegment{
 				Redundancy: &pb.RedundancyScheme{
@@ -146,6 +147,7 @@ func TestIdentifyIrreparableSegments(t *testing.T) {
 
 		// make the pointer repairable
 		pointer = &pb.Pointer{
+			Type:         pb.Pointer_REMOTE,
 			CreationDate: time.Now(),
 			Remote: &pb.RemoteSegment{
 				Redundancy: &pb.RedundancyScheme{
@@ -197,6 +199,7 @@ func makePointer(t *testing.T, planet *testplanet.Planet, pointerPath string, cr
 		minReq, repairThreshold = numOfStorageNodes-1, numOfStorageNodes+1
 	}
 	pointer := &pb.Pointer{
+		Type:         pb.Pointer_REMOTE,
 		CreationDate: time.Now(),
 		Remote: &pb.RemoteSegment{
 			Redundancy: &pb.RedundancyScheme{

--- a/uplink/storage/segments/store.go
+++ b/uplink/storage/segments/store.go
@@ -161,7 +161,8 @@ func (s *segmentStore) Get(ctx context.Context, streamID storj.StreamID, segment
 	}
 
 	switch {
-	case len(info.EncryptedInlineData) != 0:
+	// no order limits also means its inline segment
+	case len(info.EncryptedInlineData) != 0 || len(limits) == 0:
 		return ranger.ByteRanger(info.EncryptedInlineData), info.SegmentEncryption, nil
 	default:
 		needed := CalcNeededNodes(objectRS)


### PR DESCRIPTION
What: With migration to new metainfo API I missed a case when the last segment can be inline segment. For example, there is such a case when file size is multiplication of max segment size. 

Why: We had a bug where files uploaded with old uplink were not accessible because new uplink was not able to get redundancy scheme values.

Please describe the tests:
 - Test 1: backward compatibility test and test-sim tests updated
 - Test 2: to test manual try upload file with the previous release and download with master/this branch
 
Please describe the performance impact: overhead should be minimal

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
