### PR TITLE
rm noisy debug logs that we dont need

### DIFF
--- a/pkg/kademlia/endpoint.go
+++ b/pkg/kademlia/endpoint.go
@@ -113,11 +113,8 @@ func (endpoint *Endpoint) Ping(ctx context.Context, req *pb.PingRequest) (_ *pb.
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
-	endpoint.log.Debug("pinged", zap.Stringer("by", peerID.ID), zap.Stringer("srcAddr", p.Addr))
 	if endpoint.pingStats != nil {
 		endpoint.pingStats.WasPinged(time.Now(), peerID.ID, p.Addr.String())
-	} else {
-		endpoint.log.Debug("not updating pingStats because nil")
 	}
 	return &pb.PingResponse{}, nil
 }


### PR DESCRIPTION
What/Why:

We are removing kademlia, but in the meantime, the debug log is becoming noisy and its not useful info so we are removing it.

Please describe the tests:
n/a
 
Please describe the performance impact:
n/a

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
