### PR TITLE
fix certificates auth export command

### DIFF
--- a/cmd/certificates/auth.go
+++ b/cmd/certificates/auth.go
@@ -214,10 +214,8 @@ func cmdExportAuth(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return errs.Wrap(err)
 			}
-		} else {
-			if len(args) == 0 {
-				return errs.New("Need either `--emails-path` or positional args.")
-			}
+		} else if len(args) == 0 {
+			return errs.New("Need either `--emails-path` or positional args.")
 		}
 		emails = append(emails, args...)
 	}

--- a/cmd/certificates/auth.go
+++ b/cmd/certificates/auth.go
@@ -201,20 +201,20 @@ func cmdExportAuth(cmd *cobra.Command, args []string) error {
 
 	var emails []string
 	switch {
-	case len(args) > 0 && !authCfg.All:
+	case len(args) >= 0 && !authCfg.All:
 		if authCfg.EmailsPath != "" {
 			return errs.New("Either use `--emails-path` or positional args, not both.")
 		}
 		emails = args
-	case len(args) == 0 || authCfg.All:
-		emails, err = authDB.UserIDs(ctx)
-		if err != nil {
-			return err
-		}
-	default:
+	case authCfg.EmailsPath != "" && !authCfg.All:
 		emails, err = parseEmailsList(authCfg.EmailsPath, authCfg.Delimiter)
 		if err != nil {
 			return errs.Wrap(err)
+		}
+	default:
+		emails, err = authDB.UserIDs(ctx)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/scripts/test-certificates.sh
+++ b/scripts/test-certificates.sh
@@ -78,7 +78,7 @@ for i in {0..4}; do
   fi
 done
 
-exported_auths=$(_certificates auth export)
+exported_auths=$(_certificates auth export --all)
 _certificates run --min-difficulty 0 --authorization-addr $AUTHS_HTTP_ADDR &
 CERTS_PID=$!
 
@@ -96,7 +96,7 @@ done
 kill_certificates_server
 
 # Expect 10 authorizations total.
-auths=$(_certificates auth export)
+auths=$(_certificates auth export --all)
 require_lines 10 "$auths" $LINENO
 
 for i in {1..4}; do


### PR DESCRIPTION
What: Fix certificates auth export switch logic.

Why: `--emails-path` wasn't working correctly.

Please describe the tests: None. This command is partially tested in scripts/test-certificates.sh but that script is currently disabled as it's flaky with plans to re-implement in go.
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
