### PR TITLE
storagenode/gracefulexit: use custom type for satellite GE client instead of grpc-specific one

### DIFF
--- a/storagenode/gracefulexit/worker.go
+++ b/storagenode/gracefulexit/worker.go
@@ -122,12 +122,12 @@ func (worker *Worker) Run(ctx context.Context, done func()) (err error) {
 	return errs.Wrap(err)
 }
 
-type SatelliteGracefulExit_ProcessClient interface {
+type SatelliteGracefulExitProcessClient interface {
 	Send(*pb.StorageNodeMessage) error
 	Recv() (*pb.SatelliteMessage, error)
 }
 
-func (worker *Worker) transferPiece(ctx context.Context, transferPiece *pb.TransferPiece, c SatelliteGracefulExit_ProcessClient) error {
+func (worker *Worker) transferPiece(ctx context.Context, transferPiece *pb.TransferPiece, c SatelliteGracefulExitProcessClient) error {
 	pieceID := transferPiece.OriginalPieceId
 	reader, err := worker.store.Reader(ctx, worker.satelliteID, pieceID)
 	if err != nil {

--- a/storagenode/gracefulexit/worker.go
+++ b/storagenode/gracefulexit/worker.go
@@ -122,7 +122,12 @@ func (worker *Worker) Run(ctx context.Context, done func()) (err error) {
 	return errs.Wrap(err)
 }
 
-func (worker *Worker) transferPiece(ctx context.Context, transferPiece *pb.TransferPiece, c pb.SatelliteGracefulExit_ProcessClient) error {
+type SatelliteGracefulExit_ProcessClient interface {
+	Send(*pb.StorageNodeMessage) error
+	Recv() (*pb.SatelliteMessage, error)
+}
+
+func (worker *Worker) transferPiece(ctx context.Context, transferPiece *pb.TransferPiece, c SatelliteGracefulExit_ProcessClient) error {
 	pieceID := transferPiece.OriginalPieceId
 	reader, err := worker.store.Reader(ctx, worker.satelliteID, pieceID)
 	if err != nil {


### PR DESCRIPTION
What: 
In the storagenode graceful exit worker, there is a function called `transferPiece` that takes a grpc client as an argument. This causes flaky build failures since the grpc client has a slightly different interface than the drpc client.
This PR defines a custom type with only `Send()` and `Recv()` methods that is used as a substitute for both types of clients.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
