### PR TITLE
scripts: ignore .build directory for size checks

### DIFF
--- a/scripts/check-large-files.go
+++ b/scripts/check-large-files.go
@@ -14,6 +14,7 @@ import (
 )
 
 var ignoreFolder = map[string]bool{
+	".build":       true,
 	".git":         true,
 	"node_modules": true,
 	"coverage":     true,


### PR DESCRIPTION
What: .build will contain different artifacts, so they might exceed the 650KB limit.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
