### PR TITLE
storagenode/piecestore: Fix to ignore both gRPC and dRPC EOF errors.

### DIFF
--- a/pkg/rpc/dial.go
+++ b/pkg/rpc/dial.go
@@ -94,7 +94,7 @@ func (d Dialer) dialContext(ctx context.Context, address string) (net.Conn, erro
 
 // DialNode creates an rpc connection to the specified node.
 func (d Dialer) DialNode(ctx context.Context, node *pb.Node) (_ *Conn, err error) {
-	defer mon.Task()(&ctx)(&err)
+	defer mon.Task()(&ctx, "node: "+node.Id.String()[0:8])(&err)
 
 	if d.TLSOptions == nil {
 		return nil, Error.New("tls options not set when required for this dial")

--- a/storagenode/piecestore/endpoint.go
+++ b/storagenode/piecestore/endpoint.go
@@ -685,7 +685,8 @@ func min(a, b int64) int64 {
 
 // ignoreEOF ignores io.EOF error.
 func ignoreEOF(err error) error {
-	if err == io.EOF {
+	// gRPC gives us an io.EOF but dRPC gives us a wrapped io.EOF
+	if errs.Is(err, io.EOF) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
**What:** This PR adds the ability to ignore io.EOF's that come wrapped or not wrapped.

**Why:** gRPC gives us an unwrapped io.EOF error but dRPC givers us a wrapped one. Since we weren't ignoring the EOF when using dRPC it was causing this error for both uplink and satellite audit downloads.

```
storagenode/6    12F3yR1nJU 21:09:02.714 | INFO	piecestore	piecestore/endpoint.go:440	download failed	{"Piece ID": "PYXQ6IBKHGDH6PWGX3ZZH5SIQAU6BNKLI7QTIYBCYS3U7Y3V2HIQ", "SatelliteID": "1ZNd6Cz8h5Q1NUSesmYXcANd7CwJgcuVVfTGkYof4LQbfzEhrG", "Action": "GET", "error": "piecestore: piecestore protocol: EOF", "errorVerbose": "piecestore: piecestore protocol: EOF\n\tstorj.io/drpc/drpcstream.(*Stream).MsgRecv:242\n\tstorj.io/storj/pkg/pb.(*drpcPiecestoreDownloadStream).Recv:910\n\tstorj.io/storj/storagenode/piecestore.(*Endpoint).doDownload.func4:576\n\tstorj.io/storj/storagenode/piecestore.(*Endpoint).doDownload:609\n\tstorj.io/storj/storagenode/piecestore.(*drpcEndpoint).Download:370\n\tstorj.io/storj/pkg/pb.DRPCPiecestoreDescription.Method.func2:838\n\tstorj.io/drpc/drpcserver.(*Server).doHandle:163\n\tstorj.io/drpc/drpcserver.(*Server).HandleRPC:141\n\tstorj.io/drpc/drpcserver.(*Server).ServeOne:102\n\tstorj.io/drpc/drpcserver.(*Server).Serve.func2:135\n\tstorj.io/drpc/drpcctx.(*Tracker).track:51"}
```

After this fix both uplink and satellite downloads don't cause this error in the logs.

Please describe the tests:
 - Test 1: I ran a benchmark on storj-sim of a few hundred downloads without any errors. 
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
