### PR TITLE
Satellite/PieceHashValidation: Increase time window from 2h to 24h to avoid timezone issues

### DIFF
--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	pieceHashExpiration = 2 * time.Hour
+	pieceHashExpiration = 24 * time.Hour
 	satIDExpiration     = 24 * time.Hour
 	lastSegment         = -1
 	listLimit           = 1000

--- a/uplink/piecestore/verification.go
+++ b/uplink/piecestore/verification.go
@@ -15,7 +15,7 @@ import (
 	"storj.io/storj/pkg/signing"
 )
 
-const pieceHashExpiration = 2 * time.Hour
+const pieceHashExpiration = 24 * time.Hour
 
 var (
 	// ErrInternal is an error class for internal errors.


### PR DESCRIPTION
What: Increase the time window from 2h to 24h

Why: Because 930 storage nodes have problems to get the correct timezone. Most likely a docker issue. We should replace the timestamp with https://storjlabs.atlassian.net/browse/V3-2936 but while waiting on that fix I would like to cherry pick this workaround to buy us time.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
