### PR TITLE
internal/sync2: make Fence accept context

### DIFF
--- a/cmd/storj-sim/network.go
+++ b/cmd/storj-sim/network.go
@@ -146,7 +146,10 @@ func networkTest(flags *Flags, command string, args []string) error {
 	processes.Start(ctx, &group, "run")
 
 	for _, process := range processes.List {
-		process.Status.Started.Wait()
+		process.Status.Started.Wait(ctx)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	cmd := exec.CommandContext(ctx, command, args...)

--- a/cmd/storj-sim/process.go
+++ b/cmd/storj-sim/process.go
@@ -176,7 +176,9 @@ func (process *Process) Exec(ctx context.Context, command string) (err error) {
 
 	// wait for dependencies to start
 	for _, fence := range process.Wait {
-		fence.Wait()
+		if !fence.Wait(ctx) {
+			return ctx.Err()
+		}
 	}
 
 	// in case we have an explicit delay then sleep

--- a/internal/sync2/fence_test.go
+++ b/internal/sync2/fence_test.go
@@ -4,6 +4,7 @@
 package sync2_test
 
 import (
+	"context"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -12,10 +13,14 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"storj.io/storj/internal/sync2"
+	"storj.io/storj/internal/testcontext"
 )
 
 func TestFence(t *testing.T) {
 	t.Parallel()
+
+	ctx := testcontext.NewWithTimeout(t, 30*time.Second)
+	defer ctx.Cleanup()
 
 	var group errgroup.Group
 	var fence sync2.Fence
@@ -23,7 +28,9 @@ func TestFence(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		group.Go(func() error {
-			fence.Wait()
+			if !fence.Wait(ctx) {
+				return errors.New("got false from Wait")
+			}
 			if atomic.LoadInt32(&done) == 0 {
 				return errors.New("fence not yet released")
 			}
@@ -41,6 +48,36 @@ func TestFence(t *testing.T) {
 			return nil
 		})
 	}
+
+	if err := group.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFence_ContextCancel(t *testing.T) {
+	t.Parallel()
+
+	tctx := testcontext.NewWithTimeout(t, 30*time.Second)
+	defer tctx.Cleanup()
+
+	ctx, cancel := context.WithCancel(tctx)
+
+	var group errgroup.Group
+	var fence sync2.Fence
+
+	for i := 0; i < 10; i++ {
+		group.Go(func() error {
+			if fence.Wait(ctx) {
+				return errors.New("got true from Wait")
+			}
+			return nil
+		})
+	}
+
+	// wait a bit for all goroutines to hit the fence
+	time.Sleep(100 * time.Millisecond)
+
+	cancel()
 
 	if err := group.Wait(); err != nil {
 		t.Fatal(err)

--- a/internal/version/checker/service.go
+++ b/internal/version/checker/service.go
@@ -85,8 +85,10 @@ func (srv *Service) Run(ctx context.Context) (err error) {
 }
 
 // IsAllowed returns whether if the Service is allowed to operate or not
-func (srv *Service) IsAllowed() bool {
-	srv.checked.Wait()
+func (srv *Service) IsAllowed(ctx context.Context) bool {
+	if !srv.checked.Wait(ctx) {
+		return false
+	}
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 	return srv.allowed

--- a/storagenode/console/service.go
+++ b/storagenode/console/service.go
@@ -133,7 +133,7 @@ func (s *Service) GetDashboardData(ctx context.Context) (_ *Dashboard, err error
 	data.NodeID = s.contact.Local().Id
 	data.Wallet = s.walletAddress
 	data.Version = s.versionInfo.Version
-	data.UpToDate = s.version.IsAllowed()
+	data.UpToDate = s.version.IsAllowed(ctx)
 	data.StartedAt = s.startedAt
 
 	data.LastPinged = s.pingStats.WhenLastPinged()

--- a/storagenode/contact/chore.go
+++ b/storagenode/contact/chore.go
@@ -48,8 +48,8 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 	defer mon.Task()(&ctx)(&err)
 	chore.log.Info("Storagenode contact chore starting up")
 
-	if err = chore.service.waitForSelfData(ctx); err != nil {
-		return err
+	if !chore.service.initialized.Wait(ctx) {
+		return ctx.Err()
 	}
 
 	return chore.Loop.Run(ctx, func(ctx context.Context) error {

--- a/storagenode/contact/contact_test.go
+++ b/storagenode/contact/contact_test.go
@@ -5,6 +5,7 @@ package contact_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -30,6 +31,8 @@ func TestStoragenodeContactEndpoint(t *testing.T) {
 		require.NoError(t, err)
 
 		firstPing := pingStats.WhenLastPinged()
+
+		time.Sleep(time.Second) //HACKFIX: windows has large time granularity
 
 		resp, err = conn.ContactClient().PingNode(ctx, &pb.ContactPingRequest{})
 		require.NotNil(t, resp)


### PR DESCRIPTION
What: Currently there wasn't a way to use `sync2.Fence` such that it waits for context to be completed. Ensure that it can detect context closing. Also update `storagenode/contact` to use `sync2.Fence`.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
