### PR TITLE
satellite/metainfo: add unique nodeid check when update pointer in metainfo

### DIFF
--- a/satellite/metainfo/service.go
+++ b/satellite/metainfo/service.go
@@ -98,8 +98,10 @@ func (s *Service) UpdatePieces(ctx context.Context, path string, ref *pb.Pointer
 				continue
 			}
 			existing := pieceMap[piece.PieceNum]
-			if existing != nil && existing.NodeId == piece.NodeId {
+			_, ok := uniqueNodeMap[piece.NodeId]
+			if existing != nil && existing.NodeId == piece.NodeId && ok {
 				delete(pieceMap, piece.PieceNum)
+				delete(uniqueNodeMap, piece.NodeId)
 			}
 		}
 
@@ -117,6 +119,7 @@ func (s *Service) UpdatePieces(ctx context.Context, path string, ref *pb.Pointer
 				return nil, ErrDuplicatedNodeID.New("piece num: %d, node id: %s", piece.PieceNum, piece.NodeId.String())
 			}
 			pieceMap[piece.PieceNum] = piece
+			uniqueNodeMap[piece.NodeId] = struct{}{}
 		}
 
 		// copy the pieces from the map back to the pointer

--- a/satellite/metainfo/service.go
+++ b/satellite/metainfo/service.go
@@ -81,8 +81,10 @@ func (s *Service) UpdatePieces(ctx context.Context, path string, ref *pb.Pointer
 
 		// put all existing pieces to a map
 		pieceMap := make(map[int32]*pb.RemotePiece)
+		uniqueNodeMap := make(map[storj.NodeID]struct{})
 		for _, piece := range pointer.GetRemote().GetRemotePieces() {
 			pieceMap[piece.PieceNum] = piece
+			uniqueNodeMap[piece.NodeId] = struct{}{}
 		}
 
 		// remove the toRemove pieces from the map
@@ -105,6 +107,10 @@ func (s *Service) UpdatePieces(ctx context.Context, path string, ref *pb.Pointer
 			_, exists := pieceMap[piece.PieceNum]
 			if exists {
 				return nil, Error.New("piece to add already exists (piece no: %d)", piece.PieceNum)
+			}
+			_, exists = uniqueNodeMap[piece.NodeId]
+			if exists {
+				return nil, Error.New("node already exits for the piece to add (piece no: %d, node id: %s)", piece.PieceNum, piece.NodeId.String())
 			}
 			pieceMap[piece.PieceNum] = piece
 		}

--- a/satellite/metainfo/service.go
+++ b/satellite/metainfo/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/skyrings/skyring-common/tools/uuid"
+	"github.com/zeebo/errs"
 	"go.uber.org/zap"
 
 	"storj.io/storj/pkg/macaroon"
@@ -17,6 +18,9 @@ import (
 	"storj.io/storj/storage"
 	"storj.io/storj/uplink/storage/meta"
 )
+
+// ErrDuplicatedNodeID  is an error class for having duplicated node IDs in a pointer.
+var ErrDuplicatedNodeID = errs.Class("node id already exits in the piece to add")
 
 // Service structure
 //
@@ -110,7 +114,7 @@ func (s *Service) UpdatePieces(ctx context.Context, path string, ref *pb.Pointer
 			}
 			_, exists = uniqueNodeMap[piece.NodeId]
 			if exists {
-				return nil, Error.New("node already exits for the piece to add (piece no: %d, node id: %s)", piece.PieceNum, piece.NodeId.String())
+				return nil, ErrDuplicatedNodeID.New("piece num: %d, node id: %s", piece.PieceNum, piece.NodeId.String())
 			}
 			pieceMap[piece.PieceNum] = piece
 		}

--- a/satellite/metainfo/service_test.go
+++ b/satellite/metainfo/service_test.go
@@ -107,7 +107,7 @@ func TestUpdatePiecesDuplicateNodeID(t *testing.T) {
 
 // getRemoteSegment returns a remote pointer its path from satellite.
 func getRemoteSegment(
-	t *testing.T, ctx context.Context, satellite *testplanet.SatelliteSystem,
+	ctx context.Context, t *testing.T, satellite *testplanet.SatelliteSystem,
 ) (_ *pb.Pointer, path string) {
 	t.Helper()
 

--- a/satellite/metainfo/service_test.go
+++ b/satellite/metainfo/service_test.go
@@ -74,7 +74,7 @@ func TestUpdatePiecesDuplicateNodeID(t *testing.T) {
 		err = uplinkPeer.Upload(ctx, saPeer, "test1", "test/path", expectedData)
 		require.NoError(t, err)
 
-		pointer, path := getRemoteSegment(t, ctx, saPeer)
+		pointer, path := getRemoteSegment(ctx, t, saPeer)
 
 		duplicatedNodeID := storj.NodeID{}
 		pieceToRemove := make([]*pb.RemotePiece, 1)


### PR DESCRIPTION
What: 
- add unique node ID check when update pointer
Why:
- we need to make sure that no node is storing multiple piece for the same segment

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
