### PR TITLE
satellite: remove satellite API code from peer

### DIFF
--- a/cmd/satellite/api.go
+++ b/cmd/satellite/api.go
@@ -72,6 +72,11 @@ func cmdAPIRun(cmd *cobra.Command, args []string) (err error) {
 		zap.S().Warn("Failed to initialize telemetry batcher on satellite api: ", err)
 	}
 
+	err = db.CreateTables()
+	if err != nil {
+		return errs.New("Error creating tables for master database on satellite: %+v", err)
+	}
+
 	runError := peer.Run(ctx)
 	closeError := peer.Close()
 	return errs.Combine(runError, closeError)

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -200,11 +200,6 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 		zap.S().Warn("Failed to initialize telemetry batcher: ", err)
 	}
 
-	err = db.CreateTables()
-	if err != nil {
-		return errs.New("Error creating tables for master database on satellite: %+v", err)
-	}
-
 	runError := peer.Run(ctx)
 	closeError := peer.Close()
 	return errs.Combine(runError, closeError)

--- a/cmd/storj-sim/network.go
+++ b/cmd/storj-sim/network.go
@@ -233,7 +233,7 @@ func newNetwork(flags *Flags) (*Processes, error) {
 	var satellites []*Process
 	for i := 0; i < flags.SatelliteCount; i++ {
 		process := processes.New(Info{
-			Name:       fmt.Sprintf("satellite-api/%d", i),
+			Name:       fmt.Sprintf("satellite/%d", i),
 			Executable: "satellite",
 			Directory:  filepath.Join(processes.Directory, "satellite", fmt.Sprint(i)),
 			Address:    net.JoinHostPort(host, port(satellitePeer, i, publicGRPC)),
@@ -290,7 +290,6 @@ func newNetwork(flags *Flags) (*Processes, error) {
 
 		process.Arguments = withCommon(process.Directory, Arguments{
 			"run": {
-				"--server.address", process.Address,
 				"--debug.addr", net.JoinHostPort(host, port(satellitePeer, i, debugPeerHTTP)),
 			},
 		})

--- a/cmd/storj-sim/network.go
+++ b/cmd/storj-sim/network.go
@@ -534,8 +534,8 @@ func identitySetup(network *Processes) (*Processes, error) {
 			continue
 		}
 
-		if strings.Contains(process.Name, "satellite-api") {
-			// satellite-api uses the same identity as the satellite
+		if strings.Contains(process.Name, "satellite-peer") {
+			// satellite-peer uses the same identity as the satellite
 			continue
 		}
 		if strings.Contains(process.Name, "satellite-repair") {

--- a/scripts/test-sim-backwards.sh
+++ b/scripts/test-sim-backwards.sh
@@ -49,7 +49,9 @@ PATH=$RELEASE_DIR/bin:$PATH storj-sim -x --host $STORJ_NETWORK_HOST4 network tes
 
 # this replaces anywhere that has "/release/" in the config file, which currently just renames the static dir paths
 sed -i -e 's#/release/#/branch/#g' `storj-sim network env SATELLITE_API_0_DIR`/config.yaml
-sed -i -e 's#127.0.0.1:100#127.0.0.1:140#g' `storj-sim network env SATELLITE_PEER_0_DIR`/config.yaml
+
+# replace any 140XX port with 100XX port to fix, satellite.API part removal from satellite.Peer
+sed -i -e "s#$STORJ_NETWORK_HOST4:100#$STORJ_NETWORK_HOST4:140#g" `storj-sim network env SATELLITE_API_0_DIR`/config.yaml
 
 ## Ensure that partially upgraded network works
 

--- a/scripts/test-sim-backwards.sh
+++ b/scripts/test-sim-backwards.sh
@@ -48,7 +48,7 @@ PATH=$RELEASE_DIR/bin:$PATH storj-sim -x --host $STORJ_NETWORK_HOST4 network --p
 PATH=$RELEASE_DIR/bin:$PATH storj-sim -x --host $STORJ_NETWORK_HOST4 network test bash "$SCRIPTDIR"/test-backwards.sh upload
 
 # this replaces anywhere that has "/release/" in the config file, which currently just renames the static dir paths
-sed -i -e 's#/release/#/branch/#g' `storj-sim network env SATELLITE_0_DIR`/config.yaml
+sed -i -e 's#/release/#/branch/#g' `storj-sim network env SATELLITE_API_0_DIR`/config.yaml
 
 ## Ensure that partially upgraded network works
 

--- a/scripts/test-sim-backwards.sh
+++ b/scripts/test-sim-backwards.sh
@@ -49,6 +49,7 @@ PATH=$RELEASE_DIR/bin:$PATH storj-sim -x --host $STORJ_NETWORK_HOST4 network tes
 
 # this replaces anywhere that has "/release/" in the config file, which currently just renames the static dir paths
 sed -i -e 's#/release/#/branch/#g' `storj-sim network env SATELLITE_API_0_DIR`/config.yaml
+sed -i -e 's#127.0.0.1:100#127.0.0.1:140#g' `storj-sim network env SATELLITE_PEER_0_DIR`/config.yaml
 
 ## Ensure that partially upgraded network works
 

--- a/scripts/test-sim-backwards.sh
+++ b/scripts/test-sim-backwards.sh
@@ -48,10 +48,10 @@ PATH=$RELEASE_DIR/bin:$PATH storj-sim -x --host $STORJ_NETWORK_HOST4 network --p
 PATH=$RELEASE_DIR/bin:$PATH storj-sim -x --host $STORJ_NETWORK_HOST4 network test bash "$SCRIPTDIR"/test-backwards.sh upload
 
 # this replaces anywhere that has "/release/" in the config file, which currently just renames the static dir paths
-sed -i -e 's#/release/#/branch/#g' `storj-sim network env SATELLITE_API_0_DIR`/config.yaml
+sed -i -e 's#/release/#/branch/#g' `storj-sim network env SATELLITE_0_DIR`/config.yaml
 
 # replace any 140XX port with 100XX port to fix, satellite.API part removal from satellite.Peer
-sed -i -e "s#$STORJ_NETWORK_HOST4:100#$STORJ_NETWORK_HOST4:140#g" `storj-sim network env SATELLITE_API_0_DIR`/config.yaml
+sed -i -e "s#$STORJ_NETWORK_HOST4:100#$STORJ_NETWORK_HOST4:140#g" `storj-sim network env SATELLITE_0_DIR`/config.yaml
 
 ## Ensure that partially upgraded network works
 


### PR DESCRIPTION
What/Why:

Now that the Satellite API is separated from the peer and deployed to production separately, this PR remove the duplicate API code from the peer.go file.

This PR also moves the database migration into the `satelllite run api` command in order to work better with storj-sim.  Additionally this might be best for the production deploy, we may want all the other split satellite services to wait on the API to complete the migration then they can start up after.

Please describe the tests:
- updates storj-sim to pass the integration and backwards compatibility tests

Please describe the performance impact:
n/a

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
