### PR TITLE
satellite/satellitedb: switch to postgres only

### DIFF
--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -30,7 +30,7 @@ import (
 
 // Satellite defines satellite configuration
 type Satellite struct {
-	Database string `help:"satellite database connection string" releaseDefault:"postgres://" devDefault:"sqlite3://$CONFDIR/master.db"`
+	Database string `help:"satellite database connection string" releaseDefault:"postgres://" devDefault:"postgres://"`
 
 	satellite.Config
 }
@@ -84,15 +84,15 @@ var (
 	setupCfg Satellite
 
 	qdiagCfg struct {
-		Database   string `help:"satellite database connection string" releaseDefault:"postgres://" devDefault:"sqlite3://$CONFDIR/master.db"`
+		Database   string `help:"satellite database connection string" releaseDefault:"postgres://" devDefault:"postgres://"`
 		QListLimit int    `help:"maximum segments that can be requested" default:"1000"`
 	}
 	nodeUsageCfg struct {
-		Database string `help:"satellite database connection string" releaseDefault:"postgres://" devDefault:"sqlite3://$CONFDIR/master.db"`
+		Database string `help:"satellite database connection string" releaseDefault:"postgres://" devDefault:"postgres://"`
 		Output   string `help:"destination of report output" default:""`
 	}
 	partnerAttribtionCfg struct {
-		Database string `help:"satellite database connection string" releaseDefault:"postgres://" devDefault:"sqlite3://$CONFDIR/master.db"`
+		Database string `help:"satellite database connection string" releaseDefault:"postgres://" devDefault:"postgres://"`
 		Output   string `help:"destination of report output" default:""`
 	}
 	confDir     string

--- a/internal/testplanet/satellite.go
+++ b/internal/testplanet/satellite.go
@@ -48,7 +48,7 @@ import (
 	"storj.io/storj/satellite/repair/checker"
 	"storj.io/storj/satellite/repair/irreparable"
 	"storj.io/storj/satellite/repair/repairer"
-	"storj.io/storj/satellite/satellitedb"
+	"storj.io/storj/satellite/satellitedb/satellitedbtest"
 	"storj.io/storj/satellite/vouchers"
 )
 
@@ -220,7 +220,8 @@ func (planet *Planet) newSatellites(count int) ([]*SatelliteSystem, error) {
 		if planet.config.Reconfigure.NewSatelliteDB != nil {
 			db, err = planet.config.Reconfigure.NewSatelliteDB(log.Named("db"), i)
 		} else {
-			db, err = satellitedb.NewInMemory(log.Named("db"))
+			schema := satellitedbtest.SchemaName(planet.id, "S", i, "")
+			db, err = satellitedbtest.NewPostgres(log.Named("db"), schema)
 		}
 		if err != nil {
 			return nil, err

--- a/satellite/metainfo/metainfo_test.go
+++ b/satellite/metainfo/metainfo_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/zeebo/errs"
 	"go.uber.org/zap"
 
 	"storj.io/storj/internal/errs2"
@@ -351,8 +350,7 @@ func TestCommitSegment(t *testing.T) {
 			}
 			_, err = metainfo.CommitSegment(ctx, "bucket", "path", -1, pointer, limits)
 			require.Error(t, err)
-			err = errs.Unwrap(err)
-			require.Equal(t, rpcstatus.Code(err), rpcstatus.InvalidArgument)
+			require.True(t, errs2.IsRPC(err, rpcstatus.InvalidArgument))
 			require.Contains(t, err.Error(), "is less than or equal to the repair threshold")
 		}
 

--- a/satellite/satellitedb/satellitedbtest/pgschema.go
+++ b/satellite/satellitedb/satellitedbtest/pgschema.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package satellitedbtest
+
+import (
+	"github.com/zeebo/errs"
+	"go.uber.org/zap"
+
+	"storj.io/storj/internal/dbutil/pgutil"
+	"storj.io/storj/internal/dbutil/pgutil/pgtest"
+	"storj.io/storj/satellite"
+	"storj.io/storj/satellite/satellitedb"
+	dbx "storj.io/storj/satellite/satellitedb/dbx"
+)
+
+// NewPostgres returns the default postgres satellite.DB for testing.
+func NewPostgres(log *zap.Logger, schema string) (satellite.DB, error) {
+	db, err := satellitedb.New(log, pgutil.ConnstrWithSchema(*pgtest.ConnStr, schema))
+	if err != nil {
+		return nil, err
+	}
+
+	return &SchemaDB{
+		DB:       db,
+		Schema:   schema,
+		AutoDrop: true,
+	}, nil
+}
+
+// SchemaDB implements automatic schema handling for satellite.DB
+type SchemaDB struct {
+	satellite.DB
+
+	Schema   string
+	AutoDrop bool
+}
+
+// TestDBAccess for raw database access,
+// should not be used outside of migration tests.
+func (db *SchemaDB) TestDBAccess() *dbx.DB {
+	return db.DB.(interface{ TestDBAccess() *dbx.DB }).TestDBAccess()
+}
+
+// CreateTables creates the schema and creates tables.
+func (db *SchemaDB) CreateTables() error {
+	err := db.DB.CreateSchema(db.Schema)
+	if err != nil {
+		return err
+	}
+
+	return db.DB.CreateTables()
+}
+
+// Close closes the database and drops the schema, when `AutoDrop` is set.
+func (db *SchemaDB) Close() error {
+	var dropErr error
+	if db.AutoDrop {
+		dropErr = db.DB.DropSchema(db.Schema)
+	}
+
+	return errs.Combine(dropErr, db.DB.Close())
+}


### PR DESCRIPTION
Changes to switch to using only Postgres in tests. There are multiple changes to allow `testplanet` to connect to the default database defined by `STORJ_POSTGRES_TEST`.

This only changes the default behavior to run against postgres. The follow-up https://github.com/storj/storj/pull/3296 will remove the dead sqlite code.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
