### PR TITLE
web/storagenode: charts on first day of the month updated

### DIFF
--- a/web/storagenode/src/app/utils/chartUtils.ts
+++ b/web/storagenode/src/app/utils/chartUtils.ts
@@ -50,6 +50,10 @@ export class ChartUtils {
             daysDisplayed[i] = date.toLocaleDateString('en-US', {day: 'numeric'});
         }
 
+        if (daysDisplayed.length === 1) {
+            daysDisplayed.unshift('0');
+        }
+
         return daysDisplayed;
     }
 
@@ -80,6 +84,11 @@ export class ChartUtils {
             bandwidthChartData[i] = BandwidthUsed.emptyWithDate(date);
         }
 
+        if (bandwidthChartData.length === 1) {
+            bandwidthChartData.unshift(BandwidthUsed.emptyWithDate(1));
+            bandwidthChartData[0].intervalStart.setUTCHours(0, 0, 0, 0);
+        }
+
         return bandwidthChartData;
     }
 
@@ -108,6 +117,11 @@ export class ChartUtils {
             }
 
             storageChartData[i] = Stamp.emptyWithDate(date);
+        }
+
+        if (storageChartData.length === 1) {
+            storageChartData.unshift(Stamp.emptyWithDate(1));
+            storageChartData[0].intervalStart.setUTCHours(0, 0, 0, 0);
         }
 
         return storageChartData;


### PR DESCRIPTION
What: added conditions to make charts be displayed on first day of the month

Why: charts were not displayed on first day of the month

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
