### PR TITLE
Rename --log-path back to --log for storagenode-updater

### DIFF
--- a/cmd/storagenode-updater/main.go
+++ b/cmd/storagenode-updater/main.go
@@ -60,7 +60,7 @@ var (
 
 		BinaryLocation string `help:"the storage node executable binary location" default:"storagenode.exe"`
 		ServiceName    string `help:"storage node OS service name" default:"storagenode"`
-		LogPath        string `help:"path to log file, if empty standard output will be used" default:""`
+		Log            string `help:"path to log file, if empty standard output will be used" default:""`
 	}
 
 	confDir     string
@@ -81,8 +81,8 @@ func init() {
 }
 
 func cmdRun(cmd *cobra.Command, args []string) (err error) {
-	if runCfg.LogPath != "" {
-		logFile, err := os.OpenFile(runCfg.LogPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if runCfg.Log != "" {
+		logFile, err := os.OpenFile(runCfg.Log, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 		if err != nil {
 			log.Fatalf("error opening log file: %s", err)
 		}

--- a/installer/windows/Product.wxs
+++ b/installer/windows/Product.wxs
@@ -57,7 +57,7 @@
           Account="[SERVICEACCOUNT]"
           Password="[SERVICEPASSWORD]"
           ErrorControl="normal"
-          Arguments="run --config-dir &quot;[INSTALLFOLDER]\&quot; --identity-dir &quot;[IDENTITYDIR]\&quot; --binary-location &quot;[INSTALLFOLDER]\storagenode.exe&quot; --log-path &quot;[INSTALLFOLDER]\storagenode-updater.log&quot;"
+          Arguments="run --config-dir &quot;[INSTALLFOLDER]\&quot; --identity-dir &quot;[IDENTITYDIR]\&quot; --binary-location &quot;[INSTALLFOLDER]\storagenode.exe&quot; --log &quot;[INSTALLFOLDER]\storagenode-updater.log&quot;"
           />
         <ServiceControl Id="StoragenodeUpdaterStartService" Start="install" Stop="both" Remove="uninstall" Name="storagenode-updater" Wait="yes" />
       </Component>


### PR DESCRIPTION
What: Renames the `--log-path` argument of storagenode-updater back to `--log`.

Why: We need to keep config args consistent between release to avoid issues with upgrade. The rename from `--log` to `--log-path` was introduced with #3276. It is already planned to rename it back to `--log` with #3338. But we want this change to happen in this separate PR, so it can be included in the next 0.24.x release for storagenodes.

Please describe the tests: N/A
 
Please describe the performance impact: None

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
