### PR TITLE
satellite/audit: fix audit panic

### DIFF
--- a/satellite/audit/disqualification_test.go
+++ b/satellite/audit/disqualification_test.go
@@ -49,7 +49,7 @@ func TestDisqualificationTooManyFailedAudits(t *testing.T) {
 		var (
 			satellitePeer = planet.Satellites[0]
 			nodeID        = planet.StorageNodes[0].ID()
-			report        = &audit.Report{
+			report        = audit.Report{
 				Fails: storj.NodeIDList{nodeID},
 			}
 		)

--- a/satellite/audit/reporter.go
+++ b/satellite/audit/reporter.go
@@ -45,11 +45,8 @@ func NewReporter(log *zap.Logger, overlay *overlay.Service, containment Containm
 // RecordAudits saves audit results to overlay. When no error, it returns
 // nil for both return values, otherwise it returns the report with the fields
 // set to the values which have been saved and the error.
-func (reporter *Reporter) RecordAudits(ctx context.Context, req *Report) (_ *Report, err error) {
+func (reporter *Reporter) RecordAudits(ctx context.Context, req Report) (_ Report, err error) {
 	defer mon.Task()(&ctx)(&err)
-	if req == nil {
-		return nil, nil
-	}
 
 	successes := req.Successes
 	fails := req.Fails
@@ -68,7 +65,7 @@ func (reporter *Reporter) RecordAudits(ctx context.Context, req *Report) (_ *Rep
 	tries := 0
 	for tries <= reporter.maxRetries {
 		if len(successes) == 0 && len(fails) == 0 && len(offlines) == 0 && len(pendingAudits) == 0 {
-			return nil, nil
+			return Report{}, nil
 		}
 
 		errlist = errs.Group{}
@@ -103,14 +100,14 @@ func (reporter *Reporter) RecordAudits(ctx context.Context, req *Report) (_ *Rep
 
 	err = errlist.Err()
 	if tries >= reporter.maxRetries && err != nil {
-		return &Report{
+		return Report{
 			Successes:     successes,
 			Fails:         fails,
 			Offlines:      offlines,
 			PendingAudits: pendingAudits,
 		}, errs.Combine(Error.New("some nodes failed to be updated in overlay"), err)
 	}
-	return nil, nil
+	return Report{}, nil
 }
 
 // recordAuditFailStatus updates nodeIDs in overlay with isup=true, auditsuccess=false

--- a/satellite/audit/reporter_test.go
+++ b/satellite/audit/reporter_test.go
@@ -39,7 +39,7 @@ func TestReportPendingAudits(t *testing.T) {
 		overlay := satellite.Overlay.Service
 		containment := satellite.DB.Containment()
 
-		failed, err := audits.Reporter.RecordAudits(ctx, &report)
+		failed, err := audits.Reporter.RecordAudits(ctx, report)
 		require.NoError(t, err)
 		assert.Zero(t, failed)
 
@@ -66,7 +66,7 @@ func TestRecordAuditsAtLeastOnce(t *testing.T) {
 		report := audit.Report{Successes: []storj.NodeID{nodeID}}
 
 		// expect RecordAudits to try recording at least once (maxRetries is set to 0)
-		failed, err := audits.Reporter.RecordAudits(ctx, &report)
+		failed, err := audits.Reporter.RecordAudits(ctx, report)
 		require.NoError(t, err)
 		require.Zero(t, failed)
 

--- a/satellite/audit/verifier.go
+++ b/satellite/audit/verifier.go
@@ -95,7 +95,7 @@ func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[
 
 	defer func() {
 		// if piece hashes have not been verified for this segment, do not mark nodes as failing audit
-		if !pointer.PieceHashesVerified {
+		if !pointer.PieceHashesVerified && report != nil {
 			report.PendingAudits = nil
 			report.Fails = nil
 		}
@@ -362,6 +362,10 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 	pieceHashesVerified := make(map[storj.NodeID]bool)
 	pieceHashesVerifiedMutex := &sync.Mutex{}
 	defer func() {
+		if report == nil {
+			return
+		}
+
 		pieceHashesVerifiedMutex.Lock()
 
 		// for each node in Fails and PendingAudits, remove if piece hashes not verified for that segment

--- a/satellite/audit/verifier.go
+++ b/satellite/audit/verifier.go
@@ -82,20 +82,20 @@ func NewVerifier(log *zap.Logger, metainfo *metainfo.Service, dialer rpc.Dialer,
 }
 
 // Verify downloads shares then verifies the data correctness at a random stripe.
-func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[storj.NodeID]bool) (report *Report, err error) {
+func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[storj.NodeID]bool) (report Report, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	pointer, err := verifier.metainfo.Get(ctx, path)
 	if err != nil {
 		if storage.ErrKeyNotFound.Has(err) {
-			return nil, ErrSegmentDeleted.New("%q", path)
+			return Report{}, ErrSegmentDeleted.New("%q", path)
 		}
-		return nil, err
+		return Report{}, err
 	}
 
 	defer func() {
 		// if piece hashes have not been verified for this segment, do not mark nodes as failing audit
-		if !pointer.PieceHashesVerified && report != nil {
+		if !pointer.PieceHashesVerified {
 			report.PendingAudits = nil
 			report.Fails = nil
 		}
@@ -103,7 +103,7 @@ func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[
 
 	randomIndex, err := GetRandomStripe(ctx, pointer)
 	if err != nil {
-		return nil, err
+		return Report{}, err
 	}
 
 	shareSize := pointer.GetRemote().GetRedundancy().GetErasureShareSize()
@@ -116,7 +116,7 @@ func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[
 
 	orderLimits, privateKey, err := verifier.orders.CreateAuditOrderLimits(ctx, bucketID, pointer, skip)
 	if err != nil {
-		return nil, err
+		return Report{}, err
 	}
 
 	// NOTE offlineNodes will include disqualified nodes because they aren't in
@@ -131,14 +131,14 @@ func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[
 
 	shares, err := verifier.DownloadShares(ctx, orderLimits, privateKey, randomIndex, shareSize)
 	if err != nil {
-		return &Report{
+		return Report{
 			Offlines: offlineNodes,
 		}, err
 	}
 
 	_, err = verifier.checkIfSegmentAltered(ctx, path, pointer)
 	if err != nil {
-		return &Report{
+		return Report{
 			Offlines: offlineNodes,
 		}, err
 	}
@@ -214,7 +214,7 @@ func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[
 	total := int(pointer.Remote.Redundancy.GetTotal())
 
 	if len(sharesToAudit) < required {
-		return &Report{
+		return Report{
 			Fails:    failedNodes,
 			Offlines: offlineNodes,
 		}, ErrNotEnoughShares.New("got %d, required %d", len(sharesToAudit), required)
@@ -222,7 +222,7 @@ func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[
 
 	pieceNums, correctedShares, err := auditShares(ctx, required, total, sharesToAudit)
 	if err != nil {
-		return &Report{
+		return Report{
 			Fails:    failedNodes,
 			Offlines: offlineNodes,
 		}, err
@@ -278,14 +278,14 @@ func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[
 
 	pendingAudits, err := createPendingAudits(ctx, containedNodes, correctedShares, pointer, randomIndex, path)
 	if err != nil {
-		return &Report{
+		return Report{
 			Successes: successNodes,
 			Fails:     failedNodes,
 			Offlines:  offlineNodes,
 		}, err
 	}
 
-	return &Report{
+	return Report{
 		Successes:     successNodes,
 		Fails:         failedNodes,
 		Offlines:      offlineNodes,
@@ -331,7 +331,7 @@ func (verifier *Verifier) DownloadShares(ctx context.Context, limits []*pb.Addre
 }
 
 // Reverify reverifies the contained nodes in the stripe
-func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report *Report, err error) {
+func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report Report, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	// result status enum
@@ -354,18 +354,14 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 	pointer, err := verifier.metainfo.Get(ctx, path)
 	if err != nil {
 		if storage.ErrKeyNotFound.Has(err) {
-			return nil, ErrSegmentDeleted.New("%q", path)
+			return Report{}, ErrSegmentDeleted.New("%q", path)
 		}
-		return nil, err
+		return Report{}, err
 	}
 
 	pieceHashesVerified := make(map[storj.NodeID]bool)
 	pieceHashesVerifiedMutex := &sync.Mutex{}
 	defer func() {
-		if report == nil {
-			return
-		}
-
 		pieceHashesVerifiedMutex.Lock()
 
 		// for each node in Fails and PendingAudits, remove if piece hashes not verified for that segment
@@ -564,7 +560,6 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 		}(pending)
 	}
 
-	report = &Report{}
 	for range pieces {
 		result := <-ch
 		switch result.status {

--- a/satellite/audit/worker.go
+++ b/satellite/audit/worker.go
@@ -118,19 +118,17 @@ func (worker *Worker) work(ctx context.Context, path storj.Path) error {
 
 	// Skip all reverified nodes in the next Verify step.
 	skip := make(map[storj.NodeID]bool)
-	if report != nil {
-		for _, nodeID := range report.Successes {
-			skip[nodeID] = true
-		}
-		for _, nodeID := range report.Offlines {
-			skip[nodeID] = true
-		}
-		for _, nodeID := range report.Fails {
-			skip[nodeID] = true
-		}
-		for _, pending := range report.PendingAudits {
-			skip[pending.NodeID] = true
-		}
+	for _, nodeID := range report.Successes {
+		skip[nodeID] = true
+	}
+	for _, nodeID := range report.Offlines {
+		skip[nodeID] = true
+	}
+	for _, nodeID := range report.Fails {
+		skip[nodeID] = true
+	}
+	for _, pending := range report.PendingAudits {
+		skip[pending.NodeID] = true
 	}
 
 	// Next, audit the the remaining nodes that are not in containment mode.


### PR DESCRIPTION
What: 
Use `Report` instead of `*Report` in the audit service so we do not have to worry about nil-pointer-exception behavior in the event of an empty report.

Why:
https://build.dev.storj.io/blue/organizations/jenkins/storj/detail/PR-3017/19/tests

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
