### PR TITLE
certificate/signing: increase min required difficulty to 36

### DIFF
--- a/certificate/peer.go
+++ b/certificate/peer.go
@@ -37,7 +37,7 @@ type Config struct {
 	AuthorizationDB   authorization.DBConfig
 	AuthorizationAddr string `default:"127.0.0.1:9000" help:"address for authorization http proxy to listen on"`
 
-	MinDifficulty uint `default:"30" help:"minimum difficulty of the requester's identity required to claim an authorization"`
+	MinDifficulty uint `default:"36" help:"minimum difficulty of the requester's identity required to claim an authorization"`
 }
 
 // Peer is the certificates server.

--- a/cmd/identity/batch.go
+++ b/cmd/identity/batch.go
@@ -41,7 +41,7 @@ var (
 	keyCfg struct {
 		// TODO: where is this used and should it be conistent with "latest" alias?
 		VersionNumber uint   `default:"0" help:"version of identity (0 is latest)"`
-		MinDifficulty int    `help:"minimum difficulty to output" default:"30"`
+		MinDifficulty int    `help:"minimum difficulty to output" default:"36"`
 		Concurrency   int    `help:"worker concurrency" default:"4"`
 		OutputDir     string `help:"output directory to place keys" default:"."`
 	}

--- a/pkg/identity/certificate_authority.go
+++ b/pkg/identity/certificate_authority.go
@@ -53,7 +53,7 @@ type CASetupConfig struct {
 	ParentKeyPath  string `help:"path to the parent authority's private key"`
 	CertPath       string `help:"path to the certificate chain for this identity" default:"$IDENTITYDIR/ca.cert"`
 	KeyPath        string `help:"path to the private key for this identity" default:"$IDENTITYDIR/ca.key"`
-	Difficulty     uint64 `help:"minimum difficulty for identity generation" default:"30"`
+	Difficulty     uint64 `help:"minimum difficulty for identity generation" default:"36"`
 	Timeout        string `help:"timeout for CA generation; golang duration string (0 no timeout)" default:"5m"`
 	Overwrite      bool   `help:"if true, existing CA certs AND keys will overwritten" default:"false" setup:"true"`
 	Concurrency    uint   `help:"number of concurrent workers for certificate authority generation" default:"4"`


### PR DESCRIPTION
What:  After increasing the default difficulty of the `identity create` command (see #3428) and released the new version, we are now increasing the minimum required difficulty in the certificate signing service.

See: https://storjlabs.atlassian.net/browse/V3-2848

Note, this PR also increases the min required difficulty in the `identity batch` command for the sake of consistency.

Why: We want to raise the bar of Proof of Work for new storage nodes.

Please describe the tests: Existing tests should still be enough
 
Please describe the performance impact: None

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
