### PR TITLE
Fix locale to "en-US" when parsing numbers

### DIFF
--- a/installer/windows/Storj/CustomAction.cs
+++ b/installer/windows/Storj/CustomAction.cs
@@ -1,5 +1,6 @@
 using Microsoft.Deployment.WindowsInstaller;
 using System;
+using System.Globalization;
 using System.IO;
 
 namespace Storj
@@ -126,7 +127,7 @@ namespace Storj
                 return ActionResult.Success;
             }
 
-            if (!double.TryParse(storageStr, out double storage))
+            if (!double.TryParse(storageStr, NumberStyles.Number, CultureInfo.CreateSpecificCulture("en-US"), out double storage))
             {
                 session["STORJ_STORAGE_VALID"] = string.Format("'{0}' is not a valid number.", storageStr);
                 return ActionResult.Success;
@@ -165,7 +166,7 @@ namespace Storj
                 return ActionResult.Success;
             }
 
-            if (!double.TryParse(bandwidthStr, out double bandwidth))
+            if (!double.TryParse(bandwidthStr, NumberStyles.Number, CultureInfo.CreateSpecificCulture("en-US"), out double bandwidth))
             {
                 session["STORJ_BANDWIDTH_VALID"] = string.Format("'{0}' is not a valid number.", bandwidthStr);
                 return ActionResult.Success;


### PR DESCRIPTION
What: Windows installer always uses US locale when parsing numbers from user input.

Why: To make it work for users with another default locale, like German.

Please describe the tests: N/A
 
Please describe the performance impact: None

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
