### PR TITLE
satellite/repair: remove deprecated error message

### DIFF
--- a/satellite/repair/checker/checker.go
+++ b/satellite/repair/checker/checker.go
@@ -171,15 +171,6 @@ func (checker *Checker) updateIrreparableSegmentStatus(ctx context.Context, poin
 	// minimum required pieces in redundancy
 	// except for the case when the repair and success thresholds are the same (a case usually seen during testing)
 	if numHealthy >= redundancy.MinReq && numHealthy <= redundancy.RepairThreshold && numHealthy < redundancy.SuccessThreshold {
-		if len(missingPieces) == 0 {
-			checker.logger.Error("Missing pieces is zero in checker, but this should be impossible -- bad redundancy scheme:",
-				zap.String("path", path),
-				zap.Int32("min", redundancy.MinReq),
-				zap.Int32("repair", redundancy.RepairThreshold),
-				zap.Int32("success", redundancy.SuccessThreshold),
-				zap.Int32("total", redundancy.Total))
-			return nil
-		}
 		err = checker.repairQueue.Insert(ctx, &pb.InjuredSegment{
 			Path:         []byte(path),
 			LostPieces:   missingPieces,
@@ -263,15 +254,6 @@ func (obs *checkerObserver) RemoteSegment(ctx context.Context, path metainfo.Sco
 	// minimum required pieces in redundancy
 	// except for the case when the repair and success thresholds are the same (a case usually seen during testing)
 	if numHealthy >= redundancy.MinReq && numHealthy <= repairThreshold && numHealthy < redundancy.SuccessThreshold {
-		if len(missingPieces) == 0 {
-			obs.log.Error("Missing pieces is zero in checker, but this should be impossible -- bad redundancy scheme:",
-				zap.String("path", path.Raw),
-				zap.Int32("min", redundancy.MinReq),
-				zap.Int32("repair", redundancy.RepairThreshold),
-				zap.Int32("success", redundancy.SuccessThreshold),
-				zap.Int32("total", redundancy.Total))
-			return nil
-		}
 		obs.monStats.remoteSegmentsNeedingRepair++
 		err = obs.repairQueue.Insert(ctx, &pb.InjuredSegment{
 			Path:         []byte(path.Raw),


### PR DESCRIPTION
What: Remove an old error message in repair checker.

Why: The audit job will remove bad pieces from pointer. As a result the repair checker will find pointers that contain only valid pieces but less than repair threshold. The repair checker will throw an error. I removed that error and executed the same test again. Now the repair checker will add the segment to the repair queue and the repair job will upload new pieces to new storage nodes. Everything works fine without that error validation.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
