### PR TITLE
storagenode/dashboard: update online status

### DIFF
--- a/cmd/storagenode/dashboard.go
+++ b/cmd/storagenode/dashboard.go
@@ -143,7 +143,6 @@ func printDashboard(data *pb.DashboardResponse) error {
 	fmt.Fprintf(w, "External\t%s\n", color.WhiteString(data.GetExternalAddress()))
 	// Disabling the Link to the Dashboard as its not working yet
 	// fmt.Fprintf(w, "Dashboard\t%s\n", color.WhiteString(data.GetDashboardAddress()))
-	fmt.Fprintf(w, "\nNeighborhood Size %+v\n", whiteInt(data.GetNodeConnections()))
 	if err = w.Flush(); err != nil {
 		return err
 	}

--- a/cmd/storagenode/dashboard.go
+++ b/cmd/storagenode/dashboard.go
@@ -25,7 +25,7 @@ import (
 	"storj.io/storj/pkg/rpc"
 )
 
-const contactWindow = time.Minute * 10
+const contactWindow = time.Hour * 2
 
 type dashboardClient struct {
 	conn *rpc.Conn
@@ -94,15 +94,10 @@ func printDashboard(data *pb.DashboardResponse) error {
 	w := tabwriter.NewWriter(color.Output, 0, 0, 1, ' ', 0)
 	fmt.Fprintf(w, "ID\t%s\n", color.YellowString(data.NodeId.String()))
 
-	switch {
-	case data.LastPinged.IsZero():
+	if data.LastPinged.IsZero() || time.Since(data.LastPinged) >= contactWindow {
 		fmt.Fprintf(w, "Last Contact\t%s\n", color.RedString("OFFLINE"))
-	case time.Since(data.LastPinged) >= contactWindow:
-		fmt.Fprintf(w, "Last Contact\t%s\n", color.RedString(fmt.Sprintf("%s ago",
-			time.Since(data.LastPinged).Truncate(time.Second))))
-	default:
-		fmt.Fprintf(w, "Last Contact\t%s\n", color.GreenString(fmt.Sprintf("%s ago",
-			time.Since(data.LastPinged).Truncate(time.Second))))
+	} else {
+		fmt.Fprintf(w, "Last Contact\t%s\n", color.GreenString("ONLINE"))
 	}
 
 	// TODO: use stdtime in protobuf

--- a/cmd/storagenode/dashboard.go
+++ b/cmd/storagenode/dashboard.go
@@ -154,10 +154,6 @@ func printDashboard(data *pb.DashboardResponse) error {
 	return nil
 }
 
-func whiteInt(value int64) string {
-	return color.WhiteString(fmt.Sprintf("%+v", value))
-}
-
 // clearScreen clears the screen so it can be redrawn
 func clearScreen() {
 	switch runtime.GOOS {

--- a/pkg/kademlia/endpoint.go
+++ b/pkg/kademlia/endpoint.go
@@ -13,7 +13,6 @@ import (
 
 	"storj.io/storj/pkg/identity"
 	"storj.io/storj/pkg/pb"
-	"storj.io/storj/pkg/rpc/rpcpeer"
 	"storj.io/storj/pkg/rpc/rpcstatus"
 	"storj.io/storj/pkg/storj"
 )
@@ -27,7 +26,7 @@ type SatelliteIDVerifier interface {
 }
 
 type pingStatsSource interface {
-	WasPinged(when time.Time, byID storj.NodeID, byAddr string)
+	WasPinged(when time.Time)
 }
 
 // Endpoint implements the kademlia Endpoints
@@ -104,16 +103,14 @@ func (endpoint *Endpoint) Ping(ctx context.Context, req *pb.PingRequest) (_ *pb.
 	// NOTE: this code is very similar to that in storagenode/contact.(*Endpoint).PingNode().
 	// That other will be used going forward, and this will soon be gutted and deprecated. The
 	// code similarity will only exist until the transition away from Kademlia is complete.
-	peer, err := rpcpeer.FromContext(ctx)
 	if err != nil {
 		return nil, rpcstatus.Error(rpcstatus.Internal, err.Error())
 	}
-	peerID, err := identity.PeerIdentityFromPeer(peer)
 	if err != nil {
 		return nil, rpcstatus.Error(rpcstatus.Unauthenticated, err.Error())
 	}
 	if endpoint.pingStats != nil {
-		endpoint.pingStats.WasPinged(time.Now(), peerID.ID, peer.Addr.String())
+		endpoint.pingStats.WasPinged(time.Now())
 	}
 	return &pb.PingResponse{}, nil
 }

--- a/storagenode/console/service.go
+++ b/storagenode/console/service.go
@@ -132,7 +132,7 @@ func (s *Service) GetDashboardData(ctx context.Context) (_ *Dashboard, err error
 	data.Version = s.versionInfo.Version
 	data.UpToDate = s.version.IsAllowed()
 
-	data.LastPinged, data.LastPingFromID, data.LastPingFromAddress = s.pingStats.WhenLastPinged()
+	data.LastPinged = s.pingStats.WhenLastPinged()
 
 	stats, err := s.reputationDB.All(ctx)
 	if err != nil {

--- a/storagenode/contact/contact_test.go
+++ b/storagenode/contact/contact_test.go
@@ -32,13 +32,13 @@ func TestStoragenodeContactEndpoint(t *testing.T) {
 		require.NotNil(t, resp)
 		require.NoError(t, err)
 
-		firstPing, _, _ := pingStats.WhenLastPinged()
+		firstPing := pingStats.WhenLastPinged()
 
 		resp, err = conn.ContactClient().PingNode(ctx, &pb.ContactPingRequest{})
 		require.NotNil(t, resp)
 		require.NoError(t, err)
 
-		secondPing, _, _ := pingStats.WhenLastPinged()
+		secondPing := pingStats.WhenLastPinged()
 
 		require.True(t, secondPing.After(firstPing))
 	})

--- a/storagenode/contact/endpoint.go
+++ b/storagenode/contact/endpoint.go
@@ -14,7 +14,6 @@ import (
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/rpc/rpcpeer"
 	"storj.io/storj/pkg/rpc/rpcstatus"
-	"storj.io/storj/pkg/storj"
 )
 
 // Endpoint implements the contact service Endpoints
@@ -27,10 +26,8 @@ type Endpoint struct {
 
 // PingStats contains information regarding who and when the node was last pinged
 type PingStats struct {
-	mu               sync.Mutex
-	lastPinged       time.Time
-	whoPingedNodeID  storj.NodeID
-	whoPingedAddress string
+	mu         sync.Mutex
+	lastPinged time.Time
 }
 
 // NewEndpoint returns a new contact service endpoint
@@ -53,22 +50,20 @@ func (endpoint *Endpoint) PingNode(ctx context.Context, req *pb.ContactPingReque
 		return nil, rpcstatus.Error(rpcstatus.Unauthenticated, err.Error())
 	}
 	endpoint.log.Debug("pinged", zap.Stringer("by", peerID.ID), zap.Stringer("srcAddr", peer.Addr))
-	endpoint.pingStats.WasPinged(time.Now(), peerID.ID, peer.Addr.String())
+	endpoint.pingStats.WasPinged(time.Now())
 	return &pb.ContactPingResponse{}, nil
 }
 
 // WhenLastPinged returns last time someone pinged this node.
-func (stats *PingStats) WhenLastPinged() (when time.Time, who storj.NodeID, addr string) {
+func (stats *PingStats) WhenLastPinged() (when time.Time) {
 	stats.mu.Lock()
 	defer stats.mu.Unlock()
-	return stats.lastPinged, stats.whoPingedNodeID, stats.whoPingedAddress
+	return stats.lastPinged
 }
 
 // WasPinged notifies the service it has been remotely pinged.
-func (stats *PingStats) WasPinged(when time.Time, srcNodeID storj.NodeID, srcAddress string) {
+func (stats *PingStats) WasPinged(when time.Time) {
 	stats.mu.Lock()
 	defer stats.mu.Unlock()
 	stats.lastPinged = when
-	stats.whoPingedNodeID = srcNodeID
-	stats.whoPingedAddress = srcAddress
 }

--- a/storagenode/contact/endpoint.go
+++ b/storagenode/contact/endpoint.go
@@ -24,7 +24,7 @@ type Endpoint struct {
 	pingStats *PingStats
 }
 
-// PingStats contains information regarding who and when the node was last pinged
+// PingStats contains information regarding when the node was last pinged
 type PingStats struct {
 	mu         sync.Mutex
 	lastPinged time.Time

--- a/storagenode/inspector/inspector.go
+++ b/storagenode/inspector/inspector.go
@@ -114,18 +114,16 @@ func (inspector *Endpoint) getDashboardData(ctx context.Context) (_ *pb.Dashboar
 		return &pb.DashboardResponse{}, Error.Wrap(err)
 	}
 
-	lastPingedAt, lastPingFromID, lastPingFromAddress := inspector.pingStats.WhenLastPinged()
+	lastPingedAt := inspector.pingStats.WhenLastPinged()
 
 	return &pb.DashboardResponse{
-		NodeId:              inspector.contact.Local().Id,
-		InternalAddress:     "",
-		ExternalAddress:     inspector.contact.Local().Address.Address,
-		LastPinged:          lastPingedAt,
-		LastPingFromId:      &lastPingFromID,
-		LastPingFromAddress: lastPingFromAddress,
-		DashboardAddress:    inspector.dashboardAddress.String(),
-		Uptime:              ptypes.DurationProto(time.Since(inspector.startTime)),
-		Stats:               statsSummary,
+		NodeId:           inspector.contact.Local().Id,
+		InternalAddress:  "",
+		ExternalAddress:  inspector.contact.Local().Address.Address,
+		LastPinged:       lastPingedAt,
+		DashboardAddress: inspector.dashboardAddress.String(),
+		Uptime:           ptypes.DurationProto(time.Since(inspector.startTime)),
+		Stats:            statsSummary,
 	}, nil
 }
 

--- a/storagenode/inspector/inspector_test.go
+++ b/storagenode/inspector/inspector_test.go
@@ -130,7 +130,6 @@ func TestInspectorDashboard(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.True(t, response.LastPinged.After(testStartedTime))
-			assert.NotEmpty(t, response.LastPingFromAddress)
 
 			assert.True(t, response.Uptime.Nanos > 0)
 			assert.Equal(t, storageNode.ID(), response.NodeId)

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -273,6 +273,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 			peer.Storage2.Trust,
 			peer.Storage2.Monitor,
 			peer.Storage2.RetainService,
+			peer.Contact.PingStats,
 			peer.Storage2.Store,
 			peer.DB.Orders(),
 			peer.DB.Bandwidth(),

--- a/web/storagenode/src/app/store/modules/node.ts
+++ b/web/storagenode/src/app/store/modules/node.ts
@@ -27,7 +27,7 @@ const {
     GET_NODE_INFO,
 } = NODE_ACTIONS;
 
-const statusThreshHoldMinutes = 10;
+const statusThreshHoldMinutes = 120;
 const snoAPI = new SNOApi();
 
 const allSatellites = {


### PR DESCRIPTION
What: Update online status on incoming download, upload and delete requests. Increase the online windo to 2 hours. This is a quick and dirty solution that we should replace doing the kademlia removal.

Why: At the moment the storage node dashboard is showing offline. Removing it is also a bad idea because that will remove the feedback for the storage nodes and they wouldn't be able to detect if something is wrong with the storage node.

Teamwork with @stefanbenten.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
