### PR TITLE
satellite/console: remove domain prefix from token cookie key

### DIFF
--- a/satellite/console/consoleweb/server.go
+++ b/satellite/console/consoleweb/server.go
@@ -529,7 +529,7 @@ func (server *Server) initializeTemplates() (err error) {
 	return nil
 }
 
-// stripPort strips the port from hostport string if any
+// stripPort strips the port from hostport string if any.
 func stripPort(hostport string) string {
 	i := strings.Index(hostport, ":")
 	if i < 0 {

--- a/satellite/console/consoleweb/server.go
+++ b/satellite/console/consoleweb/server.go
@@ -198,12 +198,7 @@ func (server *Server) bucketUsageReportHandler(w http.ResponseWriter, r *http.Re
 	var err error
 	defer mon.Task()(&ctx)(&err)
 
-	host, _, err := net.SplitHostPort(r.Host)
-	if err != nil {
-		server.log.Error("bucket usage report error", zap.Error(err))
-		server.serveError(w, r, http.StatusInternalServerError)
-		return
-	}
+	host := stripPort(r.Host)
 
 	tokenCookie, err := r.Cookie(host + "_tokenKey")
 	if err != nil {
@@ -532,4 +527,13 @@ func (server *Server) initializeTemplates() (err error) {
 	}
 
 	return nil
+}
+
+// stripPort strips the port from hostport string if any
+func stripPort(hostport string) string {
+	i := strings.Index(hostport, ":")
+	if i < 0 {
+		return hostport
+	}
+	return hostport[:i]
 }

--- a/satellite/console/consoleweb/server.go
+++ b/satellite/console/consoleweb/server.go
@@ -198,14 +198,7 @@ func (server *Server) bucketUsageReportHandler(w http.ResponseWriter, r *http.Re
 	var err error
 	defer mon.Task()(&ctx)(&err)
 
-	host, err := stripPort(r.Host)
-	if err != nil {
-		server.log.Error("bucket usage report error", zap.Error(err))
-		server.serveError(w, r, http.StatusInternalServerError)
-		return
-	}
-
-	tokenCookie, err := r.Cookie(host + "_tokenKey")
+	tokenCookie, err := r.Cookie("_tokenKey")
 	if err != nil {
 		server.serveError(w, r, http.StatusUnauthorized)
 		return
@@ -532,43 +525,4 @@ func (server *Server) initializeTemplates() (err error) {
 	}
 
 	return nil
-}
-
-// stripPort strips the port from hostport string if any.
-func stripPort(hostport string) (string, error) {
-	i := strings.LastIndex(hostport, ":")
-	if i < 0 {
-		return hostport, nil
-	}
-
-	// assume using ipv4
-	if hostport[0] != '[' {
-		host := hostport[:i]
-		if strings.Index(host, ":") >= 0 {
-			return "", errs.New("too many columns")
-		}
-
-		return host, nil
-	}
-
-	// ipv6
-	end := strings.LastIndex(hostport, "]")
-	if end == -1 {
-		return "", errs.New("invalid ipv6 address, no closing \"]\" at the end")
-	}
-
-	// only port separating ":" can follow after closing "]"
-	if end+1 != i {
-		return "", errs.New("invalid ipv6 address, invalid character after \"]\"")
-	}
-
-	host := hostport[1:end]
-	if strings.Index(host, "[") >= 0 {
-		return "", errs.New("unexpected '[' in address")
-	}
-	if strings.Index(host, "]") >= 0 {
-		return "", errs.New("unexpected ']' in address")
-	}
-
-	return host, nil
 }

--- a/web/satellite/src/utils/authToken.ts
+++ b/web/satellite/src/utils/authToken.ts
@@ -3,12 +3,7 @@
 
 // AuthToken exposes methods to manage auth cookie
 export class AuthToken {
-    private static readonly tokenKeySuffix: string = '_tokenKey';
     private static tokenKey: string = '_tokenKey';
-
-    public static initialize(): void {
-        AuthToken.tokenKey = (document as any).location.hostname + AuthToken.tokenKeySuffix;
-    }
 
     public static get(): string {
         return AuthToken.getCookie(AuthToken.tokenKey);
@@ -42,5 +37,3 @@ export class AuthToken {
         return '';
     }
 }
-
-AuthToken.initialize();


### PR DESCRIPTION
What: Remove domain prefix from token cookie key

Why: It seems that browsers doesn't share cookies between different subdomains of one domain by default

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
