### PR TITLE
satellite/metainfo: fix GetObject method

### DIFF
--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -1176,7 +1176,13 @@ func (endpoint *Endpoint) GetObject(ctx context.Context, req *pb.ObjectGetReques
 
 		index := int64(0)
 		for {
-			pointer, _, err = endpoint.getPointer(ctx, keyInfo.ProjectID, index, req.Bucket, req.EncryptedPath)
+			path, err := CreatePath(ctx, keyInfo.ProjectID, index, req.Bucket, req.EncryptedPath)
+			if err != nil {
+				endpoint.log.Error("unable to get pointer path", zap.Error(err))
+				return nil, status.Error(codes.Internal, "unable to get object")
+			}
+
+			pointer, err = endpoint.metainfo.Get(ctx, path)
 			if err != nil {
 				if storage.ErrKeyNotFound.Has(err) {
 					break


### PR DESCRIPTION
What: Fix metainfo.GetObject method to catch `storage.ErrKeyNotFound` in correct way. The issue was with older inline uploads where number of segments were encrypted. 

Why: Without this fix we are not able to download old inline files.

Please describe the tests:
 - Test 1: TBD
 
Please describe the performance impact: none

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
