### PR TITLE
satellite/metainfo: fix some uses of metainfo.Delete

### DIFF
--- a/satellite/audit/reverify_test.go
+++ b/satellite/audit/reverify_test.go
@@ -812,7 +812,7 @@ func TestReverifyExpired1(t *testing.T) {
 		newPointer.ExpirationDate = time.Now().UTC().Add(-1 * time.Hour)
 		newPointerBytes, err := proto.Marshal(newPointer)
 		require.NoError(t, err)
-		err = satellite.Metainfo.PointerDB.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
+		err = satellite.Metainfo.Database.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
 		require.NoError(t, err)
 
 		report, err := audits.Verifier.Reverify(ctx, path)
@@ -930,7 +930,7 @@ func TestReverifyExpired2(t *testing.T) {
 		newPointer.ExpirationDate = time.Now().UTC().Add(-1 * time.Hour)
 		newPointerBytes, err := proto.Marshal(newPointer)
 		require.NoError(t, err)
-		err = satellite.Metainfo.PointerDB.CompareAndSwap(ctx, storage.Key(path1), oldPointerBytes, newPointerBytes)
+		err = satellite.Metainfo.Database.CompareAndSwap(ctx, storage.Key(path1), oldPointerBytes, newPointerBytes)
 		require.NoError(t, err)
 
 		// reverify with path 2. Since the selected node was put in containment for path1,

--- a/satellite/audit/reverify_test.go
+++ b/satellite/audit/reverify_test.go
@@ -812,7 +812,7 @@ func TestReverifyExpired1(t *testing.T) {
 		newPointer.ExpirationDate = time.Now().UTC().Add(-1 * time.Hour)
 		newPointerBytes, err := proto.Marshal(newPointer)
 		require.NoError(t, err)
-		err = satellite.Metainfo.Service.DB.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
+		err = satellite.Metainfo.PointerDB.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
 		require.NoError(t, err)
 
 		report, err := audits.Verifier.Reverify(ctx, path)
@@ -930,7 +930,7 @@ func TestReverifyExpired2(t *testing.T) {
 		newPointer.ExpirationDate = time.Now().UTC().Add(-1 * time.Hour)
 		newPointerBytes, err := proto.Marshal(newPointer)
 		require.NoError(t, err)
-		err = satellite.Metainfo.Service.DB.CompareAndSwap(ctx, storage.Key(path1), oldPointerBytes, newPointerBytes)
+		err = satellite.Metainfo.PointerDB.CompareAndSwap(ctx, storage.Key(path1), oldPointerBytes, newPointerBytes)
 		require.NoError(t, err)
 
 		// reverify with path 2. Since the selected node was put in containment for path1,

--- a/satellite/audit/reverify_test.go
+++ b/satellite/audit/reverify_test.go
@@ -243,7 +243,7 @@ func TestReverifyFailMissingShareNotVerified(t *testing.T) {
 		require.NoError(t, err)
 
 		// update pointer to have PieceHashesVerified false
-		err = satellite.Metainfo.Service.Delete(ctx, path)
+		err = satellite.Metainfo.Service.UnsynchronizedDelete(ctx, path)
 		require.NoError(t, err)
 		pointer.PieceHashesVerified = false
 		err = satellite.Metainfo.Service.Put(ctx, path, pointer)

--- a/satellite/audit/verifier.go
+++ b/satellite/audit/verifier.go
@@ -95,7 +95,7 @@ func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[
 		return Report{}, err
 	}
 	if pointer.ExpirationDate != (time.Time{}) && pointer.ExpirationDate.Before(time.Now().UTC()) {
-		errDelete := verifier.metainfo.Delete(ctx, path)
+		errDelete := verifier.metainfo.UnsynchronizedDelete(ctx, path)
 		if errDelete != nil {
 			return Report{}, Error.Wrap(errDelete)
 		}
@@ -369,7 +369,7 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 		return Report{}, err
 	}
 	if pointer.ExpirationDate != (time.Time{}) && pointer.ExpirationDate.Before(time.Now().UTC()) {
-		errDelete := verifier.metainfo.Delete(ctx, path)
+		errDelete := verifier.metainfo.UnsynchronizedDelete(ctx, path)
 		if errDelete != nil {
 			return Report{}, Error.Wrap(errDelete)
 		}
@@ -437,7 +437,7 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 				return
 			}
 			if pendingPointer.ExpirationDate != (time.Time{}) && pendingPointer.ExpirationDate.Before(time.Now().UTC()) {
-				errDelete := verifier.metainfo.Delete(ctx, pending.Path)
+				errDelete := verifier.metainfo.UnsynchronizedDelete(ctx, pending.Path)
 				if errDelete != nil {
 					verifier.log.Debug("Reverify: error deleting expired segment", zap.Binary("Segment", []byte(pending.Path)), zap.Stringer("Node ID", pending.NodeID), zap.Error(errDelete))
 				}

--- a/satellite/audit/verifier.go
+++ b/satellite/audit/verifier.go
@@ -87,7 +87,7 @@ func NewVerifier(log *zap.Logger, metainfo *metainfo.Service, dialer rpc.Dialer,
 func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[storj.NodeID]bool) (report Report, err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	pointer, err := verifier.metainfo.Get(ctx, path)
+	pointerBytes, pointer, err := verifier.metainfo.GetWithBytes(ctx, path)
 	if err != nil {
 		if storage.ErrKeyNotFound.Has(err) {
 			return Report{}, ErrSegmentDeleted.New("%q", path)
@@ -95,11 +95,11 @@ func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[
 		return Report{}, err
 	}
 	if pointer.ExpirationDate != (time.Time{}) && pointer.ExpirationDate.Before(time.Now().UTC()) {
-		errDelete := verifier.metainfo.UnsynchronizedDelete(ctx, path)
+		errDelete := verifier.metainfo.Delete(ctx, path, pointerBytes)
 		if errDelete != nil {
 			return Report{}, Error.Wrap(errDelete)
 		}
-		return Report{}, ErrSegmentExpired.New("Segment expired before Verify")
+		return Report{}, ErrSegmentExpired.New("segment expired before Verify")
 	}
 
 	defer func() {
@@ -361,7 +361,7 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 		err          error
 	}
 
-	pointer, err := verifier.metainfo.Get(ctx, path)
+	pointerBytes, pointer, err := verifier.metainfo.GetWithBytes(ctx, path)
 	if err != nil {
 		if storage.ErrKeyNotFound.Has(err) {
 			return Report{}, ErrSegmentDeleted.New("%q", path)
@@ -369,7 +369,7 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 		return Report{}, err
 	}
 	if pointer.ExpirationDate != (time.Time{}) && pointer.ExpirationDate.Before(time.Now().UTC()) {
-		errDelete := verifier.metainfo.UnsynchronizedDelete(ctx, path)
+		errDelete := verifier.metainfo.Delete(ctx, path, pointerBytes)
 		if errDelete != nil {
 			return Report{}, Error.Wrap(errDelete)
 		}
@@ -420,7 +420,7 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 		containedInSegment++
 
 		go func(pending *PendingAudit) {
-			pendingPointer, err := verifier.metainfo.Get(ctx, pending.Path)
+			pendingPointerBytes, pendingPointer, err := verifier.metainfo.GetWithBytes(ctx, pending.Path)
 			if err != nil {
 				if storage.ErrKeyNotFound.Has(err) {
 					// segment has been deleted since node was contained
@@ -437,7 +437,7 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 				return
 			}
 			if pendingPointer.ExpirationDate != (time.Time{}) && pendingPointer.ExpirationDate.Before(time.Now().UTC()) {
-				errDelete := verifier.metainfo.UnsynchronizedDelete(ctx, pending.Path)
+				errDelete := verifier.metainfo.Delete(ctx, pending.Path, pendingPointerBytes)
 				if errDelete != nil {
 					verifier.log.Debug("Reverify: error deleting expired segment", zap.Binary("Segment", []byte(pending.Path)), zap.Stringer("Node ID", pending.NodeID), zap.Error(errDelete))
 				}

--- a/satellite/audit/verifier_test.go
+++ b/satellite/audit/verifier_test.go
@@ -415,7 +415,7 @@ func TestVerifierExpired(t *testing.T) {
 		newPointer.ExpirationDate = time.Now().UTC().Add(-1 * time.Hour)
 		newPointerBytes, err := proto.Marshal(newPointer)
 		require.NoError(t, err)
-		err = satellite.Metainfo.Service.DB.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
+		err = satellite.Metainfo.PointerDB.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
 		require.NoError(t, err)
 
 		report, err := audits.Verifier.Verify(ctx, path, nil)

--- a/satellite/audit/verifier_test.go
+++ b/satellite/audit/verifier_test.go
@@ -415,7 +415,7 @@ func TestVerifierExpired(t *testing.T) {
 		newPointer.ExpirationDate = time.Now().UTC().Add(-1 * time.Hour)
 		newPointerBytes, err := proto.Marshal(newPointer)
 		require.NoError(t, err)
-		err = satellite.Metainfo.PointerDB.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
+		err = satellite.Metainfo.Database.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
 		require.NoError(t, err)
 
 		report, err := audits.Verifier.Verify(ctx, path, nil)

--- a/satellite/audit/verifier_test.go
+++ b/satellite/audit/verifier_test.go
@@ -541,7 +541,7 @@ func TestVerifierMissingPieceHashesNotVerified(t *testing.T) {
 		require.NoError(t, err)
 
 		// update pointer to have PieceHashesVerified false
-		err = satellite.Metainfo.Service.Delete(ctx, path)
+		err = satellite.Metainfo.Service.UnsynchronizedDelete(ctx, path)
 		require.NoError(t, err)
 		pointer.PieceHashesVerified = false
 		err = satellite.Metainfo.Service.Put(ctx, path, pointer)

--- a/satellite/gc/gc_test.go
+++ b/satellite/gc/gc_test.go
@@ -74,7 +74,7 @@ func TestGarbageCollection(t *testing.T) {
 		require.NotZero(t, keptPieceID)
 
 		// Delete one object from metainfo service on satellite
-		err = satellite.Metainfo.Service.Delete(ctx, deletedEncPath)
+		err = satellite.Metainfo.Service.UnsynchronizedDelete(ctx, deletedEncPath)
 		require.NoError(t, err)
 
 		// Check that piece of the deleted object is on the storagenode

--- a/satellite/gracefulexit/endpoint_test.go
+++ b/satellite/gracefulexit/endpoint_test.go
@@ -931,7 +931,7 @@ func TestFailureNotFoundPieceHashUnverified(t *testing.T) {
 		newPointer.PieceHashesVerified = false
 		newPointerBytes, err := proto.Marshal(newPointer)
 		require.NoError(t, err)
-		err = satellite.Metainfo.Service.DB.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
+		err = satellite.Metainfo.PointerDB.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
 		require.NoError(t, err)
 
 		// begin processing graceful exit messages

--- a/satellite/gracefulexit/endpoint_test.go
+++ b/satellite/gracefulexit/endpoint_test.go
@@ -931,7 +931,7 @@ func TestFailureNotFoundPieceHashUnverified(t *testing.T) {
 		newPointer.PieceHashesVerified = false
 		newPointerBytes, err := proto.Marshal(newPointer)
 		require.NoError(t, err)
-		err = satellite.Metainfo.PointerDB.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
+		err = satellite.Metainfo.Database.CompareAndSwap(ctx, storage.Key(path), oldPointerBytes, newPointerBytes)
 		require.NoError(t, err)
 
 		// begin processing graceful exit messages

--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -400,7 +400,7 @@ func (endpoint *Endpoint) DeleteSegmentOld(ctx context.Context, req *pb.SegmentD
 		return nil, rpcstatus.Error(rpcstatus.Internal, err.Error())
 	}
 
-	err = endpoint.metainfo.Delete(ctx, path)
+	err = endpoint.metainfo.UnsynchronizedDelete(ctx, path)
 
 	if err != nil {
 		return nil, rpcstatus.Error(rpcstatus.Internal, err.Error())
@@ -1149,7 +1149,7 @@ func (endpoint *Endpoint) CommitObject(ctx context.Context, req *pb.ObjectCommit
 	lastSegmentPointer.Remote.Redundancy = streamID.Redundancy
 	lastSegmentPointer.Metadata = req.EncryptedMetadata
 
-	err = endpoint.metainfo.Delete(ctx, lastSegmentPath)
+	err = endpoint.metainfo.UnsynchronizedDelete(ctx, lastSegmentPath)
 	if err != nil {
 		return nil, rpcstatus.Error(rpcstatus.Internal, err.Error())
 	}
@@ -1724,7 +1724,7 @@ func (endpoint *Endpoint) BeginDeleteSegment(ctx context.Context, req *pb.Segmen
 
 	// moved from FinishDeleteSegment to avoid inconsistency if someone will not
 	// call FinishDeleteSegment on uplink side
-	err = endpoint.metainfo.Delete(ctx, path)
+	err = endpoint.metainfo.UnsynchronizedDelete(ctx, path)
 	if err != nil {
 		return nil, rpcstatus.Error(rpcstatus.Internal, err.Error())
 	}

--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -1118,6 +1118,7 @@ func (endpoint *Endpoint) CommitObject(ctx context.Context, req *pb.ObjectCommit
 	}
 
 	segmentIndex := int64(0)
+	var lastSegmentPointerBytes []byte
 	var lastSegmentPointer *pb.Pointer
 	var lastSegmentPath string
 	for {
@@ -1126,7 +1127,7 @@ func (endpoint *Endpoint) CommitObject(ctx context.Context, req *pb.ObjectCommit
 			return nil, rpcstatus.Errorf(rpcstatus.InvalidArgument, "unable to create segment path: %v", err)
 		}
 
-		pointer, err := endpoint.metainfo.Get(ctx, path)
+		pointerBytes, pointer, err := endpoint.metainfo.GetWithBytes(ctx, path)
 		if err != nil {
 			if storage.ErrKeyNotFound.Has(err) {
 				break
@@ -1134,6 +1135,7 @@ func (endpoint *Endpoint) CommitObject(ctx context.Context, req *pb.ObjectCommit
 			return nil, rpcstatus.Errorf(rpcstatus.Internal, "unable to create get segment: %v", err)
 		}
 
+		lastSegmentPointerBytes = pointerBytes
 		lastSegmentPointer = pointer
 		lastSegmentPath = path
 		segmentIndex++
@@ -1149,7 +1151,7 @@ func (endpoint *Endpoint) CommitObject(ctx context.Context, req *pb.ObjectCommit
 	lastSegmentPointer.Remote.Redundancy = streamID.Redundancy
 	lastSegmentPointer.Metadata = req.EncryptedMetadata
 
-	err = endpoint.metainfo.UnsynchronizedDelete(ctx, lastSegmentPath)
+	err = endpoint.metainfo.Delete(ctx, lastSegmentPath, lastSegmentPointerBytes)
 	if err != nil {
 		return nil, rpcstatus.Error(rpcstatus.Internal, err.Error())
 	}

--- a/satellite/metainfo/service.go
+++ b/satellite/metainfo/service.go
@@ -23,13 +23,13 @@ import (
 // architecture: Service
 type Service struct {
 	logger    *zap.Logger
-	DB        PointerDB
+	db        PointerDB
 	bucketsDB BucketsDB
 }
 
 // NewService creates new metainfo service
 func NewService(logger *zap.Logger, db PointerDB, bucketsDB BucketsDB) *Service {
-	return &Service{logger: logger, DB: db, bucketsDB: bucketsDB}
+	return &Service{logger: logger, db: db, bucketsDB: bucketsDB}
 }
 
 // Put puts pointer to db under specific path
@@ -45,7 +45,7 @@ func (s *Service) Put(ctx context.Context, path string, pointer *pb.Pointer) (er
 	}
 
 	// CompareAndSwap is used instead of Put to avoid overwriting existing pointers
-	err = s.DB.CompareAndSwap(ctx, []byte(path), nil, pointerBytes)
+	err = s.db.CompareAndSwap(ctx, []byte(path), nil, pointerBytes)
 	return Error.Wrap(err)
 }
 
@@ -69,7 +69,7 @@ func (s *Service) UpdatePiecesCheckDuplicates(ctx context.Context, path string, 
 
 	for {
 		// read the pointer
-		oldPointerBytes, err := s.DB.Get(ctx, []byte(path))
+		oldPointerBytes, err := s.db.Get(ctx, []byte(path))
 		if err != nil {
 			return nil, Error.Wrap(err)
 		}
@@ -149,7 +149,7 @@ func (s *Service) UpdatePiecesCheckDuplicates(ctx context.Context, path string, 
 		}
 
 		// write the pointer using compare-and-swap
-		err = s.DB.CompareAndSwap(ctx, []byte(path), oldPointerBytes, newPointerBytes)
+		err = s.db.CompareAndSwap(ctx, []byte(path), oldPointerBytes, newPointerBytes)
 		if storage.ErrValueChanged.Has(err) {
 			continue
 		}
@@ -163,7 +163,7 @@ func (s *Service) UpdatePiecesCheckDuplicates(ctx context.Context, path string, 
 // Get gets pointer from db
 func (s *Service) Get(ctx context.Context, path string) (pointer *pb.Pointer, err error) {
 	defer mon.Task()(&ctx)(&err)
-	pointerBytes, err := s.DB.Get(ctx, []byte(path))
+	pointerBytes, err := s.db.Get(ctx, []byte(path))
 	if err != nil {
 		return nil, Error.Wrap(err)
 	}
@@ -181,7 +181,7 @@ func (s *Service) Get(ctx context.Context, path string) (pointer *pb.Pointer, er
 func (s *Service) GetWithBytes(ctx context.Context, path string) (pointerBytes []byte, pointer *pb.Pointer, err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	pointerBytes, err = s.DB.Get(ctx, []byte(path))
+	pointerBytes, err = s.db.Get(ctx, []byte(path))
 	if err != nil {
 		return nil, nil, Error.Wrap(err)
 	}
@@ -208,7 +208,7 @@ func (s *Service) List(ctx context.Context, prefix string, startAfter string, en
 		}
 	}
 
-	rawItems, more, err := storage.ListV2(ctx, s.DB, storage.ListOptions{
+	rawItems, more, err := storage.ListV2(ctx, s.db, storage.ListOptions{
 		Prefix:       prefixKey,
 		StartAfter:   storage.Key(startAfter),
 		EndBefore:    storage.Key(endBefore),
@@ -281,13 +281,13 @@ func (s *Service) setMetadata(item *pb.ListResponse_Item, data []byte, metaFlags
 func (s *Service) Delete(ctx context.Context, path string, oldPointerBytes []byte) (err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	return Error.Wrap(s.DB.CompareAndSwap(ctx, []byte(path), oldPointerBytes, nil))
+	return Error.Wrap(s.db.CompareAndSwap(ctx, []byte(path), oldPointerBytes, nil))
 }
 
 // UnsynchronizedDelete deletes from item from db without verifying whether the pointer has changed in the database.
 func (s *Service) UnsynchronizedDelete(ctx context.Context, path string) (err error) {
 	defer mon.Task()(&ctx)(&err)
-	return s.DB.Delete(ctx, []byte(path))
+	return s.db.Delete(ctx, []byte(path))
 }
 
 // CreateBucket creates a new bucket in the buckets db

--- a/satellite/metainfo/service.go
+++ b/satellite/metainfo/service.go
@@ -259,8 +259,8 @@ func (s *Service) setMetadata(item *pb.ListResponse_Item, data []byte, metaFlags
 	return nil
 }
 
-// Delete deletes from item from db
-func (s *Service) Delete(ctx context.Context, path string) (err error) {
+// UnsynchronizedDelete deletes from item from db without verifying whether the pointer has changed in the database.
+func (s *Service) UnsynchronizedDelete(ctx context.Context, path string) (err error) {
 	defer mon.Task()(&ctx)(&err)
 	return s.DB.Delete(ctx, []byte(path))
 }

--- a/satellite/repair/checker/checker_test.go
+++ b/satellite/repair/checker/checker_test.go
@@ -174,7 +174,7 @@ func TestIdentifyIrreparableSegments(t *testing.T) {
 			},
 		}
 		// update test pointer in db
-		err = metainfo.Delete(ctx, pointerPath)
+		err = metainfo.UnsynchronizedDelete(ctx, pointerPath)
 		require.NoError(t, err)
 		err = metainfo.Put(ctx, pointerPath, pointer)
 		require.NoError(t, err)


### PR DESCRIPTION
Calling `Delete` directly is usually very dangerous, because the pointerdb is changing all the time. Any time we call directly delete we must ensure that there are no changes.

Hence:

1. Rename `Delete` to `UnsynchronizedDelete` to make it more obvious that it's dangerous.
2. Add new method `Delete` that takes the old pointer bytes as an argument.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
