### PR TITLE
pkg/transport: set default timeout to 10 minutes

### DIFF
--- a/pkg/transport/common.go
+++ b/pkg/transport/common.go
@@ -21,5 +21,5 @@ const (
 	defaultTransportDialTimeout = 20 * time.Second
 
 	// defaultTransportRequestTimeout is the default time to wait for a response.
-	defaultTransportRequestTimeout = 20 * time.Second
+	defaultTransportRequestTimeout = 10 * time.Minute
 )


### PR DESCRIPTION
What: It seems that under load the go scheduler can get a bit unfair. Increase the request timeout to 10 minutes, to avoid potential issues.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
