### PR TITLE
uplink: reenable storj.Forward direction for listing objects

### DIFF
--- a/uplink/metainfo/kvmetainfo/objects.go
+++ b/uplink/metainfo/kvmetainfo/objects.go
@@ -182,9 +182,9 @@ func (db *DB) ListObjects(ctx context.Context, bucket string, options storj.List
 	// case storj.Backward:
 	// 	// backward lists backwards from cursor, including cursor
 	// 	endBefore = keyAfter(options.Cursor)
-	// case storj.Forward:
-	// 	// forward lists forwards from cursor, including cursor
-	// 	startAfter = keyBefore(options.Cursor)
+	case storj.Forward:
+		// forward lists forwards from cursor, including cursor
+		startAfter = keyBefore(options.Cursor)
 	case storj.After:
 		// after lists forwards from cursor, without cursor
 		startAfter = options.Cursor

--- a/uplink/metainfo/kvmetainfo/objects_test.go
+++ b/uplink/metainfo/kvmetainfo/objects_test.go
@@ -281,7 +281,7 @@ func TestListObjectsEmpty(t *testing.T) {
 		for _, direction := range []storj.ListDirection{
 			// storj.Before,
 			// storj.Backward,
-			// storj.Forward,
+			storj.Forward,
 			storj.After,
 		} {
 			list, err := db.ListObjects(ctx, bucket.Name, storj.ListOptions{Direction: direction})
@@ -392,84 +392,81 @@ func TestListObjects(t *testing.T) {
 				options: options("a/", "xaa", storj.After, 2),
 				more:    true,
 				result:  []string{"xb", "xbb"},
-			},
-			// TODO commented until we will decide if we will support direction for object listing
-			//
-			// {
-			// 	options: options("", "", storj.Forward, 0),
-			// 	result:  []string{"a", "a/", "aa", "b", "b/", "bb", "c"},
-			// }, {
-			// 	options: options("", "`", storj.Forward, 0),
-			// 	result:  []string{"a", "a/", "aa", "b", "b/", "bb", "c"},
-			// }, {
-			// 	options: options("", "b", storj.Forward, 0),
-			// 	result:  []string{"b", "b/", "bb", "c"},
-			// }, {
-			// 	options: options("", "c", storj.Forward, 0),
-			// 	result:  []string{"c"},
-			// }, {
-			// 	options: options("", "ca", storj.Forward, 0),
-			// 	result:  []string{},
-			// }, {
-			// 	options: options("", "", storj.Forward, 1),
-			// 	more:    true,
-			// 	result:  []string{"a"},
-			// }, {
-			// 	options: options("", "`", storj.Forward, 1),
-			// 	more:    true,
-			// 	result:  []string{"a"},
-			// }, {
-			// 	options: options("", "aa", storj.Forward, 1),
-			// 	more:    true,
-			// 	result:  []string{"aa"},
-			// }, {
-			// 	options: options("", "c", storj.Forward, 1),
-			// 	result:  []string{"c"},
-			// }, {
-			// 	options: options("", "ca", storj.Forward, 1),
-			// 	result:  []string{},
-			// }, {
-			// 	options: options("", "", storj.Forward, 2),
-			// 	more:    true,
-			// 	result:  []string{"a", "a/"},
-			// }, {
-			// 	options: options("", "`", storj.Forward, 2),
-			// 	more:    true,
-			// 	result:  []string{"a", "a/"},
-			// }, {
-			// 	options: options("", "aa", storj.Forward, 2),
-			// 	more:    true,
-			// 	result:  []string{"aa", "b"},
-			// }, {
-			// 	options: options("", "bb", storj.Forward, 2),
-			// 	result:  []string{"bb", "c"},
-			// }, {
-			// 	options: options("", "c", storj.Forward, 2),
-			// 	result:  []string{"c"},
-			// }, {
-			// 	options: options("", "ca", storj.Forward, 2),
-			// 	result:  []string{},
-			// }, {
-			// 	options: optionsRecursive("", "", storj.Forward, 0),
-			// 	result:  []string{"a", "a/xa", "a/xaa", "a/xb", "a/xbb", "a/xc", "aa", "b", "b/ya", "b/yaa", "b/yb", "b/ybb", "b/yc", "bb", "c"},
-			// }, {
-			// 	options: options("a", "", storj.Forward, 0),
-			// 	result:  []string{"xa", "xaa", "xb", "xbb", "xc"},
-			// }, {
-			// 	options: options("a/", "", storj.Forward, 0),
-			// 	result:  []string{"xa", "xaa", "xb", "xbb", "xc"},
-			// }, {
-			// 	options: options("a/", "xb", storj.Forward, 0),
-			// 	result:  []string{"xb", "xbb", "xc"},
-			// }, {
-			// 	options: optionsRecursive("", "a/xbb", storj.Forward, 5),
-			// 	more:    true,
-			// 	result:  []string{"a/xbb", "a/xc", "aa", "b", "b/ya"},
-			// }, {
-			// 	options: options("a/", "xaa", storj.Forward, 2),
-			// 	more:    true,
-			// 	result:  []string{"xaa", "xb"},
-			// }, {
+			}, {
+				options: options("", "", storj.Forward, 0),
+				result:  []string{"a", "a/", "aa", "b", "b/", "bb", "c"},
+			}, {
+				options: options("", "`", storj.Forward, 0),
+				result:  []string{"a", "a/", "aa", "b", "b/", "bb", "c"},
+			}, {
+				options: options("", "b", storj.Forward, 0),
+				result:  []string{"b", "b/", "bb", "c"},
+			}, {
+				options: options("", "c", storj.Forward, 0),
+				result:  []string{"c"},
+			}, {
+				options: options("", "ca", storj.Forward, 0),
+				result:  []string{},
+			}, {
+				options: options("", "", storj.Forward, 1),
+				more:    true,
+				result:  []string{"a"},
+			}, {
+				options: options("", "`", storj.Forward, 1),
+				more:    true,
+				result:  []string{"a"},
+			}, {
+				options: options("", "aa", storj.Forward, 1),
+				more:    true,
+				result:  []string{"aa"},
+			}, {
+				options: options("", "c", storj.Forward, 1),
+				result:  []string{"c"},
+			}, {
+				options: options("", "ca", storj.Forward, 1),
+				result:  []string{},
+			}, {
+				options: options("", "", storj.Forward, 2),
+				more:    true,
+				result:  []string{"a", "a/"},
+			}, {
+				options: options("", "`", storj.Forward, 2),
+				more:    true,
+				result:  []string{"a", "a/"},
+			}, {
+				options: options("", "aa", storj.Forward, 2),
+				more:    true,
+				result:  []string{"aa", "b"},
+			}, {
+				options: options("", "bb", storj.Forward, 2),
+				result:  []string{"bb", "c"},
+			}, {
+				options: options("", "c", storj.Forward, 2),
+				result:  []string{"c"},
+			}, {
+				options: options("", "ca", storj.Forward, 2),
+				result:  []string{},
+			}, {
+				options: optionsRecursive("", "", storj.Forward, 0),
+				result:  []string{"a", "a/xa", "a/xaa", "a/xb", "a/xbb", "a/xc", "aa", "b", "b/ya", "b/yaa", "b/yb", "b/ybb", "b/yc", "bb", "c"},
+			}, {
+				options: options("a", "", storj.Forward, 0),
+				result:  []string{"xa", "xaa", "xb", "xbb", "xc"},
+			}, {
+				options: options("a/", "", storj.Forward, 0),
+				result:  []string{"xa", "xaa", "xb", "xbb", "xc"},
+			}, {
+				options: options("a/", "xb", storj.Forward, 0),
+				result:  []string{"xb", "xbb", "xc"},
+			}, {
+				options: optionsRecursive("", "a/xbb", storj.Forward, 5),
+				more:    true,
+				result:  []string{"a/xbb", "a/xc", "aa", "b", "b/ya"},
+			}, {
+				options: options("a/", "xaa", storj.Forward, 2),
+				more:    true,
+				result:  []string{"xaa", "xb"},
+			}, //{
 			// 	options: options("", "", storj.Backward, 0),
 			// 	result:  []string{"a", "a/", "aa", "b", "b/", "bb", "c"},
 			// }, {

--- a/uplink/metainfo/kvmetainfo/paths.go
+++ b/uplink/metainfo/kvmetainfo/paths.go
@@ -8,21 +8,20 @@ package kvmetainfo
 //   since the exact previous key is
 //     append(previousPrefix(cursor), infinite(0xFF)...)
 
-// TODO commented until we will decide if we will support direction for objects listing
-// func keyBefore(cursor string) string {
-// 	if cursor == "" {
-// 		return ""
-// 	}
+func keyBefore(cursor string) string {
+	if cursor == "" {
+		return ""
+	}
 
-// 	before := []byte(cursor)
-// 	if before[len(before)-1] == 0 {
-// 		return string(before[:len(before)-1])
-// 	}
-// 	before[len(before)-1]--
+	before := []byte(cursor)
+	if before[len(before)-1] == 0 {
+		return string(before[:len(before)-1])
+	}
+	before[len(before)-1]--
 
-// 	before = append(before, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f)
-// 	return string(before)
-// }
+	before = append(before, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f)
+	return string(before)
+}
 
 // func keyAfter(cursor string) string {
 // 	return cursor + "\x00"


### PR DESCRIPTION
What: This direction was disabled during Metainfo refactoring and with this PR its reenabled. 

Why: We were supporting this earlier.

Please describe the tests:
 - Test 1: some tests were reenabled too
 
Please describe the performance impact: none

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
