### PR TITLE
satellite/audit: containment Get deletes pending audits, when associated segment has been deleted

### DIFF
--- a/satellite/audit/containment_test.go
+++ b/satellite/audit/containment_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"storj.io/storj/internal/memory"
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testplanet"
 	"storj.io/storj/internal/testrand"
@@ -157,14 +158,21 @@ func TestContainUpdateStats(t *testing.T) {
 	})
 }
 
+// TestContainGetDeleted ensures that we delete a pending audit for a node if the
+// segment associated with the pending audit is deleted
 func TestContainGetDeleted(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
-		SatelliteCount: 1, StorageNodeCount: 2,
+		SatelliteCount: 1, StorageNodeCount: 2, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		// stop audit
-		planet.Satellites[0].Audit.Worker.Pause()
+		satellite := planet.Satellites[0]
+		ul := planet.Uplinks[0]
+		containment := satellite.DB.Containment()
+
+		// stop audit worker
+		satellite.Audit.Worker.Loop.Pause()
 
 		// upload file
+		testData := testrand.Bytes(8 * memory.KiB)
 		err := ul.UploadWithConfig(ctx, satellite, &uplink.RSConfig{
 			MinThreshold:     1,
 			RepairThreshold:  1,
@@ -173,64 +181,118 @@ func TestContainGetDeleted(t *testing.T) {
 		}, "testbucket", "test/path", testData)
 		require.NoError(t, err)
 
-		// add to containment with specific path and piece ID
-		info1 := &audit.PendingAudit{
-			NodeID:            planet.StorageNodes[0].ID(),
-			ExpectedShareHash: pkcrypto.SHA256Hash(testrand.Bytes(10)),
-		}
+		// get path from audit chore
+		satellite.Audit.Chore.Loop.TriggerWait()
+		path, err := satellite.Audit.Queue.Next()
+		require.NoError(t, err)
 
-		err := containment.IncrementPending(ctx, info1)
+		pointer, err := satellite.Metainfo.Service.Get(ctx, path)
+		require.NoError(t, err)
+
+		remote := pointer.GetRemote()
+		pieces := remote.GetRemotePieces()
+
+		piece := pieces[0]
+
+		// create pending audit
+		pending := &audit.PendingAudit{
+			NodeID:            piece.NodeId,
+			PieceID:           remote.RootPieceId,
+			ExpectedShareHash: pkcrypto.SHA256Hash(nil),
+			Path:              path,
+		}
+		err = containment.IncrementPending(ctx, pending)
 		require.NoError(t, err)
 
 		// expect that node is in containment mode
+		_, err = containment.Get(ctx, piece.NodeId)
+		require.NoError(t, err)
 
 		// delete file
-		// get from containment
-		// expect not found error
+		err = ul.Delete(ctx, satellite, "testbucket", "test/path")
+		require.NoError(t, err)
+
+		// get from containment and expect not found error
+		_, err = containment.Get(ctx, piece.NodeId)
+		require.Error(t, err)
+		assert.True(t, audit.ErrContainedNotFound.Has(err))
 	})
 }
 
-// TODO better name
-// this is to make sure that we don't delete from containment if a *different* file that a node is storing is deleted
+// TestContainGetNotDeleted ensures that a node in containment mode does not get deleted
+// if a segment with that node is deleted that is not the segment the node was contained for
 func TestContainGetNotDeleted(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
-		SatelliteCount: 1, StorageNodeCount: 2,
+		SatelliteCount: 1, StorageNodeCount: 2, UplinkCount: 1,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
-		// stop audit
-		planet.Satellites[0].Audit.Worker.Pause()
+		satellite := planet.Satellites[0]
+		ul := planet.Uplinks[0]
+		containment := satellite.DB.Containment()
 
-		// upload two files
-		err := ul.UploadWithConfig(ctx, satellite, &uplink.RSConfig{
+		// stop audit worker
+		planet.Satellites[0].Audit.Worker.Loop.Pause()
+
+		// upload one file
+		testData := testrand.Bytes(8 * memory.KiB)
+		rs := &uplink.RSConfig{
 			MinThreshold:     1,
 			RepairThreshold:  1,
 			SuccessThreshold: 2,
 			MaxThreshold:     2,
-		}, "testbucket", "test/path", testData)
+		}
+		err := ul.UploadWithConfig(ctx, satellite, rs, "testbucket", "test/path1", testData)
 		require.NoError(t, err)
 
-		// add to containment with file 0
-		info1 := &audit.PendingAudit{
-			NodeID:            planet.StorageNodes[0].ID(),
-			ExpectedShareHash: pkcrypto.SHA256Hash(testrand.Bytes(10)),
-		}
+		// get encrypted path from audit chore
+		satellite.Audit.Chore.Loop.TriggerWait()
+		path, err := satellite.Audit.Queue.Next()
+		require.NoError(t, err)
 
-		err := containment.IncrementPending(ctx, info1)
+		pointer, err := satellite.Metainfo.Service.Get(ctx, path)
+		require.NoError(t, err)
+
+		remote := pointer.GetRemote()
+		pieces := remote.GetRemotePieces()
+
+		piece := pieces[0]
+
+		// create pending audit
+		pending := &audit.PendingAudit{
+			NodeID:            piece.NodeId,
+			PieceID:           remote.RootPieceId,
+			ExpectedShareHash: pkcrypto.SHA256Hash(nil),
+			Path:              path,
+		}
+		err = containment.IncrementPending(ctx, pending)
 		require.NoError(t, err)
 
 		// expect that node is in containment mode
+		_, err = containment.Get(ctx, piece.NodeId)
+		require.NoError(t, err)
 
-		// delete file 1
-		// get from containment
-		// expect still exists in containment
+		// upload and delete a different file
+		err = ul.UploadWithConfig(ctx, satellite, rs, "testbucket", "test/path2", testData)
+		require.NoError(t, err)
+
+		err = ul.Delete(ctx, satellite, "testbucket", "test/path2")
+		require.NoError(t, err)
+
+		// get from containment and expect that node is still there
+		_, err = containment.Get(ctx, piece.NodeId)
+		require.NoError(t, err)
 	})
 }
 
+// TestContainIncrementDelted ensures that if we increment a pending audit for a node
+// and that segment no longer exists, that the pending audit is deleted.
+// TODO what if the segment the node is incremented for exists, but the original does not?
+// TODO what if neither of the segments exists?
 func TestContainIncrementDeleted(t *testing.T) {
 	testplanet.Run(t, testplanet.Config{
 		SatelliteCount: 1, StorageNodeCount: 2,
 	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 		// stop audit
-		planet.Satellites[0].Audit.Worker.Pause()
+		planet.Satellites[0].Audit.Worker.Loop.Pause()
 
 		// upload 2 files
 		// add to containment with specific path and piece ID (file 1)


### PR DESCRIPTION
What: 
When we call `containment.Get(ctx, nodeID)`, containment should check metainfo to see if the segment associated with that node's pending audit has been deleted or if it does not contain that node any longer. If so, it should delete the node from containment mode.

Why:
We do not want to keep up with deleting from containment mode in every situation that a pointer might be updated. Currently, the only option for deleting from containment mode does not take into account which segment has been modified or deleted, so we will delete any node from containment if it is in a segment that is being deleted, even if it was contained for a different segment.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
