### PR TITLE
satellite/audit: do not audit expired segments

### DIFF
--- a/internal/testplanet/uplink.go
+++ b/internal/testplanet/uplink.go
@@ -160,7 +160,7 @@ func (client *Uplink) DialPiecestore(ctx context.Context, destination Peer) (*pi
 
 // Upload data to specific satellite
 func (client *Uplink) Upload(ctx context.Context, satellite *SatelliteSystem, bucket string, path storj.Path, data []byte) error {
-	return client.UploadWithExpiration(ctx, satellite, bucket, path, data, time.Now().Add(1*time.Hour))
+	return client.UploadWithExpiration(ctx, satellite, bucket, path, data, time.Time{})
 }
 
 // UploadWithExpiration data to specific satellite and expiration time
@@ -170,7 +170,7 @@ func (client *Uplink) UploadWithExpiration(ctx context.Context, satellite *Satel
 
 // UploadWithConfig uploads data to specific satellite with configured values
 func (client *Uplink) UploadWithConfig(ctx context.Context, satellite *SatelliteSystem, redundancy *uplink.RSConfig, bucket string, path storj.Path, data []byte) error {
-	return client.UploadWithExpirationAndConfig(ctx, satellite, redundancy, bucket, path, data, time.Now().Add(1*time.Hour))
+	return client.UploadWithExpirationAndConfig(ctx, satellite, redundancy, bucket, path, data, time.Time{})
 }
 
 // UploadWithExpirationAndConfig uploads data to specific satellite with configured values and expiration time

--- a/internal/testplanet/uplink.go
+++ b/internal/testplanet/uplink.go
@@ -160,7 +160,7 @@ func (client *Uplink) DialPiecestore(ctx context.Context, destination Peer) (*pi
 
 // Upload data to specific satellite
 func (client *Uplink) Upload(ctx context.Context, satellite *SatelliteSystem, bucket string, path storj.Path, data []byte) error {
-	return client.UploadWithExpiration(ctx, satellite, bucket, path, data, time.Time{})
+	return client.UploadWithExpiration(ctx, satellite, bucket, path, data, time.Now().Add(1*time.Hour))
 }
 
 // UploadWithExpiration data to specific satellite and expiration time
@@ -170,7 +170,7 @@ func (client *Uplink) UploadWithExpiration(ctx context.Context, satellite *Satel
 
 // UploadWithConfig uploads data to specific satellite with configured values
 func (client *Uplink) UploadWithConfig(ctx context.Context, satellite *SatelliteSystem, redundancy *uplink.RSConfig, bucket string, path storj.Path, data []byte) error {
-	return client.UploadWithExpirationAndConfig(ctx, satellite, redundancy, bucket, path, data, time.Time{})
+	return client.UploadWithExpirationAndConfig(ctx, satellite, redundancy, bucket, path, data, time.Now().Add(1*time.Hour))
 }
 
 // UploadWithExpirationAndConfig uploads data to specific satellite with configured values and expiration time

--- a/satellite/audit/reverify_test.go
+++ b/satellite/audit/reverify_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -14,11 +15,13 @@ import (
 	"storj.io/storj/internal/testcontext"
 	"storj.io/storj/internal/testplanet"
 	"storj.io/storj/internal/testrand"
+	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/peertls/tlsopts"
 	"storj.io/storj/pkg/pkcrypto"
 	"storj.io/storj/pkg/rpc"
 	"storj.io/storj/pkg/storj"
 	"storj.io/storj/satellite/audit"
+	"storj.io/storj/storage"
 	"storj.io/storj/uplink"
 )
 
@@ -774,5 +777,55 @@ func TestReverifyDifferentShare(t *testing.T) {
 		require.Len(t, report.PendingAudits, 0)
 		require.Len(t, report.Fails, 1)
 		require.Equal(t, report.Fails[0], selectedNode)
+	})
+}
+
+func TestReverifyExpired(t *testing.T) {
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		satellite := planet.Satellites[0]
+		audits := satellite.Audit
+		queue := audits.Queue
+
+		audits.Worker.Loop.Pause()
+
+		ul := planet.Uplinks[0]
+		testData := testrand.Bytes(8 * memory.KiB)
+
+		err := ul.Upload(ctx, satellite, "testbucket", "test/path", testData)
+		require.NoError(t, err)
+
+		audits.Chore.Loop.TriggerWait()
+		path, err := queue.Next()
+		require.NoError(t, err)
+
+		// set pointer's expiration date to be already expired
+		pointer, err := satellite.Metainfo.Service.Get(ctx, path)
+		require.NoError(t, err)
+		oldPointerBytes, err := proto.Marshal(pointer)
+		require.NoError(t, err)
+		newPointer := &pb.Pointer{}
+		err = proto.Unmarshal(oldPointerBytes, newPointer)
+		require.NoError(t, err)
+		newPointer.ExpirationDate = time.Now().UTC().Add(-1 * time.Hour)
+		newPointerBytes, err := proto.Marshal(newPointer)
+		require.NoError(t, err)
+		err = satellite.Metainfo.Service.DB.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
+		require.NoError(t, err)
+
+		report, err := audits.Verifier.Reverify(ctx, path)
+		require.Error(t, err)
+		require.True(t, audit.ErrSegmentExpired.Has(err))
+
+		// Reverify should delete the expired segment
+		pointer, err = satellite.Metainfo.Service.Get(ctx, path)
+		require.Error(t, err)
+		require.Nil(t, pointer)
+
+		assert.Len(t, report.Successes, 0)
+		assert.Len(t, report.Fails, 0)
+		assert.Len(t, report.Offlines, 0)
+		assert.Len(t, report.PendingAudits, 0)
 	})
 }

--- a/satellite/audit/verifier.go
+++ b/satellite/audit/verifier.go
@@ -368,6 +368,13 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 		}
 		return Report{}, err
 	}
+	if pointer.ExpirationDate.Before(time.Now().UTC()) {
+		deleteErr := verifier.metainfo.Delete(ctx, path)
+		if deleteErr != nil {
+			return Report{}, Error.Wrap(deleteErr)
+		}
+		return Report{}, ErrSegmentExpired.New("Segment expired before Verify")
+	}
 
 	pieceHashesVerified := make(map[storj.NodeID]bool)
 	pieceHashesVerifiedMutex := &sync.Mutex{}

--- a/satellite/audit/verifier.go
+++ b/satellite/audit/verifier.go
@@ -94,7 +94,7 @@ func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[
 		}
 		return Report{}, err
 	}
-	if pointer.ExpirationDate.Before(time.Now().UTC()) {
+	if pointer.ExpirationDate != (time.Time{}) && pointer.ExpirationDate.Before(time.Now().UTC()) {
 		errDelete := verifier.metainfo.Delete(ctx, path)
 		if errDelete != nil {
 			return Report{}, Error.Wrap(errDelete)
@@ -368,7 +368,7 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 		}
 		return Report{}, err
 	}
-	if pointer.ExpirationDate.Before(time.Now().UTC()) {
+	if pointer.ExpirationDate != (time.Time{}) && pointer.ExpirationDate.Before(time.Now().UTC()) {
 		errDelete := verifier.metainfo.Delete(ctx, path)
 		if errDelete != nil {
 			return Report{}, Error.Wrap(errDelete)
@@ -436,7 +436,7 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 				verifier.log.Debug("Reverify: error getting pending pointer from metainfo", zap.Binary("Segment", []byte(pending.Path)), zap.Stringer("Node ID", pending.NodeID), zap.Error(err))
 				return
 			}
-			if pendingPointer.ExpirationDate.Before(time.Now().UTC()) {
+			if pendingPointer.ExpirationDate != (time.Time{}) && pendingPointer.ExpirationDate.Before(time.Now().UTC()) {
 				errDelete := verifier.metainfo.Delete(ctx, pending.Path)
 				if errDelete != nil {
 					verifier.log.Debug("Reverify: error deleting expired segment", zap.Binary("Segment", []byte(pending.Path)), zap.Stringer("Node ID", pending.NodeID), zap.Error(errDelete))


### PR DESCRIPTION
What: 
* When a segment is audited, if it has already expired, do not audit nodes for that segment and delete the segment. Do this for Verify as well as Reverify
* When a node is audited for data in containment mode, if the data it was contained for has expired, delete the segment and remove the node from containment mode

Why:
This case was not carried over during an audit refactor: https://github.com/storj/storj/pull/1559

Please describe the tests:
 - Test 1: Select a segment to call `audit.Verify` on. Update it to have an expired timestamp. Expect that `audit.Verify` returns an "expired" error, and deletes the segment from metainfo.
 - Test 2: Select a segment to call `audit.Reverify` on. Update it to have an expired timestamp. Expect that `audit.Reverify` returns an "expired" error, and deletes the segment from metainfo. (almost identical to Test 1)
- Test 3: Upload two segments (path1 and path2) and select a node containing a piece for both. Update the segment at path1 to be expired. Add the selected node to containment for its piece from path1. Call `audit.Reverify` on path2. Expect that the node did not fail an audit, that the pointer associated with path1 was removed, and that the node was removed from containment.
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
