### PR TITLE
piecestore: update usage before completing upload

### DIFF
--- a/storagenode/piecestore/endpoint.go
+++ b/storagenode/piecestore/endpoint.go
@@ -265,8 +265,16 @@ func (endpoint *Endpoint) doUpload(stream uploadStream) (err error) {
 		return ErrInternal.Wrap(err)
 	}
 
+	orderSaved := false
 	largestOrder := pb.Order{}
-	defer endpoint.saveOrder(ctx, limit, &largestOrder)
+	// Ensure that the order is saved even in the face of an error. In the
+	// success path, the order will be saved just before sending the response
+	// and closing the stream (in which case, orderSaved will be true).
+	defer func() {
+		if !orderSaved {
+			endpoint.saveOrder(ctx, limit, &largestOrder)
+		}
+	}()
 
 	for {
 		message, err = stream.Recv() // TODO: reuse messages to avoid allocations
@@ -351,6 +359,11 @@ func (endpoint *Endpoint) doUpload(stream uploadStream) (err error) {
 			if err != nil {
 				return ErrInternal.Wrap(err)
 			}
+
+			// Save the order before completing the call. Set orderSaved so
+			// that the defer above does not also save.
+			orderSaved = true
+			endpoint.saveOrder(ctx, limit, &largestOrder)
 
 			closeErr := stream.SendAndClose(&pb.PieceUploadResponse{
 				Done: storageNodeHash,


### PR DESCRIPTION
The upload code currently updates the usage in a deferred call to saveOrder().
The consequence is that in the success case, the RPC is completed before
the usage has been updated.

This change repurposes the deferred call to update usage in the
failure case, while explicitly updating the usage before completing the
RPC.

This fixes some test flakiness when using dRPC. gRPC waits until the final status is written before a `Recv` call completes, and the final status is written by the server after the handler function has exited. In practice this means that the client is blocked until the `defer` call is also finished. So this change will not change performance at all.

It has two advantages:

(1) It fixes test flakiness

and, more importantly:

(2) reduces the chances that someone will accidentally write a flaky test in the future

What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
