### PR TITLE
satellite/repair: improve logging

### DIFF
--- a/satellite/repair/repairer/ec.go
+++ b/satellite/repair/repairer/ec.go
@@ -57,7 +57,7 @@ func (ec *ECRepairer) dialPiecestore(ctx context.Context, n *pb.Node) (*piecesto
 // After downloading a piece, the ECRepairer will verify the hash and original order limit for that piece.
 // If verification fails, another piece will be downloaded until we reach the minimum required or run out of order limits.
 // If piece hash verification fails, it will return all failed node IDs.
-func (ec *ECRepairer) Get(ctx context.Context, limits []*pb.AddressedOrderLimit, privateKey storj.PiecePrivateKey, es eestream.ErasureScheme, dataSize int64) (_ io.ReadCloser, failedPieces []*pb.RemotePiece, err error) {
+func (ec *ECRepairer) Get(ctx context.Context, limits []*pb.AddressedOrderLimit, privateKey storj.PiecePrivateKey, es eestream.ErasureScheme, dataSize int64, path storj.Path) (_ io.ReadCloser, failedPieces []*pb.RemotePiece, err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	if len(limits) != es.TotalCount() {
@@ -122,7 +122,9 @@ func (ec *ECRepairer) Get(ctx context.Context, limits []*pb.AddressedOrderLimit,
 							NodeId:   limit.GetLimit().StorageNodeId,
 						})
 					} else {
-						ec.log.Debug("Failed to download pieces for repair", zap.Error(err))
+						ec.log.Debug("Failed to download pieces for repair",
+							zap.Binary("Segment", []byte(path)),
+							zap.Error(err))
 					}
 					return
 				}
@@ -268,22 +270,23 @@ func (ec *ECRepairer) Repair(ctx context.Context, limits []*pb.AddressedOrderLim
 
 	for i, addressedLimit := range limits {
 		go func(i int, addressedLimit *pb.AddressedOrderLimit) {
-			hash, err := ec.putPiece(psCtx, ctx, addressedLimit, privateKey, readers[i], expiration)
+			hash, err := ec.putPiece(psCtx, ctx, addressedLimit, privateKey, readers[i], expiration, path)
 			infos <- info{i: i, err: err, hash: hash}
 		}(i, addressedLimit)
 	}
 	ec.log.Info("Starting a timer for repair so that the number of pieces will be closer to the success threshold",
+		zap.Binary("Segment", []byte(path)),
 		zap.Duration("Timer", timeout),
-		zap.String("Path", path),
 		zap.Int("Node Count", nonNilCount(limits)),
 		zap.Int("Optimal Threshold", rs.OptimalThreshold()),
+		zap.String("Segment Path", path),
 	)
 
 	var successfulCount, failureCount, cancellationCount int32
 	timer := time.AfterFunc(timeout, func() {
 		if ctx.Err() != context.Canceled {
 			ec.log.Info("Timer expired. Canceling the long tail...",
-				zap.String("Path", path),
+				zap.Binary("Segment", []byte(path)),
 				zap.Int32("Successfully repaired", atomic.LoadInt32(&successfulCount)),
 			)
 			cancel()
@@ -307,7 +310,7 @@ func (ec *ECRepairer) Repair(ctx context.Context, limits []*pb.AddressedOrderLim
 				cancellationCount++
 			}
 			ec.log.Debug("Repair to storage node failed",
-				zap.String("Path", path),
+				zap.Binary("Segment", []byte(path)),
 				zap.String("NodeID", limits[info.i].GetLimit().StorageNodeId.String()),
 				zap.Error(info.err),
 			)
@@ -335,11 +338,11 @@ func (ec *ECRepairer) Repair(ctx context.Context, limits []*pb.AddressedOrderLim
 	}()
 
 	if successfulCount == 0 {
-		return nil, nil, Error.New("repair %v to all nodes failed", path)
+		return nil, nil, Error.New("repair to all nodes failed")
 	}
 
 	ec.log.Info("Successfully repaired",
-		zap.String("Path", path),
+		zap.Binary("Segment", []byte(path)),
 		zap.Int32("Success Count", atomic.LoadInt32(&successfulCount)),
 	)
 
@@ -351,7 +354,7 @@ func (ec *ECRepairer) Repair(ctx context.Context, limits []*pb.AddressedOrderLim
 	return successfulNodes, successfulHashes, nil
 }
 
-func (ec *ECRepairer) putPiece(ctx, parent context.Context, limit *pb.AddressedOrderLimit, privateKey storj.PiecePrivateKey, data io.ReadCloser, expiration time.Time) (hash *pb.PieceHash, err error) {
+func (ec *ECRepairer) putPiece(ctx, parent context.Context, limit *pb.AddressedOrderLimit, privateKey storj.PiecePrivateKey, data io.ReadCloser, expiration time.Time, path storj.Path) (hash *pb.PieceHash, err error) {
 	nodeName := "nil"
 	if limit != nil {
 		nodeName = limit.GetLimit().StorageNodeId.String()[0:8]
@@ -372,6 +375,7 @@ func (ec *ECRepairer) putPiece(ctx, parent context.Context, limit *pb.AddressedO
 	})
 	if err != nil {
 		ec.log.Debug("Failed dialing for putting piece to node",
+			zap.Binary("Segment", []byte(path)),
 			zap.String("PieceID", pieceID.String()),
 			zap.String("NodeID", storageNodeID.String()),
 			zap.Error(err),
@@ -383,6 +387,7 @@ func (ec *ECRepairer) putPiece(ctx, parent context.Context, limit *pb.AddressedO
 	upload, err := ps.Upload(ctx, limit.GetLimit(), privateKey)
 	if err != nil {
 		ec.log.Debug("Failed requesting upload of pieces to node",
+			zap.Binary("Segment", []byte(path)),
 			zap.String("PieceID", pieceID.String()),
 			zap.String("NodeID", storageNodeID.String()),
 			zap.Error(err),
@@ -405,9 +410,13 @@ func (ec *ECRepairer) putPiece(ctx, parent context.Context, limit *pb.AddressedO
 	// to slow connection. No error logging for this case.
 	if ctx.Err() == context.Canceled {
 		if parent.Err() == context.Canceled {
-			ec.log.Info("Upload to node canceled by user", zap.String("NodeID", storageNodeID.String()))
+			ec.log.Info("Upload to node canceled by user",
+				zap.Binary("Segment", []byte(path)),
+				zap.String("NodeID", storageNodeID.String()))
 		} else {
-			ec.log.Debug("Node cut from upload due to slow connection", zap.String("NodeID", storageNodeID.String()))
+			ec.log.Debug("Node cut from upload due to slow connection",
+				zap.Binary("Segment", []byte(path)),
+				zap.String("NodeID", storageNodeID.String()))
 		}
 		err = context.Canceled
 	} else if err != nil {
@@ -417,6 +426,7 @@ func (ec *ECRepairer) putPiece(ctx, parent context.Context, limit *pb.AddressedO
 		}
 
 		ec.log.Debug("Failed uploading piece to node",
+			zap.Binary("Segment", []byte(path)),
 			zap.String("PieceID", pieceID.String()),
 			zap.String("NodeID", storageNodeID.String()),
 			zap.String("Node Address", nodeAddress),

--- a/satellite/repair/repairer/ec.go
+++ b/satellite/repair/repairer/ec.go
@@ -311,7 +311,7 @@ func (ec *ECRepairer) Repair(ctx context.Context, limits []*pb.AddressedOrderLim
 			}
 			ec.log.Debug("Repair to storage node failed",
 				zap.Binary("Segment", []byte(path)),
-				zap.String("NodeID", limits[info.i].GetLimit().StorageNodeId.String()),
+				zap.Stringer("NodeID", limits[info.i].GetLimit().StorageNodeId),
 				zap.Error(info.err),
 			)
 			continue
@@ -376,8 +376,8 @@ func (ec *ECRepairer) putPiece(ctx, parent context.Context, limit *pb.AddressedO
 	if err != nil {
 		ec.log.Debug("Failed dialing for putting piece to node",
 			zap.Binary("Segment", []byte(path)),
-			zap.String("PieceID", pieceID.String()),
-			zap.String("NodeID", storageNodeID.String()),
+			zap.Stringer("PieceID", pieceID),
+			zap.Stringer("NodeID", storageNodeID),
 			zap.Error(err),
 		)
 		return nil, err
@@ -388,8 +388,8 @@ func (ec *ECRepairer) putPiece(ctx, parent context.Context, limit *pb.AddressedO
 	if err != nil {
 		ec.log.Debug("Failed requesting upload of pieces to node",
 			zap.Binary("Segment", []byte(path)),
-			zap.String("PieceID", pieceID.String()),
-			zap.String("NodeID", storageNodeID.String()),
+			zap.Stringer("PieceID", pieceID),
+			zap.Stringer("NodeID", storageNodeID),
 			zap.Error(err),
 		)
 		return nil, err
@@ -412,11 +412,11 @@ func (ec *ECRepairer) putPiece(ctx, parent context.Context, limit *pb.AddressedO
 		if parent.Err() == context.Canceled {
 			ec.log.Info("Upload to node canceled by user",
 				zap.Binary("Segment", []byte(path)),
-				zap.String("NodeID", storageNodeID.String()))
+				zap.Stringer("NodeID", storageNodeID))
 		} else {
 			ec.log.Debug("Node cut from upload due to slow connection",
 				zap.Binary("Segment", []byte(path)),
-				zap.String("NodeID", storageNodeID.String()))
+				zap.Stringer("NodeID", storageNodeID))
 		}
 		err = context.Canceled
 	} else if err != nil {
@@ -427,8 +427,8 @@ func (ec *ECRepairer) putPiece(ctx, parent context.Context, limit *pb.AddressedO
 
 		ec.log.Debug("Failed uploading piece to node",
 			zap.Binary("Segment", []byte(path)),
-			zap.String("PieceID", pieceID.String()),
-			zap.String("NodeID", storageNodeID.String()),
+			zap.Stringer("PieceID", pieceID),
+			zap.Stringer("NodeID", storageNodeID),
 			zap.String("Node Address", nodeAddress),
 			zap.Error(err),
 		)

--- a/satellite/repair/repairer/repairer.go
+++ b/satellite/repair/repairer/repairer.go
@@ -87,12 +87,12 @@ func (service *Service) process(ctx context.Context) (err error) {
 			}
 			return err
 		}
-		service.log.Info("Retrieved segment from repair queue", zap.Binary("segment", seg.GetPath()))
+		service.log.Info("Retrieved segment from repair queue", zap.Binary("Segment", seg.GetPath()))
 
 		service.Limiter.Go(ctx, func() {
 			err := service.worker(ctx, seg)
 			if err != nil {
-				service.log.Error("repair worker failed:", zap.Error(err))
+				service.log.Error("repair worker failed:", zap.Binary("Segment", seg.GetPath()), zap.Error(err))
 			}
 		})
 	}
@@ -103,17 +103,17 @@ func (service *Service) worker(ctx context.Context, seg *pb.InjuredSegment) (err
 
 	workerStartTime := time.Now().UTC()
 
-	service.log.Info("Limiter running repair on segment", zap.Binary("segment", seg.GetPath()))
+	service.log.Info("Limiter running repair on segment", zap.Binary("Segment", seg.GetPath()))
 	// note that shouldDelete is used even in the case where err is not null
 	shouldDelete, err := service.repairer.Repair(ctx, string(seg.GetPath()))
 	if shouldDelete {
 		if IrreparableError.Has(err) {
 			service.log.Error("deleting irreparable segment from the queue:",
 				zap.Error(service.queue.Delete(ctx, seg)),
-				zap.Binary("segment", seg.GetPath()),
+				zap.Binary("Segment", seg.GetPath()),
 			)
 		} else {
-			service.log.Info("deleting segment from repair queue", zap.Binary("segment", seg.GetPath()))
+			service.log.Info("deleting segment from repair queue", zap.Binary("Segment", seg.GetPath()))
 		}
 		delErr := service.queue.Delete(ctx, seg)
 		if delErr != nil {

--- a/satellite/repair/repairer/segments.go
+++ b/satellite/repair/repairer/segments.go
@@ -81,14 +81,14 @@ func (repairer *SegmentRepairer) Repair(ctx context.Context, path storj.Path) (s
 	if err != nil {
 		if storage.ErrKeyNotFound.Has(err) {
 			mon.Meter("repair_unnecessary").Mark(1)
-			repairer.log.Sugar().Debugf("segment %v was deleted", path)
+			repairer.log.Debug("segment was deleted", zap.Binary("Segment", []byte(path)))
 			return true, nil
 		}
 		return false, Error.Wrap(err)
 	}
 
 	if pointer.GetType() != pb.Pointer_REMOTE {
-		return true, Error.New("cannot repair inline segment %s", path)
+		return true, Error.New("cannot repair inline segment")
 	}
 
 	mon.Meter("repair_attempts").Mark(1)
@@ -115,7 +115,7 @@ func (repairer *SegmentRepairer) Repair(ctx context.Context, path storj.Path) (s
 	// irreparable piece
 	if int32(numHealthy) < pointer.Remote.Redundancy.MinReq {
 		mon.Meter("repair_nodes_unavailable").Mark(1)
-		return true, Error.Wrap(IrreparableError.New("segment %v cannot be repaired: only %d healthy pieces, %d required", path, numHealthy, pointer.Remote.Redundancy.MinReq+1))
+		return true, Error.Wrap(IrreparableError.New("segment cannot be repaired: only %d healthy pieces, %d required", numHealthy, pointer.Remote.Redundancy.MinReq+1))
 	}
 
 	repairThreshold := pointer.Remote.Redundancy.RepairThreshold
@@ -126,7 +126,7 @@ func (repairer *SegmentRepairer) Repair(ctx context.Context, path storj.Path) (s
 	// repair not needed
 	if int32(numHealthy) > repairThreshold {
 		mon.Meter("repair_unnecessary").Mark(1)
-		repairer.log.Sugar().Debugf("segment %v with %d pieces above repair threshold %d", path, numHealthy, repairThreshold)
+		repairer.log.Debug("segment above repair threshold", zap.Int("numHealthy", numHealthy), zap.Int32("repairThreshold", repairThreshold))
 		return true, nil
 	}
 
@@ -187,7 +187,7 @@ func (repairer *SegmentRepairer) Repair(ctx context.Context, path storj.Path) (s
 	}
 
 	// Download the segment using just the healthy pieces
-	segmentReader, failedPieces, err := repairer.ec.Get(ctx, getOrderLimits, getPrivateKey, redundancy, pointer.GetSegmentSize())
+	segmentReader, failedPieces, err := repairer.ec.Get(ctx, getOrderLimits, getPrivateKey, redundancy, pointer.GetSegmentSize(), path)
 
 	// Populate node IDs that failed piece hashes verification
 	var failedNodeIDs storj.NodeIDList


### PR DESCRIPTION
What: Improve the logging around failed repair.
```
satellite/0      12fbck97kq 01:36:35.511 | ERROR	repairer	repairer/repairer.go:95	repair worker failed:	{"Segment": "ZDY0Zjg1MDEtMjJkMC00YjI0LWI1YjItNmIyYzllZGIxOTRhL2wvcmVsZWFzZS1hbHBoYTE3LwI2ebiX+gjbGB9ZJFHU5/T0tgfN5zH9/f4B1GBDk9j9Vg==", "error": "repairer error: repairing injured segment: repairer error: couldn't download enough pieces, number of successful downloaded pieces (1) is less than required number (4)"
```

Why: At the moment the satellite prints out the encrypted path. It is hard to grep a logfile for the encrypted path. My hope is that with the new logging will allow us to grep, sort and count the binary value instead of the encrypted path. There is still one line that prints out the encrypted path so that we still have it if we need it.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
