### PR TITLE
{satellite,storagenode}/gracefulexit: clearer log messages

### DIFF
--- a/satellite/gracefulexit/chore.go
+++ b/satellite/gracefulexit/chore.go
@@ -46,7 +46,7 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 	defer mon.Task()(&ctx)(&err)
 	return chore.Loop.Run(ctx, func(ctx context.Context) (err error) {
 		defer mon.Task()(&ctx)(&err)
-		chore.log.Debug("checking pending graceful exits")
+		chore.log.Debug("checking pending exits")
 
 		exitingNodes, err := chore.overlay.GetExitingNodes(ctx)
 		if err != nil {

--- a/satellite/gracefulexit/chore.go
+++ b/satellite/gracefulexit/chore.go
@@ -46,8 +46,7 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 	defer mon.Task()(&ctx)(&err)
 	return chore.Loop.Run(ctx, func(ctx context.Context) (err error) {
 		defer mon.Task()(&ctx)(&err)
-
-		chore.log.Info("running graceful exit chore.")
+		chore.log.Debug("checking pending graceful exits")
 
 		exitingNodes, err := chore.overlay.GetExitingNodes(ctx)
 		if err != nil {
@@ -56,7 +55,7 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 		}
 
 		nodeCount := len(exitingNodes)
-		chore.log.Debug("graceful exit.", zap.Int("exitingNodes", nodeCount))
+		chore.log.Debug("graceful exit", zap.Int("exitingNodes", nodeCount))
 		if nodeCount == 0 {
 			return nil
 		}

--- a/storagenode/gracefulexit/chore.go
+++ b/storagenode/gracefulexit/chore.go
@@ -63,8 +63,7 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 
 	err = chore.Loop.Run(ctx, func(ctx context.Context) (err error) {
 		defer mon.Task()(&ctx)(&err)
-
-		chore.log.Info("running graceful exit chore.")
+		chore.log.Debug("checking pending graceful exits")
 
 		satellites, err := chore.satelliteDB.ListGracefulExits(ctx)
 		if err != nil {
@@ -73,7 +72,7 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 		}
 
 		if len(satellites) == 0 {
-			chore.log.Debug("no satellites found.")
+			chore.log.Debug("no satellites found")
 			return nil
 		}
 

--- a/storagenode/gracefulexit/chore.go
+++ b/storagenode/gracefulexit/chore.go
@@ -63,7 +63,7 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 
 	err = chore.Loop.Run(ctx, func(ctx context.Context) (err error) {
 		defer mon.Task()(&ctx)(&err)
-		chore.log.Debug("checking pending graceful exits")
+		chore.log.Debug("checking pending exits")
 
 		satellites, err := chore.satelliteDB.ListGracefulExits(ctx)
 		if err != nil {
@@ -90,17 +90,17 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 			worker := NewWorker(chore.log, chore.store, chore.satelliteDB, chore.dialer, satelliteID, addr)
 			if _, ok := chore.exitingMap.LoadOrStore(satelliteID, worker); ok {
 				// already running a worker for this satellite
-				chore.log.Debug("skipping graceful exit for satellite. worker already exists.", zap.Stringer("satellite ID", satelliteID))
+				chore.log.Debug("skipping for satellite, worker already exists.", zap.Stringer("satellite ID", satelliteID))
 				continue
 			}
 
 			chore.limiter.Go(ctx, func() {
 				err := worker.Run(ctx, func() {
-					chore.log.Debug("finished graceful exit for satellite.", zap.Stringer("satellite ID", satelliteID))
+					chore.log.Debug("finished for satellite.", zap.Stringer("satellite ID", satelliteID))
 					chore.exitingMap.Delete(satelliteID)
 				})
 				if err != nil {
-					chore.log.Error("worker failed.", zap.Error(err))
+					chore.log.Error("worker failed", zap.Error(err))
 				}
 			})
 		}


### PR DESCRIPTION
"running graceful exit chore" makes it sound like the storagenode/satellite is gracefully exiting and confusing people. Also lower the level to debug.

https://forum.storj.io/t/changelog-v0-24-5/2420/16

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
