### PR TITLE
identity/cmd: increase default difficulty to 36

### DIFF
--- a/cmd/identity/main.go
+++ b/cmd/identity/main.go
@@ -56,7 +56,7 @@ var (
 
 	//nolint
 	config struct {
-		Difficulty     uint64 `default:"30" help:"minimum difficulty for identity generation"`
+		Difficulty     uint64 `default:"36" help:"minimum difficulty for identity generation"`
 		Concurrency    uint   `default:"4" help:"number of concurrent workers for certificate authority generation"`
 		ParentCertPath string `help:"path to the parent authority's certificate chain"`
 		ParentKeyPath  string `help:"path to the parent authority's private key"`


### PR DESCRIPTION
What: The default difficulty for creating a new identity is increased from 30 to 36.

A separate PR will change the signing service to accept identities with difficulty of at least 36.

See: https://storjlabs.atlassian.net/browse/V3-2848

Why: We want to raise the bar of Proof of Work for new storage nodes.

Please describe the tests: Existing test should still be enough
 
Please describe the performance impact: It will take more time to generate a new identity with the default setting, but this is exactly the desired result.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
