### PR TITLE
cmd/storagenode-updater: add "...up to date" log line if shoudn't update

### DIFF
--- a/cmd/storagenode-updater/main.go
+++ b/cmd/storagenode-updater/main.go
@@ -212,6 +212,8 @@ func update(ctx context.Context, nodeID storj.NodeID) (err error) {
 		} else {
 			log.Printf("%s version is up to date\n", runCfg.ServiceName)
 		}
+	} else {
+		log.Printf("%s version is up to date\n", runCfg.ServiceName)
 	}
 
 	return nil

--- a/cmd/storagenode-updater/main.go
+++ b/cmd/storagenode-updater/main.go
@@ -209,13 +209,11 @@ func update(ctx context.Context, nodeID storj.NodeID) (err error) {
 			log.Println("service", runCfg.ServiceName, "restarted successfully")
 
 			// TODO remove old binary ??
-		} else {
-			log.Printf("%s version is up to date\n", runCfg.ServiceName)
+			return nil
 		}
-	} else {
-		log.Printf("%s version is up to date\n", runCfg.ServiceName)
 	}
 
+	log.Printf("%s version is up to date\n", runCfg.ServiceName)
 	return nil
 }
 


### PR DESCRIPTION
What: Print "... version is up to date" message to storagenode-updater log if rollout status determines that it shouldn't update.

Why: In the case where the rollout does not apply, this log message was missing.

Please describe the tests: N/A

Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
