### PR TITLE
storagenode/piecestore: Ignore broken pipe when the connection abruptly closes.

### DIFF
--- a/storagenode/piecestore/endpoint.go
+++ b/storagenode/piecestore/endpoint.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/zeebo/errs"
@@ -700,6 +701,10 @@ func min(a, b int64) int64 {
 func ignoreEOF(err error) error {
 	// gRPC gives us an io.EOF but dRPC gives us a wrapped io.EOF
 	if errs.Is(err, io.EOF) {
+		return nil
+	}
+	// Ignore if the client has already closed the connection.
+	if errs.Is(err, syscall.EPIPE) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
**What:** Ignores broken pipes caused when the connection is abruptly disconnected when we are already trying to close the connection anyways.

**Why:** The other party or network could abruptly close the connection while we are trying to send the close message.

Please describe the tests:
 - Test 1: This was caused from long tail cancellation during load testing.
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
