### PR TITLE
satellite/metainfo: remove Iterate from service

### DIFF
--- a/satellite/metainfo/loop.go
+++ b/satellite/metainfo/loop.go
@@ -76,19 +76,19 @@ type LoopConfig struct {
 //
 // architecture: Service
 type Loop struct {
-	config   LoopConfig
-	metainfo *Service
-	join     chan *observerContext
-	done     chan struct{}
+	config LoopConfig
+	db     PointerDB
+	join   chan *observerContext
+	done   chan struct{}
 }
 
 // NewLoop creates a new metainfo loop service.
-func NewLoop(config LoopConfig, metainfo *Service) *Loop {
+func NewLoop(config LoopConfig, db PointerDB) *Loop {
 	return &Loop{
-		metainfo: metainfo,
-		config:   config,
-		join:     make(chan *observerContext),
-		done:     make(chan struct{}),
+		db:     db,
+		config: config,
+		join:   make(chan *observerContext),
+		done:   make(chan struct{}),
 	}
 }
 
@@ -174,7 +174,7 @@ waitformore:
 		}
 	}
 
-	err = loop.metainfo.Iterate(ctx, "", "", true, false,
+	err = loop.db.Iterate(ctx, storage.IterateOptions{Recurse: true},
 		func(ctx context.Context, it storage.Iterator) error {
 			var item storage.ListItem
 

--- a/satellite/metainfo/loop_test.go
+++ b/satellite/metainfo/loop_test.go
@@ -222,7 +222,7 @@ func TestLoopCancel(t *testing.T) {
 		// create a new metainfo loop
 		metaLoop := metainfo.NewLoop(metainfo.LoopConfig{
 			CoalesceDuration: 1 * time.Second,
-		}, satellite.Metainfo.Service)
+		}, satellite.Metainfo.Database)
 
 		// create a cancelable context to pass into metaLoop.Run
 		loopCtx, cancel := context.WithCancel(ctx)

--- a/satellite/metainfo/service.go
+++ b/satellite/metainfo/service.go
@@ -244,18 +244,6 @@ func (s *Service) Delete(ctx context.Context, path string) (err error) {
 	return s.DB.Delete(ctx, []byte(path))
 }
 
-// Iterate iterates over items in db
-func (s *Service) Iterate(ctx context.Context, prefix string, first string, recurse bool, reverse bool, f func(context.Context, storage.Iterator) error) (err error) {
-	defer mon.Task()(&ctx)(&err)
-	opts := storage.IterateOptions{
-		Prefix:  storage.Key(prefix),
-		First:   storage.Key(first),
-		Recurse: recurse,
-		Reverse: reverse,
-	}
-	return s.DB.Iterate(ctx, opts, f)
-}
-
 // CreateBucket creates a new bucket in the buckets db
 func (s *Service) CreateBucket(ctx context.Context, bucket storj.Bucket) (_ storj.Bucket, err error) {
 	defer mon.Task()(&ctx)(&err)

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -386,7 +386,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 			peer.Metainfo.Database,
 			peer.DB.Buckets(),
 		)
-		peer.Metainfo.Loop = metainfo.NewLoop(config.Metainfo.Loop, peer.Metainfo.Service)
+		peer.Metainfo.Loop = metainfo.NewLoop(config.Metainfo.Loop, peer.Metainfo.Database)
 
 		peer.Metainfo.Endpoint2 = metainfo.NewEndpoint(
 			peer.Log.Named("metainfo:endpoint"),


### PR DESCRIPTION
What: Removes unneeded `Iterate` after https://github.com/storj/storj/pull/2992.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
