### PR TITLE
cmd: rename auto-updater to storagenode-updater

### DIFF
--- a/cmd/storagenode-updater/main.go
+++ b/cmd/storagenode-updater/main.go
@@ -33,12 +33,12 @@ import (
 
 var (
 	rootCmd = &cobra.Command{
-		Use:   "auto-updater",
-		Short: "Auto-updater for storage node",
+		Use:   "storagenode-updater",
+		Short: "Version updater for storage node",
 	}
 	runCmd = &cobra.Command{
 		Use:   "run",
-		Short: "Run the auto updater for storage node",
+		Short: "Run the storagenode-updater for storage node",
 		Args:  cobra.OnlyValidArgs,
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			err = cmdRun(cmd, args)


### PR DESCRIPTION
What: Rename `auto-updater` to `storagenode-updater`. 

Why: Because old name is not storage node specific.

Please describe the tests:
 - Test 1: none
 
Please describe the performance impact: none

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
