### PR TITLE
satellite/repair: defer close piecestore in downloadAndVerifyPiece

### DIFF
--- a/satellite/repair/repairer/ec.go
+++ b/satellite/repair/repairer/ec.go
@@ -167,6 +167,7 @@ func (ec *ECRepairer) downloadAndVerifyPiece(ctx context.Context, limit *pb.Addr
 	if err != nil {
 		return nil, err
 	}
+	defer func() { err = errs.Combine(err, ps.Close()) }()
 
 	downloader, err := ps.Download(ctx, limit.GetLimit(), privateKey, 0, pieceSize)
 	if err != nil {


### PR DESCRIPTION
What: add defer close piecestore in downloadAndVerifyPiece

Why: we are leaking connections and it is causing the satellite to crash

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
