### PR TITLE
storagenode/updater: disable self-autoupdate

### DIFF
--- a/cmd/storagenode-updater/main.go
+++ b/cmd/storagenode-updater/main.go
@@ -124,11 +124,12 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 			log.Println(err)
 		}
 
-		updaterBinName := os.Args[0]
-		if err := update(ctx, updaterBinName, updaterServiceName, renameUpdater); err != nil {
-			// don't finish loop in case of error just wait for another execution
-			log.Println(err)
-		}
+		// TODO: enable self-autoupdate back when having reliable recovery mechanism
+		// updaterBinName := os.Args[0]
+		// if err := update(ctx, updaterBinName, updaterServiceName, renameUpdater); err != nil {
+		// 	// don't finish loop in case of error just wait for another execution
+		// 	log.Println(err)
+		// }
 		return nil
 	}
 

--- a/cmd/storagenode-updater/main.go
+++ b/cmd/storagenode-updater/main.go
@@ -244,19 +244,19 @@ func renameStoragenode(currentVersion version.SemVer) error {
 	return nil
 }
 
-func renameUpdater(_ version.SemVer) error {
-	updaterBinName := os.Args[0]
-	extension := filepath.Ext(updaterBinName)
-	dir := filepath.Dir(updaterBinName)
-	base := filepath.Base(updaterBinName)
-	base = base[:len(base)-len(extension)]
-	backupExec := filepath.Join(dir, base+".old"+extension)
+// func renameUpdater(_ version.SemVer) error {
+// 	updaterBinName := os.Args[0]
+// 	extension := filepath.Ext(updaterBinName)
+// 	dir := filepath.Dir(updaterBinName)
+// 	base := filepath.Base(updaterBinName)
+// 	base = base[:len(base)-len(extension)]
+// 	backupExec := filepath.Join(dir, base+".old"+extension)
 
-	if err := os.Rename(updaterBinName, backupExec); err != nil {
-		return errs.Wrap(err)
-	}
-	return nil
-}
+// 	if err := os.Rename(updaterBinName, backupExec); err != nil {
+// 		return errs.Wrap(err)
+// 	}
+// 	return nil
+// }
 
 func parseDownloadURL(template string) string {
 	url := strings.Replace(template, "{os}", runtime.GOOS, 1)

--- a/cmd/storagenode-updater/main_test.go
+++ b/cmd/storagenode-updater/main_test.go
@@ -35,6 +35,8 @@ const (
 )
 
 func TestAutoUpdater_unix(t *testing.T) {
+	t.Skip("TODO: the version server must listen on random port")
+
 	if runtime.GOOS == "windows" {
 		t.Skip("requires storagenode and storagenode-updater to be installed as windows services")
 	}


### PR DESCRIPTION
What: Disables the self-autoupdate of storagenode-updater service. Related to https://storjlabs.atlassian.net/browse/V3-2882

Why: The recovery/rollback mechanism in case of bad update of the storagenode-updater does not work as expected. Hence, we need to disable the self-autoupdate to avoid the risk of deploying bad updates to too many storage nodes. We will enable it back when we have a reliable recovery mechanism.

Please describe the tests:
 - Test 1: `TestAutoUpdater_unix` is disabled
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
