### PR TITLE
Makefile: handle empty/default $GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 GO_VERSION ?= 1.13.3
 GOOS ?= linux
 GOARCH ?= amd64
+GOPATH ?= $(shell go env GOPATH)
 COMPOSE_PROJECT_NAME := ${TAG}-$(shell git rev-parse --abbrev-ref HEAD)
 BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD | sed "s!/!-!g")
 ifeq (${BRANCH_NAME},master)
@@ -372,7 +373,7 @@ diagrams-graphml:
 update-satellite-config-lock: ## Update the satellite config lock file
 	@docker run -ti --rm \
 		-v ${GOPATH}/pkg/mod:/go/pkg/mod \
-		-v $(shell pwd):/storj \
+		-v ${CURDIR}:/storj \
 		-v $(shell go env GOCACHE):/go-cache \
 		-e "GOCACHE=/go-cache" \
 		-u root:root \


### PR DESCRIPTION
What: 

Change Makefile so that things still work when one has no `$GOPATH` environment variable, because that's what I have.

Also, use `$(CURDIR)` in place of `$(shell pwd)`.

Why:

- Because I have no `$GOPATH` environment variable here. The default works for me, and (I suspect) other people too

- The change to `$(CURDIR)` saves a fork+exec, is more readable, and is more idiomatic. The only case where it should have different value from `$(shell pwd)` is when someone's configured `$SHELL` is badly broken, and I'd argue that even then `$(CURDIR)` is preferable.

Please describe the tests:
- automated tests and checks already exercise Makefile to some degree; additional behavior had to be tested manually
 
Please describe the performance impact:
- minimal

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
