### PR TITLE
internal/testplanet: ensure that metainfo schema gets dropped

### DIFF
--- a/internal/testplanet/run.go
+++ b/internal/testplanet/run.go
@@ -58,7 +58,11 @@ func Run(t *testing.T, config Config, test func(t *testing.T, ctx *testcontext.C
 			if satelliteDB.PointerDB.URL != "" {
 				satReconfigure := planetConfig.Reconfigure.Satellite
 				planetConfig.Reconfigure.Satellite = func(log *zap.Logger, index int, config *satellite.Config) {
-					schema := strings.ToLower(t.Name() + "-satellite/" + strconv.Itoa(index) + "-metainfo")
+					// TODO: use a different unique schema name to ensure we can drop it separately instead of relying
+					//       master database to drop it
+					// Something like:
+					//       schema := strings.ToLower(t.Name() + "-satellite/" + strconv.Itoa(index) + "-metainfo" + "-" + schemaSuffix)
+					schema := strings.ToLower(t.Name() + "-satellite/" + strconv.Itoa(index) + "-" + schemaSuffix)
 					config.Metainfo.DatabaseURL = pgutil.ConnstrWithSchema(satelliteDB.PointerDB.URL, schema)
 					if satReconfigure != nil {
 						satReconfigure(log, index, config)


### PR DESCRIPTION
What: This ensures that tests locally don't run against the same schema. Proper fix would be to make pointerdb an argument to the satellite rather than letting satellite.New handle the construction.

Proper fix will be tracked in https://storjlabs.atlassian.net/browse/V3-2867

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
