### PR TITLE
satellite/audit: add mutex to pieceHashesVerified map

### DIFF
--- a/satellite/audit/verifier.go
+++ b/satellite/audit/verifier.go
@@ -439,7 +439,6 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 			}
 			if !found {
 				// node is no longer in pointer, so remove from containment
-				ch <- result{nodeID: pending.NodeID, status: erred, err: err}
 				_, errDelete := verifier.containment.Delete(ctx, pending.NodeID)
 				if errDelete != nil {
 					verifier.log.Debug("Error deleting node from containment db", zap.String("Segment Path", pending.Path), zap.Stringer("Node ID", pending.NodeID), zap.Error(errDelete))

--- a/satellite/audit/verifier.go
+++ b/satellite/audit/verifier.go
@@ -359,6 +359,7 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 	}
 
 	pieceHashesVerified := make(map[storj.NodeID]bool)
+	pieceHashesVerifiedMutex := &sync.Mutex{}
 	defer func() {
 		// for each node in Fails and PendingAudits, remove if piece hashes not verified for that segment
 		newFails := storj.NodeIDList{}
@@ -415,7 +416,9 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 			}
 
 			// set whether piece hashes have been verified for this segment so we know whether to report a failed or pending audit for this node
+			pieceHashesVerifiedMutex.Lock()
 			pieceHashesVerified[pending.NodeID] = pendingPointer.PieceHashesVerified
+			pieceHashesVerifiedMutex.Unlock()
 
 			if pendingPointer.GetRemote().RootPieceId != pending.PieceID {
 				// segment has changed since initial containment

--- a/satellite/audit/verifier.go
+++ b/satellite/audit/verifier.go
@@ -361,6 +361,8 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 	pieceHashesVerified := make(map[storj.NodeID]bool)
 	pieceHashesVerifiedMutex := &sync.Mutex{}
 	defer func() {
+		pieceHashesVerifiedMutex.Lock()
+
 		// for each node in Fails and PendingAudits, remove if piece hashes not verified for that segment
 		newFails := storj.NodeIDList{}
 		newPendingAudits := []*PendingAudit{}
@@ -378,6 +380,8 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 
 		report.Fails = newFails
 		report.PendingAudits = newPendingAudits
+
+		pieceHashesVerifiedMutex.Unlock()
 	}()
 
 	pieces := pointer.GetRemote().GetRemotePieces()

--- a/satellite/audit/verifier.go
+++ b/satellite/audit/verifier.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io"
 	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/vivint/infectious"


### PR DESCRIPTION
What: 
Add a mutex to use around writes to the `pieceHashesVerifiedMap` so that we don't ever concurrently write to it.

Why:
There is a chance we can do concurrent writes to the map, which could result in memory issues on the satellite.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
