### PR TITLE
drpc: enable by default

### DIFF
--- a/internal/testcontext/compile_drpc.go
+++ b/internal/testcontext/compile_drpc.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build drpc
+// +build !grpc
 
 package testcontext
 

--- a/internal/testcontext/compile_nodrpc.go
+++ b/internal/testcontext/compile_nodrpc.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build !drpc
+// +build grpc
 
 package testcontext
 

--- a/pkg/rpc/common_drpc.go
+++ b/pkg/rpc/common_drpc.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build drpc
+// +build !grpc
 
 package rpc
 

--- a/pkg/rpc/common_grpc.go
+++ b/pkg/rpc/common_grpc.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build !drpc
+// +build grpc
 
 package rpc
 

--- a/pkg/rpc/compat_drpc.go
+++ b/pkg/rpc/compat_drpc.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build drpc
+// +build !grpc
 
 package rpc
 

--- a/pkg/rpc/compat_grpc.go
+++ b/pkg/rpc/compat_grpc.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build !drpc
+// +build grpc
 
 package rpc
 

--- a/pkg/rpc/dial_drpc.go
+++ b/pkg/rpc/dial_drpc.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build drpc
+// +build !grpc
 
 package rpc
 

--- a/pkg/rpc/dial_grpc.go
+++ b/pkg/rpc/dial_grpc.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build !drpc
+// +build grpc
 
 package rpc
 

--- a/pkg/rpc/rpcpeer/peer_drpc.go
+++ b/pkg/rpc/rpcpeer/peer_drpc.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build drpc
+// +build !grpc
 
 package rpcpeer
 

--- a/pkg/rpc/rpcpeer/peer_grpc.go
+++ b/pkg/rpc/rpcpeer/peer_grpc.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build !drpc
+// +build grpc
 
 package rpcpeer
 

--- a/pkg/rpc/rpcstatus/status_drpc.go
+++ b/pkg/rpc/rpcstatus/status_drpc.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build drpc
+// +build !grpc
 
 package rpcstatus
 

--- a/pkg/rpc/rpcstatus/status_grpc.go
+++ b/pkg/rpc/rpcstatus/status_grpc.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-// +build !drpc
+// +build grpc
 
 package rpcstatus
 


### PR DESCRIPTION
What: changes the default to use drpc instead of grpc

Why: so we can start using drpc by default

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
