### PR TITLE
Unhook jenkins from the staging (dev) cluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ node('node') {
     }
 
     stage('Build Windows Installer') {
-      node('windows') { 
+      node('windows') {
         checkout scm
 
         unstash "storagenode-binaries"
@@ -49,14 +49,6 @@ node('node') {
       echo 'Push to Repo'
       sh 'make push-images'
       echo "Current build result: ${currentBuild.result}"
-    }
-
-    if (env.BRANCH_NAME == "master") {
-      /* This should only deploy to staging if the branch is master */
-      stage('Deploy to staging') {
-        sh 'make deploy'
-        echo "Current build result: ${currentBuild.result}"
-      }
     }
 
     stage('Upload') {

--- a/Makefile
+++ b/Makefile
@@ -320,13 +320,6 @@ libuplink-gomobile:
 
 ##@ Deploy
 
-.PHONY: deploy
-deploy: ## Update Kubernetes deployments in staging (jenkins)
-	for deployment in $$(kubectl --context nonprod -n v3 get deployment -l app=storagenode --output=jsonpath='{.items..metadata.name}'); do \
-		kubectl --context nonprod --namespace v3 patch deployment $$deployment -p"{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"storagenode\",\"image\":\"storjlabs/storagenode:${TAG}\"}]}}}}" ; \
-	done
-	kubectl --context nonprod --namespace v3 patch deployment earth-satellite -p"{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"satellite\",\"image\":\"storjlabs/satellite:${TAG}\"}]}}}}"
-
 .PHONY: push-images
 push-images: ## Push Docker images to Docker Hub (jenkins)
 	# images have to be pushed before a manifest can be created


### PR DESCRIPTION
What: Unhook jenkins from the dev cluster

Why: The dev cluster is undergoing renovations. Jenkins should fail
master builds while this is happening.

Please describe the tests:
- No tests, just removing unused code.

Please describe the performance impact:
- The whole build pipeline is slightly faster!

## Code Review Checklist (to be filled out by reviewer)
 - [X] Does the PR describe what changes are being made?
 - [X] Does the PR describe why the changes are being made?
 - [X] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [X] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [X] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [X] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [X] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [X] Does any documentation need updating?
 - [X] Do the database access patterns make sense?