### PR TITLE
cmd/storj-sim: make postgres default to STORJ_SIM_POSTGRES

### DIFF
--- a/cmd/storj-sim/main.go
+++ b/cmd/storj-sim/main.go
@@ -57,7 +57,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(&printCommands, "print-commands", "x", false, "print commands as they are run")
 	rootCmd.PersistentFlags().BoolVarP(&flags.IsDev, "dev", "", false, "use configuration values tuned for development")
 
-	rootCmd.PersistentFlags().StringVarP(&flags.Postgres, "postgres", os.Getenv("STORJ_SIM_POSTGRES"), "", "connection string for postgres (defaults to STORJ_SIM_POSTGRES)")
+	rootCmd.PersistentFlags().StringVarP(&flags.Postgres, "postgres", "", os.Getenv("STORJ_SIM_POSTGRES"), "connection string for postgres (defaults to STORJ_SIM_POSTGRES)")
 
 	networkCmd := &cobra.Command{
 		Use:   "network",

--- a/cmd/storj-sim/main.go
+++ b/cmd/storj-sim/main.go
@@ -41,6 +41,7 @@ func main() {
 	}
 
 	defaultConfigDir := fpath.ApplicationDir("storj", "local-network")
+
 	configDir := defaultConfigDir
 	if os.Getenv("STORJ_NETWORK_DIR") != "" {
 		configDir = os.Getenv("STORJ_NETWORK_DIR")
@@ -56,7 +57,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(&printCommands, "print-commands", "x", false, "print commands as they are run")
 	rootCmd.PersistentFlags().BoolVarP(&flags.IsDev, "dev", "", false, "use configuration values tuned for development")
 
-	rootCmd.PersistentFlags().StringVarP(&flags.Postgres, "postgres", "", "", "connection string for postgres. If provided, storj-sim will use postgres for all databases that support it.")
+	rootCmd.PersistentFlags().StringVarP(&flags.Postgres, "postgres", os.Getenv("STORJ_SIM_POSTGRES"), "", "connection string for postgres (defaults to STORJ_SIM_POSTGRES)")
 
 	networkCmd := &cobra.Command{
 		Use:   "network",


### PR DESCRIPTION
What: Make storj-sim to read `STORJ_SIM_POSTGRES` environment variable, which makes it easier to setup defaults handling.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
