### PR TITLE
storagenode/contact: fix panic in ping satellites

### DIFF
--- a/storagenode/contact/chore.go
+++ b/storagenode/contact/chore.go
@@ -65,6 +65,7 @@ func (chore *Chore) pingSatellites(ctx context.Context) (err error) {
 	var group errgroup.Group
 	self := chore.service.Local()
 	satellites := chore.trust.GetSatellites(ctx)
+
 	for _, satellite := range satellites {
 		satellite := satellite
 		addr, err := chore.trust.GetAddress(ctx, satellite)
@@ -85,7 +86,10 @@ func (chore *Chore) pingSatellites(ctx context.Context) (err error) {
 				Capacity: &self.Capacity,
 				Operator: &self.Operator,
 			})
-			if !resp.PingNodeSuccess {
+
+			if err != nil {
+				chore.log.Error("Check-In with satellite failed", zap.Error(err))
+			} else if !resp.PingNodeSuccess {
 				chore.log.Error("Check-In with satellite failed due to failed ping back", zap.String("satellite ID", satellite.String()), zap.String("satellite addr", addr), zap.String("ping back error message", resp.GetPingErrorMessage()))
 			}
 


### PR DESCRIPTION
`resp` might be nil when the check in fails.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
