### PR TITLE
satellite/gracefulexit: check for unkown error in graceful exit disable test

### DIFF
--- a/satellite/gracefulexit/endpoint_test.go
+++ b/satellite/gracefulexit/endpoint_test.go
@@ -824,7 +824,10 @@ func TestExitDisabled(t *testing.T) {
 
 		// Process endpoint should return immediately if GE is disabled
 		response, err := processClient.Recv()
-		require.True(t, errs2.IsRPC(err, rpcstatus.Unimplemented))
+		require.Error(t, err)
+		// grpc will return "Unimplemented", drpc will return "Unknown"
+		unimplementedOrUnknown := errs2.IsRPC(err, rpcstatus.Unimplemented) || errs2.IsRPC(err, rpcstatus.Unknown)
+		require.True(t, unimplementedOrUnknown)
 		require.Nil(t, response)
 	})
 }


### PR DESCRIPTION
What: 
Allow error in graceful exit disable test to be `rpcstatus.Unknown` or `rpcstatus.Unimplemented`

Why:
grpc returns `Unimplemented` and drpc returns `Unknown`

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
