### PR TITLE
cmd/storj-sim: add --redis flag

### DIFF
--- a/cmd/storj-sim/main.go
+++ b/cmd/storj-sim/main.go
@@ -26,6 +26,7 @@ type Flags struct {
 
 	// Connection string for the postgres database to use for storj-sim processes
 	Postgres string
+	Redis    string
 }
 
 var printCommands bool
@@ -58,6 +59,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(&flags.IsDev, "dev", "", false, "use configuration values tuned for development")
 
 	rootCmd.PersistentFlags().StringVarP(&flags.Postgres, "postgres", "", os.Getenv("STORJ_SIM_POSTGRES"), "connection string for postgres (defaults to STORJ_SIM_POSTGRES)")
+	rootCmd.PersistentFlags().StringVarP(&flags.Redis, "redis", "", os.Getenv("STORJ_SIM_Redis"), "connection string for redis (defaults to STORJ_SIM_REDIS)")
 
 	networkCmd := &cobra.Command{
 		Use:   "network",

--- a/cmd/storj-sim/main.go
+++ b/cmd/storj-sim/main.go
@@ -59,7 +59,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(&flags.IsDev, "dev", "", false, "use configuration values tuned for development")
 
 	rootCmd.PersistentFlags().StringVarP(&flags.Postgres, "postgres", "", os.Getenv("STORJ_SIM_POSTGRES"), "connection string for postgres (defaults to STORJ_SIM_POSTGRES)")
-	rootCmd.PersistentFlags().StringVarP(&flags.Redis, "redis", "", os.Getenv("STORJ_SIM_Redis"), "connection string for redis (defaults to STORJ_SIM_REDIS)")
+	rootCmd.PersistentFlags().StringVarP(&flags.Redis, "redis", "", os.Getenv("STORJ_SIM_REDIS"), "connection string for redis (defaults to STORJ_SIM_REDIS)")
 
 	networkCmd := &cobra.Command{
 		Use:   "network",


### PR DESCRIPTION
What: Adds storj-sim support for --redis flag

Why: Allows users to run and configure their own redis server to use with storj sim. Defaults to environment variable $STORJ_SIM_REDIS. If not set, storj-sim will spin up the needed redis servers automatically.

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
