### PR TITLE
storagenode: avoid starting command on service stop

### DIFF
--- a/cmd/storagenode-updater/windows.go
+++ b/cmd/storagenode-updater/windows.go
@@ -12,8 +12,9 @@
 package main
 
 import (
-	"time"
 	"log"
+	"os"
+	"time"
 
 	"golang.org/x/sys/windows/svc"
 )
@@ -32,6 +33,8 @@ func init() {
 	if err != nil {
 		panic("Service failed: " + err.Error())
 	}
+	// avoid starting main() when service was stopped
+	os.Exit(0)
 }
 
 type service struct{}

--- a/cmd/storagenode/windows.go
+++ b/cmd/storagenode/windows.go
@@ -49,6 +49,8 @@ func init() {
 	if err != nil {
 		zap.S().Fatalf("Service failed: %v", err)
 	}
+	// avoid starting main() when service was stopped
+	os.Exit(0)
 }
 
 type service struct{}


### PR DESCRIPTION
What: Trigger os.Exit(0) when service return control after stop signal.

Why: Without this when service (storagenode, storagenode-updater) is stopped logic from `main()` is started

Please describe the tests:
 - Test 1: none
 
Please describe the performance impact: none

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
