### PR TITLE
satellite/gracefulexit: handle context cancelled in satellite graceful exit endpoint

### DIFF
--- a/satellite/gracefulexit/endpoint.go
+++ b/satellite/gracefulexit/endpoint.go
@@ -235,6 +235,13 @@ func (endpoint *Endpoint) doProcess(stream processStream) (err error) {
 		}()
 
 		for range ticker.C {
+			// exit if context canceled
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
 			if pending.length() == 0 {
 				incomplete, err := endpoint.db.GetIncompleteNotFailed(ctx, nodeID, endpoint.config.EndpointBatchSize, 0)
 				if err != nil {
@@ -279,6 +286,8 @@ func (endpoint *Endpoint) doProcess(stream processStream) (err error) {
 		if pendingCount == 0 {
 			select {
 			case <-processChan:
+			case <-ctx.Done():
+				return ctx.Err()
 			}
 		}
 


### PR DESCRIPTION
What: 
There are some parts of the graceful exit satellite endpoint where we block and do not handle canceled contexts. This PR fixes that.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
