### PR TITLE
makefile: add goversioninfo to build-dev-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ build-dev-deps: ## Install dependencies for builds
 	go get golang.org/x/tools/cover
 	go get github.com/modocache/gover
 	go get github.com/go-bindata/go-bindata/go-bindata
+	go get github.com/josephspurrier/goversioninfo/cmd/goversioninfo
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ${GOPATH}/bin v1.21.0
 
 .PHONY: lint


### PR DESCRIPTION
What: Add [goversioninfo](https://github.com/josephspurrier/goversioninfo) to `build-dev-deps` make target.

Why: The windows installer now requires proper version information in the storagenode binary to build; therefore, this is now a development dependency.

Please describe the tests: N/A
 
Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
