### PR TITLE
admin-key-gen: an administrator key generator

### DIFF
--- a/cmd/debug/admin-key-gen/main.go
+++ b/cmd/debug/admin-key-gen/main.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/jtolds/qod"
+	"github.com/skyrings/skyring-common/tools/uuid"
+	"github.com/spacemonkeygo/flagfile"
+	"github.com/zeebo/errs"
+
+	"storj.io/storj/pkg/macaroon"
+)
+
+var (
+	flagMacaroonHead   = flag.String("head", "", "hex-encoded admin macaroon head")
+	flagMacaroonSecret = flag.String("secret", "", "hex-encoded admin macaroon secret")
+)
+
+func main() {
+	flagfile.Load()
+	err := run(context.Background())
+	if err != nil {
+		panic(err)
+	}
+}
+
+func run(ctx context.Context) error {
+	secret, err := hex.DecodeString(*flagMacaroonSecret)
+	if err != nil {
+		return err
+	}
+	if len(secret) != 32 {
+		return errs.New("invalid secret length")
+	}
+	head, err := hex.DecodeString(*flagMacaroonHead)
+	if err != nil {
+		return err
+	}
+	if len(head) != 32 {
+		return errs.New("invalid head length")
+	}
+	adminRoot, err := macaroon.NewUnrestrictedFixedHead(secret, head)
+	if err != nil {
+		return err
+	}
+	adminRootKey, err := macaroon.ParseRawAPIKey(adminRoot.Serialize())
+	if err != nil {
+		return err
+	}
+
+	for line := range qod.Lines(os.Stdin) {
+		projectID, err := uuid.Parse(line)
+		if err != nil {
+			return err
+		}
+
+		expiry := time.Now().Add(time.Hour * 24)
+		projectKey, err := adminRootKey.Restrict(macaroon.Caveat{
+			ProjectId:       projectID[:],
+			DisallowWrites:  true,
+			DisallowDeletes: true,
+			NotAfter:        &expiry,
+		})
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(projectKey.Serialize())
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/jbenet/go-base58 v0.0.0-20150317085156-6237cf65f3a6
 	github.com/jtolds/go-luar v0.0.0-20170419063437-0786921db8c0
 	github.com/jtolds/monkit-hw v0.0.0-20190108155550-0f753668cf20
+	github.com/jtolds/qod v0.0.0-20190106035433-41b99bac4cad
 	github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e // indirect
 	github.com/klauspost/reedsolomon v0.0.0-20180704173009-925cb01d6510 // indirect
 	github.com/lib/pq v1.0.0
@@ -93,6 +94,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0 // indirect
 	github.com/skyrings/skyring-common v0.0.0-20160929130248-d1c0bb1cbd5e
 	github.com/spacemonkeygo/errors v0.0.0-20171212215202-9064522e9fd1 // indirect
+	github.com/spacemonkeygo/flagfile v0.0.0-20180426194429-0d750334dbb8
 	github.com/spf13/cast v1.3.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/jtolds/go-luar v0.0.0-20170419063437-0786921db8c0 h1:UyVaeqfY1fLPMt1i
 github.com/jtolds/go-luar v0.0.0-20170419063437-0786921db8c0/go.mod h1:OtVLEpPHGJkn8jgGrHlYELCA3uXLU0YSfNN0faeDM2M=
 github.com/jtolds/monkit-hw v0.0.0-20190108155550-0f753668cf20 h1:XK96humQhnPbQ24uKtSHKbdShDgrKYqlWBNKJTcIKbg=
 github.com/jtolds/monkit-hw v0.0.0-20190108155550-0f753668cf20/go.mod h1:1liUiYZzx8ZoPTfZrBE2q8DFRDPafts0GGjslOtcZcw=
+github.com/jtolds/qod v0.0.0-20190106035433-41b99bac4cad h1:JVYp8Ik88RrHoKiu0+Rc8PdYnBH2MFd43k2OtnuVqxk=
+github.com/jtolds/qod v0.0.0-20190106035433-41b99bac4cad/go.mod h1:CC0XsLGDIrizqHTsUEJh89QHzv2u2mix/O9xl4+LqSw=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
@@ -359,6 +361,8 @@ github.com/smartystreets/goconvey v0.0.0-20180222194500-ef6db91d284a/go.mod h1:X
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spacemonkeygo/errors v0.0.0-20171212215202-9064522e9fd1 h1:xHQewZjohU9/wUsyC99navCjQDNHtTgUOM/J1jAbzfw=
 github.com/spacemonkeygo/errors v0.0.0-20171212215202-9064522e9fd1/go.mod h1:7NL9UAYQnRM5iKHUCld3tf02fKb5Dft+41+VckASUy0=
+github.com/spacemonkeygo/flagfile v0.0.0-20180426194429-0d750334dbb8 h1:igGPAk1IhuO3QcQTgVC+7ryzcc0S/GrJfyFMw2kiDpA=
+github.com/spacemonkeygo/flagfile v0.0.0-20180426194429-0d750334dbb8/go.mod h1:Sv7P/HGgCluSQraRbYxntA4oe016UX0ShVPQyc5nHbA=
 github.com/spacemonkeygo/monotime v0.0.0-20180824235756-e3f48a95f98a h1:8+cCjxhToanKmxLIbuyBNe2EnpgwhiivsIaRJstDRFA=
 github.com/spacemonkeygo/monotime v0.0.0-20180824235756-e3f48a95f98a/go.mod h1:ul4bvvnCOPZgq8w0nTkSmWVg/hauVpFS97Am1YM1XXo=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=

--- a/pkg/macaroon/macaroon.go
+++ b/pkg/macaroon/macaroon.go
@@ -29,6 +29,15 @@ func NewUnrestricted(secret []byte) (*Macaroon, error) {
 	}, nil
 }
 
+// NewUnrestrictedFixedHead creates a new macaroon with a fixed head and a
+// generated tail
+func NewUnrestrictedFixedHead(secret []byte, head []byte) (*Macaroon, error) {
+	return &Macaroon{
+		head: head,
+		tail: sign(secret, head),
+	}, nil
+}
+
 func sign(secret []byte, data []byte) []byte {
 	signer := hmac.New(sha256.New, secret)
 	_, err := signer.Write(data)


### PR DESCRIPTION
What: accepts a list of project id uuids via standard in and creates admin macaroons that work with those uuids. 

Why: this is useful for applications that want to make use of the feature added in https://github.com/storj/storj/pull/3265

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
