### PR TITLE
satellite/gracefulexit: make disabled test more permissive

### DIFF
--- a/satellite/gracefulexit/endpoint_test.go
+++ b/satellite/gracefulexit/endpoint_test.go
@@ -824,7 +824,7 @@ func TestExitDisabled(t *testing.T) {
 
 		// Process endpoint should return immediately if GE is disabled
 		response, err := processClient.Recv()
-		require.True(t, errs2.IsRPC(err, rpcstatus.Unimplemented))
+		require.Error(t, err)
 		require.Nil(t, response)
 	})
 }


### PR DESCRIPTION
the test required that the error have rpc status of Unimplemented
but the code does not depend on this detail. drpc does not have
that specific error code, nor a clean way to tell that the error
is due to it being an unknown rpc. so, just assert that it got
an error.

Please describe the tests: N/A
 
Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
