### PR TITLE
Installer: identity directory defaults to %APPDATA%\Storj\Identity\Storagenode

### DIFF
--- a/installer/windows/Product.wxs
+++ b/installer/windows/Product.wxs
@@ -94,7 +94,6 @@
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Open dashboard" />
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1"/>
 
-    <UIRef Id="CustomInstallDir" />
     <Icon Id="storj.ico" SourceFile="storj.ico"/>
     <Property Id="ARPPRODUCTICON" Value="storj.ico" />
     <WixVariable Id="WixUILicenseRtf" Value="agpl-3.0.rtf" />

--- a/installer/windows/Product.wxs
+++ b/installer/windows/Product.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:fire="http://schemas.microsoft.com/wix/FirewallExtension">
-  <Product Id="{E97D368F-CB18-45B5-8799-1EBB10728A99}" Name="Storj V3 Storage Node" Language="1033" Version="0.0.0" Manufacturer="Storj Labs Inc." UpgradeCode="{B32CF5FC-0665-4712-B88A-22D299565F9E}">
+  <Product Id="{E97D368F-CB18-45B5-8799-1EBB10728A99}" Name="Storj V3 Storage Node" Language="1033" Version="0.22.0.0" Manufacturer="Storj Labs Inc." UpgradeCode="{B32CF5FC-0665-4712-B88A-22D299565F9E}">
     <Package Platform="x64" InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
     <MediaTemplate EmbedCab="yes" />
@@ -79,7 +79,12 @@
     </ComponentGroup>
     
     <Property Id="WIXUI_INSTALLDIR">INSTALLFOLDER</Property>
-    <Property Id="STORJ_IDENTITYDIR">IDENTITYDIR</Property>
+
+    <Property Id="STORJ_DEFAULTIDENTITYDIR"  >
+       <DirectorySearch Id="search1" Depth="0" Path="[AppDataFolder]" />
+       <DirectorySearch Id="search2" Depth="0" Path="[AppDataFolder]\Storj\Identity\storagenode" />
+      </Property>
+    <Property Id="STORJ_IDENTITYDIR"><![CDATA[STORJ_DEFAULTIDENTITYDIR]]></Property>
     <Property Id="STORJ_STORAGEDIR">STORAGEDIR</Property>
     <Property Id="STORJ_STORAGE">1.0</Property>
     <Property Id="STORJ_BANDWIDTH">2.0</Property>

--- a/installer/windows/Product.wxs
+++ b/installer/windows/Product.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:fire="http://schemas.microsoft.com/wix/FirewallExtension">
-  <Product Id="{E97D368F-CB18-45B5-8799-1EBB10728A99}" Name="Storj V3 Storage Node" Language="1033" Version="0.22.0.0" Manufacturer="Storj Labs Inc." UpgradeCode="{B32CF5FC-0665-4712-B88A-22D299565F9E}">
+  <Product Id="{E97D368F-CB18-45B5-8799-1EBB10728A99}" Name="Storj V3 Storage Node" Language="1033" Version="0.0.0" Manufacturer="Storj Labs Inc." UpgradeCode="{B32CF5FC-0665-4712-B88A-22D299565F9E}">
     <Package Platform="x64" InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
     <MediaTemplate EmbedCab="yes" />
@@ -79,16 +79,18 @@
     </ComponentGroup>
     
     <Property Id="WIXUI_INSTALLDIR">INSTALLFOLDER</Property>
-
-    <Property Id="STORJ_DEFAULTIDENTITYDIR"  >
-       <DirectorySearch Id="search1" Depth="0" Path="[AppDataFolder]" />
-       <DirectorySearch Id="search2" Depth="0" Path="[AppDataFolder]\Storj\Identity\storagenode" />
-      </Property>
-    <Property Id="STORJ_IDENTITYDIR"><![CDATA[STORJ_DEFAULTIDENTITYDIR]]></Property>
     <Property Id="STORJ_STORAGEDIR">STORAGEDIR</Property>
     <Property Id="STORJ_STORAGE">1.0</Property>
     <Property Id="STORJ_BANDWIDTH">2.0</Property>
-    <UIRef Id="CustomInstallDir" />
+    <Property Id="STORJ_IDENTITYDIR">IDENTITYDIR</Property>
+
+    <Property Id="STORJ_DEFAULTIDENTITYDIR">
+        <DirectorySearch Id='search1' Path='[PersonalFolder]' />
+        <DirectorySearch Id='search2' Path='[AppDataFolder]\Storj\Identity\storagenode'/>
+    </Property>
+    <SetDirectory Action="SetIdentityDir" Id="IDENTITYDIR" Value="[STORJ_DEFAULTIDENTITYDIR]" Sequence="first">STORJ_DEFAULTIDENTITYDIR</SetDirectory>
+
+      <UIRef Id="CustomInstallDir" />
     <Icon Id="storj.ico" SourceFile="storj.ico"/>
     <Property Id="ARPPRODUCTICON" Value="storj.ico" />
     <WixVariable Id="WixUILicenseRtf" Value="agpl-3.0.rtf" />

--- a/installer/windows/Product.wxs
+++ b/installer/windows/Product.wxs
@@ -90,7 +90,7 @@
     </Property>
     <SetDirectory Action="SetIdentityDir" Id="IDENTITYDIR" Value="[STORJ_DEFAULTIDENTITYDIR]" Sequence="first">STORJ_DEFAULTIDENTITYDIR</SetDirectory>
 
-      <UIRef Id="CustomInstallDir" />
+    <UIRef Id="CustomInstallDir" />
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Open dashboard" />
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1"/>
 


### PR DESCRIPTION
What:  default value in the Identity Folder dialog of the Windows Installer points to %APPDATA%\Storj\Identity\Storagenode

Why: because it is the default location for identity tool to generate new storage node identity. Currently, the default is set to the root of the largest drive, which requires the user to always navigate to the location of their identity.

Acceptance criteria:
- The Identity Folder dialog displays %APPDATA%\Storj\Identity\Storagenode as the default value, where %APPDATA% is expanded to the actual location for the current user, e.g. C:\Users\IEUser\AppData\Roaming\Storj\Identity\Storagenode.

Please describe the tests: no test
Please describe the performance impact: none 

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
