### PR TITLE
gracefulexit: fix build for drpc

### DIFF
--- a/storagenode/gracefulexit/worker.go
+++ b/storagenode/gracefulexit/worker.go
@@ -122,7 +122,13 @@ func (worker *Worker) Run(ctx context.Context, done func()) (err error) {
 	return errs.Wrap(err)
 }
 
-func (worker *Worker) transferPiece(ctx context.Context, transferPiece *pb.TransferPiece, c pb.SatelliteGracefulExit_ProcessClient) error {
+type gracefulExitStream interface {
+	Context() context.Context
+	Send(*pb.StorageNodeMessage) error
+	Recv() (*pb.SatelliteMessage, error)
+}
+
+func (worker *Worker) transferPiece(ctx context.Context, transferPiece *pb.TransferPiece, c gracefulExitStream) error {
 	pieceID := transferPiece.OriginalPieceId
 	reader, err := worker.store.Reader(ctx, worker.satelliteID, pieceID)
 	if err != nil {


### PR DESCRIPTION
What: Fix the drpc build of the graceful exit package

Why: Somehow #3371 was merged even though it no longer compiled under `-tags=drpc`.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
