### PR TITLE
cmd/certificates: Ensure we dont return already claimed token again

### DIFF
--- a/certificate/authorization/service.go
+++ b/certificate/authorization/service.go
@@ -47,8 +47,11 @@ func (service *Service) GetOrCreate(ctx context.Context, userID string) (_ *Toke
 	}
 
 	if existingGroup != nil && len(existingGroup) > 0 {
-		authorization := existingGroup[0]
-		return &authorization.Token, nil
+		for _, authorization := range existingGroup {
+			if authorization.Claim == nil {
+				return &authorization.Token, nil
+			}
+		}
 	}
 
 	createdGroup, err := service.db.Create(ctx, userID, 1)


### PR DESCRIPTION
What: Fixes the problem of potentially returned an already claimed token

Why: It currently could return a claimed token, which causes confusion

## Code Review Checklist (to be filled out by reviewer)
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
