### PR TITLE
pkg/rpc/rpcstatus: Fix return type

### DIFF
--- a/pkg/rpc/rpcstatus/status_drpc.go
+++ b/pkg/rpc/rpcstatus/status_drpc.go
@@ -47,7 +47,7 @@ func Code(err error) StatusCode {
 	case context.DeadlineExceeded:
 		return DeadlineExceeded
 	default:
-		return drpcerr.Code(err)
+		return StatusCode(drpcerr.Code(err))
 	}
 
 }


### PR DESCRIPTION
What: Fix return of rpcstatus.Code.

Why: I believe StatusCode used to be a type alias, and now it is its own type. This lets it compile.
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
