### PR TITLE
satellite: resolve dns addresses of storage nodes for the uplink

### DIFF
--- a/satellite/overlay/selection_test.go
+++ b/satellite/overlay/selection_test.go
@@ -314,13 +314,20 @@ func testDistinctIPs(t *testing.T, ctx *testcontext.Context, planet *testplanet.
 func TestAddrtoNetwork_Conversion(t *testing.T) {
 	ctx := testcontext.New(t)
 
-	ip := "8.8.8.8:28967"
-	network, err := overlay.GetNetwork(ctx, ip)
+	addr := "8.8.8.8:28967"
+	_, network, err := overlay.ResolveAddressAndNetwork(ctx, addr)
 	require.Equal(t, "8.8.8.0", network)
 	require.NoError(t, err)
 
-	ipv6 := "[fc00::1:200]:28967"
-	network, err = overlay.GetNetwork(ctx, ipv6)
+	addr = "localhost:28967"
+	newaddr, network, err := overlay.ResolveAddressAndNetwork(ctx, addr)
+	require.Equal(t, "127.0.0.1:28967", newaddr)
+	require.Equal(t, "127.0.0.0", network)
+	require.NoError(t, err)
+
+	ipv6Addr := "[fc00::1:200]:28967"
+	newaddr, network, err = overlay.ResolveAddressAndNetwork(ctx, ipv6Addr)
+	require.Equal(t, ipv6Addr, newaddr)
 	require.Equal(t, "fc00::", network)
 	require.NoError(t, err)
 }

--- a/satellite/overlay/service.go
+++ b/satellite/overlay/service.go
@@ -342,7 +342,7 @@ func (service *Service) Put(ctx context.Context, nodeID storj.NodeID, value pb.N
 	}
 
 	// Resolve IP Address Network to ensure it is set
-	value.LastIp, err = GetNetwork(ctx, value.Address.Address)
+	value.Address.Address, value.LastIp, err = ResolveAddressAndNetwork(ctx, value.Address.Address)
 	if err != nil {
 		return Error.Wrap(err)
 	}
@@ -436,39 +436,31 @@ func (service *Service) GetMissingPieces(ctx context.Context, pieces []*pb.Remot
 	return missingPieces, nil
 }
 
-func getIP(ctx context.Context, target string) (ip net.IPAddr, err error) {
-	defer mon.Task()(&ctx)(&err)
-	host, _, err := net.SplitHostPort(target)
-	if err != nil {
-		return net.IPAddr{}, err
-	}
-	ipAddr, err := net.ResolveIPAddr("ip", host)
-	if err != nil {
-		return net.IPAddr{}, err
-	}
-	return *ipAddr, nil
-}
-
-// GetNetwork resolves the target address and determines its IP /24 Subnet
-func GetNetwork(ctx context.Context, target string) (network string, err error) {
+// ResolveAddressAndNetwork takes a network address and returns a new address with all DNS resolution
+// performed. It also returns the /24 subnet (or /64 subnet if ipv6) network of the resolved address.
+func ResolveAddressAndNetwork(ctx context.Context, address string) (resolvedAddress, network string, err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	addr, err := getIP(ctx, target)
+	hostname, port, err := net.SplitHostPort(address)
 	if err != nil {
-		return "", err
+		return "", "", errs.Wrap(err)
+	}
+
+	addr, err := net.ResolveIPAddr("ip", hostname)
+	if err != nil {
+		return "", "", errs.Wrap(err)
 	}
 
 	// If addr can be converted to 4byte notation, it is an IPv4 address, else its an IPv6 address
 	if ipv4 := addr.IP.To4(); ipv4 != nil {
-		//Filter all IPv4 Addresses into /24 Subnet's
-		mask := net.CIDRMask(24, 32)
-		return ipv4.Mask(mask).String(), nil
-	}
-	if ipv6 := addr.IP.To16(); ipv6 != nil {
-		//Filter all IPv6 Addresses into /64 Subnet's
-		mask := net.CIDRMask(64, 128)
-		return ipv6.Mask(mask).String(), nil
+		// Filter all IPv4 Addresses into /24 Subnet's
+		return net.JoinHostPort(addr.String(), port), ipv4.Mask(net.CIDRMask(24, 32)).String(), nil
 	}
 
-	return "", errors.New("unable to get network for address " + addr.String())
+	if ipv6 := addr.IP.To16(); ipv6 != nil {
+		// Filter all IPv6 Addresses into /64 Subnet's
+		return net.JoinHostPort(addr.String(), port), ipv6.Mask(net.CIDRMask(64, 128)).String(), nil
+	}
+
+	return "", "", errs.New("unable to get network for address %q", addr.String())
 }


### PR DESCRIPTION
Right now, uplinks are pretty stressful on DNS resolution paths. When doing an upload or download, uplinks cause the operating system to do lots of parallel DNS resolutions, and in many cases can stress out or essentially DoS routers. One of the primary usability problems I've had personally with the uplink has been DNS stress on my router, and by doing non-standard tweaks just to my laptop's DNS I've hugely improved uplink performance.

It would be great for the Satellite to return already-DNS-resolved addresses to uplinks. That way, the uplink has no DNS work to do. 

There's two workable solutions and this is just one of them.

[Solution A] Just resolve the hostnames of all storage nodes on the way out to the uplink. The benefit of this solution is that if a storage node is using a DNS hostname because their IP changes frequently, this will result in the most up-to-date address for the storage node. The downside of this solution is the Satellite is doing *lots* of DNS lookups constantly.

The satellite already does DNS resolution to determine the network subnet of a storage node whenever that storage node's contact information is discovered. So [Solution B] is instead of persisting the storage node's provided hostname, actually persist the storage node's resolved IP discovered at contact time in the DB, and then serve that to the uplink. The benefits and downsides of this solution are the exact opposite of solution A.

Storage nodes should not be changing IPs much, even in a dynamic DNS situation. In my experience dynamic DNS still means IP change events are rare, maybe once a month at most. Even if they were common, it is the responsibility of the storage node to check in with the satellite at least once an hour to confirm reachability. At very worst, even if a storage node's IP changes, this would mean that the storage node would simply need to check in again, to eliminate any potential perceived downtime. This seems like an acceptable tradeoff for the Satellite to make for performance.

So this PR is Solution B. This change persists the existing DNS resolution as the node's official address.

This will have a noticeable effect on uplink performance at least with my router's and operating system's default configuration. This PR simply reuses existing network operations and discovered information better, and adds no additional network lookups or cost.

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
