### PR TITLE
test/backwards-compatibility: fix port change

### DIFF
--- a/scripts/test-sim-backwards.sh
+++ b/scripts/test-sim-backwards.sh
@@ -51,7 +51,9 @@ PATH=$RELEASE_DIR/bin:$PATH storj-sim -x --host $STORJ_NETWORK_HOST4 network tes
 sed -i -e 's#/release/#/branch/#g' `storj-sim network env SATELLITE_0_DIR`/config.yaml
 
 # replace any 140XX port with 100XX port to fix, satellite.API part removal from satellite.Core
-sed -i -e "s#$STORJ_NETWORK_HOST4:100#$STORJ_NETWORK_HOST4:140#g" `storj-sim network env SATELLITE_0_DIR`/config.yaml
+sed -i -e "s#$STORJ_NETWORK_HOST4:140#$STORJ_NETWORK_HOST4:100#g" `storj-sim network env SATELLITE_0_DIR`/config.yaml
+
+# create redis config if it's missing
 REDIS_CONFIG=$(storj-sim network env REDIS_0_DIR)/redis.conf
 if [ ! -f "$REDIS_CONFIG" ] ; then
     echo "daemonize no" >> $REDIS_CONFIG


### PR DESCRIPTION
What: `sed` expression was the wrong way around causing the port not be replaced.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
