### PR TITLE
storagenode/pieces: just a tiny comment update

### DIFF
--- a/storagenode/pieces/store.go
+++ b/storagenode/pieces/store.go
@@ -349,9 +349,6 @@ func (store *Store) DeleteFailed(ctx context.Context, expired ExpiredInfo, when 
 //
 // Important note: this metric does not include space used by piece headers, whereas
 // storj/filestore/store.(*Store).SpaceUsed() *does* include all space used by the blobs.
-//
-// The value of reservedSpace for this Store is added to the result, but this should only affect
-// tests (reservedSpace should always be 0 in real usage).
 func (store *Store) SpaceUsedForPieces(ctx context.Context) (int64, error) {
 	if cache, ok := store.blobs.(*BlobsUsageCache); ok {
 		return cache.SpaceUsedForPieces(ctx)


### PR DESCRIPTION
What:

Remove part of a comment that is no longer correct. The reservedSpace member it's talking about was removed in 022f5d2e.

Why:

Confusion avoidance

Please describe the tests:
 - I have probably not sufficiently tested that changes to comments do not affect correctness
 
Please describe the performance impact:
- none

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
