### PR TITLE
satellite/peer: add payments config

### DIFF
--- a/satellite/api.go
+++ b/satellite/api.go
@@ -43,7 +43,6 @@ import (
 	"storj.io/storj/satellite/overlay"
 	"storj.io/storj/satellite/payments"
 	"storj.io/storj/satellite/payments/mockpayments"
-	"storj.io/storj/satellite/payments/paymentsconfig"
 	"storj.io/storj/satellite/payments/stripecoinpayments"
 	"storj.io/storj/satellite/repair/irreparable"
 	"storj.io/storj/satellite/rewards"
@@ -366,15 +365,16 @@ func NewAPI(log *zap.Logger, full *identity.FullIdentity, db DB, pointerDB metai
 	}
 
 	{ // setup payments
-		config := paymentsconfig.Config{}
+		log.Debug("Satellite API Process setting up payments")
+		pc := config.Payments
 
-		switch config.Provider {
+		switch pc.Provider {
 		default:
 			peer.Payments.Accounts = mockpayments.Accounts()
 		case "stripecoinpayments":
 			service := stripecoinpayments.NewService(
 				peer.Log.Named("stripecoinpayments service"),
-				config.StripeCoinPayments,
+				pc.StripeCoinPayments,
 				peer.DB.StripeCoinPayments(),
 				peer.DB.Console().Projects())
 

--- a/satellite/console/consoleweb/server.go
+++ b/satellite/console/consoleweb/server.go
@@ -54,7 +54,6 @@ type Config struct {
 	Address         string `help:"server address of the graphql api gateway and frontend app" devDefault:"127.0.0.1:8081" releaseDefault:":10100"`
 	StaticDir       string `help:"path to static resources" default:""`
 	ExternalAddress string `help:"external endpoint of the satellite if hosted" default:""`
-	StripeKey       string `help:"stripe api key" default:""`
 
 	// TODO: remove after Vanguard release
 	AuthToken       string `help:"auth token needed for access to registration token creation endpoint" default:""`

--- a/satellite/core.go
+++ b/satellite/core.go
@@ -33,7 +33,6 @@ import (
 	"storj.io/storj/satellite/overlay"
 	"storj.io/storj/satellite/payments"
 	"storj.io/storj/satellite/payments/mockpayments"
-	"storj.io/storj/satellite/payments/paymentsconfig"
 	"storj.io/storj/satellite/payments/stripecoinpayments"
 	"storj.io/storj/satellite/repair/checker"
 	"storj.io/storj/satellite/repair/repairer"
@@ -290,15 +289,16 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, pointerDB metainfo
 
 	// TODO: remove in future, should be in API
 	{ // setup payments
-		config := paymentsconfig.Config{}
+		log.Debug("Setting up payments")
+		pc := config.Payments
 
-		switch config.Provider {
+		switch pc.Provider {
 		default:
 			peer.Payments.Accounts = mockpayments.Accounts()
 		case "stripecoinpayments":
 			service := stripecoinpayments.NewService(
 				peer.Log.Named("stripecoinpayments service"),
-				config.StripeCoinPayments,
+				pc.StripeCoinPayments,
 				peer.DB.StripeCoinPayments(),
 				peer.DB.Console().Projects())
 
@@ -307,8 +307,8 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, pointerDB metainfo
 			peer.Payments.Chore = stripecoinpayments.NewChore(
 				peer.Log.Named("stripecoinpayments clearing loop"),
 				service,
-				config.StripeCoinPayments.TransactionUpdateInterval,
-				config.StripeCoinPayments.AccountBalanceUpdateInterval)
+				pc.StripeCoinPayments.TransactionUpdateInterval,
+				pc.StripeCoinPayments.AccountBalanceUpdateInterval)
 		}
 	}
 

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -5,6 +5,7 @@ package satellite
 
 import (
 	"gopkg.in/spacemonkeygo/monkit.v2"
+	"storj.io/storj/satellite/payments/paymentsconfig"
 
 	version_checker "storj.io/storj/internal/version/checker"
 	"storj.io/storj/pkg/identity"
@@ -107,6 +108,9 @@ type Config struct {
 	LiveAccounting live.Config
 
 	Mail    mailservice.Config
+
+	Payments paymentsconfig.Config
+
 	Console consoleweb.Config
 
 	Marketing marketingweb.Config

--- a/satellite/peer.go
+++ b/satellite/peer.go
@@ -5,7 +5,6 @@ package satellite
 
 import (
 	"gopkg.in/spacemonkeygo/monkit.v2"
-	"storj.io/storj/satellite/payments/paymentsconfig"
 
 	version_checker "storj.io/storj/internal/version/checker"
 	"storj.io/storj/pkg/identity"
@@ -28,6 +27,7 @@ import (
 	"storj.io/storj/satellite/metrics"
 	"storj.io/storj/satellite/orders"
 	"storj.io/storj/satellite/overlay"
+	"storj.io/storj/satellite/payments/paymentsconfig"
 	"storj.io/storj/satellite/payments/stripecoinpayments"
 	"storj.io/storj/satellite/repair/checker"
 	"storj.io/storj/satellite/repair/irreparable"
@@ -107,7 +107,7 @@ type Config struct {
 	Rollup         rollup.Config
 	LiveAccounting live.Config
 
-	Mail    mailservice.Config
+	Mail mailservice.Config
 
 	Payments paymentsconfig.Config
 

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -131,10 +131,10 @@ contact.external-address: ""
 # graceful-exit.recv-timeout: 10m0s
 
 # path to the certificate chain for this identity
-identity.cert-path: /home/riko/.local/share/storj/identity/satellite/identity.cert
+identity.cert-path: /root/.local/share/storj/identity/satellite/identity.cert
 
 # path to the private key for this identity
-identity.key-path: /home/riko/.local/share/storj/identity/satellite/identity.key
+identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 
 # what to use for storing real-time accounting data
 # live-accounting.storage-backend: memory

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -64,9 +64,6 @@
 # path to static resources
 # console.static-dir: ""
 
-# stripe api key
-# console.stripe-key: ""
-
 # url link to terms and conditions page
 # console.terms-and-conditions-url: https://storj.io/storage-sla/
 
@@ -134,10 +131,10 @@ contact.external-address: ""
 # graceful-exit.recv-timeout: 10m0s
 
 # path to the certificate chain for this identity
-identity.cert-path: /root/.local/share/storj/identity/satellite/identity.cert
+identity.cert-path: /home/riko/.local/share/storj/identity/satellite/identity.cert
 
 # path to the private key for this identity
-identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
+identity.key-path: /home/riko/.local/share/storj/identity/satellite/identity.key
 
 # what to use for storing real-time accounting data
 # live-accounting.storage-backend: memory
@@ -333,6 +330,24 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 
 # number of update requests to process per transaction
 # overlay.update-stats-batch-size: 100
+
+# payments provider to use
+# payments.provider: ""
+
+# amount of time we wait before running next account balance update loop
+# payments.stripe-coin-payments.account-balance-update-interval: 1h30m0s
+
+# coinpayments API private key key
+# payments.stripe-coin-payments.coinpayments-private-key: ""
+
+# coinpayments API public key
+# payments.stripe-coin-payments.coinpayments-public-key: ""
+
+# stripe API secret key
+# payments.stripe-coin-payments.stripe-secret-key: ""
+
+# amount of time we wait before running next transaction update loop
+# payments.stripe-coin-payments.transaction-update-interval: 30m0s
 
 # time limit for downloading pieces from a node for repair
 # repairer.download-timeout: 5m0s


### PR DESCRIPTION
What: Add payments config to satellite peer config.

Why: To add the ability for satellite owner to set API keys for `stripe` and `coinpayments`

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
