### PR TITLE
gomobile Reader.Read should take offset and length params

### DIFF
--- a/lib/uplink-gomobile/bucket.go
+++ b/lib/uplink-gomobile/bucket.go
@@ -329,12 +329,12 @@ func (bucket *Bucket) NewReader(path storj.Path, options *ReaderOptions) (*Reade
 }
 
 // Read reads data into byte array
-func (r *Reader) Read(data []byte, off, len int) (n int32, err error) {
+func (r *Reader) Read(data []byte, offset, length int32) (n int32, err error) {
 	if r.readError != nil {
 		err = r.readError
 	} else {
 		var read int
-		read, err = r.reader.Read(data[off : off+len])
+		read, err = r.reader.Read(data[offset : offset+length])
 		n = int32(read)
 	}
 

--- a/lib/uplink-gomobile/bucket.go
+++ b/lib/uplink-gomobile/bucket.go
@@ -329,12 +329,12 @@ func (bucket *Bucket) NewReader(path storj.Path, options *ReaderOptions) (*Reade
 }
 
 // Read reads data into byte array
-func (r *Reader) Read(data []byte) (n int32, err error) {
+func (r *Reader) Read(data []byte, off, len int) (n int32, err error) {
 	if r.readError != nil {
 		err = r.readError
 	} else {
 		var read int
-		read, err = r.reader.Read(data)
+		read, err = r.reader.Read(data[off : off+len])
 		n = int32(read)
 	}
 

--- a/lib/uplink-gomobile/bucket.go
+++ b/lib/uplink-gomobile/bucket.go
@@ -288,7 +288,7 @@ func (bucket *Bucket) NewWriter(path storj.Path, options *WriterOptions) (*Write
 // Write writes data.length bytes from data to the underlying data stream.
 func (w *Writer) Write(data []byte, offset, length int32) (int32, error) {
 	// in Java byte array size is max int32
-	n, err := w.writer.Write(data[offset:length])
+	n, err := w.writer.Write(data[offset : offset+length])
 	return int32(n), safeError(err)
 }
 

--- a/lib/uplink-gomobile/libuplink_android/app/src/androidTest/java/io/storj/mobile/libuplink/LibuplinkInstrumentedTest.java
+++ b/lib/uplink-gomobile/libuplink_android/app/src/androidTest/java/io/storj/mobile/libuplink/LibuplinkInstrumentedTest.java
@@ -187,7 +187,7 @@ public class LibuplinkInstrumentedTest {
                         ByteArrayOutputStream writer = new ByteArrayOutputStream();
                         byte[] buf = new byte[256];
                         int read = 0;
-                        while ((read = reader.read(buf)) != -1) {
+                        while ((read = reader.read(buf, 0, buf.length)) != -1) {
                             writer.write(buf, 0, read);
                         }
                         assertArrayEquals(writer.toByteArray(), expectedData);
@@ -251,7 +251,7 @@ public class LibuplinkInstrumentedTest {
                         ByteArrayOutputStream writer = new ByteArrayOutputStream();
                         byte[] buf = new byte[4096];
                         int read = 0;
-                        while ((read = reader.read(buf)) != -1) {
+                        while ((read = reader.read(buf, 0, buf.length)) != -1) {
                             writer.write(buf, 0, read);
                         }
                         assertEquals(expectedData.length, writer.size());


### PR DESCRIPTION
What: `Reader.Read` in gomobile accepts `offset` and `length` params. 

In addition, this PR fixes a bug in the usage of `length` in `Writer.Write` method.

Why: This allows more optimal usage from Java code. Java does not have slices like in Golang, but achieves the same on byte arrays with the usage of offset and length.

Please describe the tests:
 - Existing tests adapted
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
