### PR TITLE
cmd/storj-sim: use less ports

### DIFF
--- a/cmd/storj-sim/network.go
+++ b/cmd/storj-sim/network.go
@@ -51,7 +51,6 @@ const (
 	gatewayPeer        = 1
 	versioncontrolPeer = 2
 	storagenodePeer    = 3
-	repairPeer         = 5
 
 	// Endpoint
 	publicGRPC  = 0
@@ -59,6 +58,8 @@ const (
 	publicHTTP  = 2
 	privateHTTP = 3
 	debugHTTP   = 9
+	// satellite specific constants
+	debugRepairerHTTP = 8
 )
 
 // port creates a port with a consistent format for storj-sim services.
@@ -313,7 +314,7 @@ func newNetwork(flags *Flags) (*Processes, error) {
 		process.Arguments = withCommon(process.Directory, Arguments{
 			"run": {
 				"repair",
-				"--debug.addr", net.JoinHostPort(host, port(repairPeer, i, debugHTTP)),
+				"--debug.addr", net.JoinHostPort(host, port(satellitePeer, i, debugRepairerHTTP)),
 			},
 		})
 


### PR DESCRIPTION
What: Use smaller port range for storj-sim.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
