### PR TITLE
satellite/accounting: adds TODOs to make storagenode tally store bytes directly

### DIFF
--- a/satellite/accounting/rollup/rollup.go
+++ b/satellite/accounting/rollup/rollup.go
@@ -133,6 +133,7 @@ func (r *Service) RollupStorage(ctx context.Context, lastRollup time.Time, rollu
 			rollupStats[iDay][node] = &accounting.Rollup{NodeID: node, StartTime: iDay}
 		}
 		//increment data at rest sum
+		// TODO make sure to calculate the byte hours from tally (V3-3125)
 		rollupStats[iDay][node].AtRestTotal += tallyRow.DataTotal
 	}
 

--- a/satellite/accounting/tally/tally.go
+++ b/satellite/accounting/tally/tally.go
@@ -109,6 +109,7 @@ func (service *Service) Tally(ctx context.Context) (err error) {
 	finishTime := time.Now()
 
 	// calculate byte hours, not just bytes
+	// TODO remove this step and store the results as bytes, not byte hours (V3-3125)
 	hours := time.Since(lastTime).Hours()
 	for id := range observer.Node {
 		observer.Node[id] *= hours

--- a/satellite/satellitedb/dbx/satellitedb.dbx
+++ b/satellite/satellitedb/dbx/satellitedb.dbx
@@ -94,6 +94,7 @@ read scalar (
 	where  accounting_timestamps.name  = ?
 )
 
+// TODO make sure to calculate the byte hours from tally (V3-3125)
 model accounting_rollup (
 	key id
 
@@ -532,6 +533,7 @@ read all (
 	where storagenode_bandwidth_rollup.interval_start >= ?
 )
 
+// TODO create a new table to use instead and store the data_total as bytes, not byte hours (V3-3125)
 model storagenode_storage_tally (
 	key   id
 

--- a/storagenode/contact/chore.go
+++ b/storagenode/contact/chore.go
@@ -57,7 +57,7 @@ func NewChore(log *zap.Logger, interval time.Duration, trust *trust.Pool, dialer
 // Run the contact chore on a regular interval with jitter
 func (chore *Chore) Run(ctx context.Context) (err error) {
 	defer mon.Task()(&ctx)(&err)
-	chore.log.Info("Storagenode contact chore starting up")
+	chore.log.Info("starting up")
 
 	var group errgroup.Group
 


### PR DESCRIPTION
What: Adds TODOs to make storagenode tally store bytes directly
Why: stopover until https://storjlabs.atlassian.net/browse/V3-3125 is implemented

copied from ticket:
Currently there is an asymmetry between how storage node and project accounting.
Project tally uses total raw bytes at the end of the tally.
Storage Node tally uses byte-hours since the last tally.

The reason storage node tallying ended up using byte-hours, is because it initially also tracked during tallying whether storage node was online or not. However later we decided to do that later. Calculate the total byte-hours in ideal scenario and then multiply it with the storage node uptime percentage.

This slight difference is confusing and makes it harder to work with.By storing the exact bytes we could show, how much should be stored at a given point in time.

We can instead keep both as bytes, which should end up simplifying code in multiple places.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
