### PR TITLE
internal/version: Change default endpoint to query

### DIFF
--- a/internal/version/service.go
+++ b/internal/version/service.go
@@ -19,7 +19,7 @@ import (
 
 // Config contains the necessary Information to check the Software Version
 type Config struct {
-	ServerAddress  string        `help:"server address to check its version against" default:"https://version.alpha.storj.io"`
+	ServerAddress  string        `help:"server address to check its version against" default:"https://version.storj.io"`
 	RequestTimeout time.Duration `help:"Request timeout for version checks" default:"0h1m0s"`
 	CheckInterval  time.Duration `help:"Interval to check the version" default:"0h15m0s"`
 }

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -350,4 +350,4 @@ server.private-address: 127.0.0.1:7778
 # version.request-timeout: 1m0s
 
 # server address to check its version against
-# version.server-address: https://version.alpha.storj.io
+# version.server-address: https://version.storj.io


### PR DESCRIPTION
What: changes the service to ask version.storj.io instead of version.alpha.storj.io

Why: It allows autoupdating

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
