### PR TITLE
satellite/repairer: move segment age calculation

### DIFF
--- a/satellite/repair/repairer/segments.go
+++ b/satellite/repair/repairer/segments.go
@@ -257,6 +257,13 @@ func (repairer *SegmentRepairer) Repair(ctx context.Context, path storj.Path) (s
 	// add pieces that failed piece hashes verification to the removal list
 	toRemove = append(toRemove, failedPieces...)
 
+	var segmentAge time.Duration
+	if pointer.CreationDate.Before(pointer.LastRepaired) {
+		segmentAge = time.Since(pointer.LastRepaired)
+	} else {
+		segmentAge = time.Since(pointer.CreationDate)
+	}
+
 	pointer.LastRepaired = time.Now().UTC()
 	pointer.RepairCount++
 
@@ -264,13 +271,6 @@ func (repairer *SegmentRepairer) Repair(ctx context.Context, path storj.Path) (s
 	_, err = repairer.metainfo.UpdatePieces(ctx, path, pointer, repairedPieces, toRemove)
 	if err != nil {
 		return false, err
-	}
-
-	var segmentAge time.Duration
-	if pointer.CreationDate.Before(pointer.LastRepaired) {
-		segmentAge = time.Since(pointer.LastRepaired)
-	} else {
-		segmentAge = time.Since(pointer.CreationDate)
 	}
 
 	mon.IntVal("segment_time_until_repair").Observe(int64(segmentAge.Seconds()))


### PR DESCRIPTION
What: 
Calculate segment age before modifying the "last repaired" timestamp on the segment.

Why:
The `segment_time_until_repair` metric is not reporting what it should be, because we are updating the "last repaired" timestamp right before calculating "segment age", which is dependent on the previous last repaired timestamp to be accurate.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
