### PR TITLE
Initialize math/rand default source

### DIFF
--- a/pkg/process/rand.go
+++ b/pkg/process/rand.go
@@ -10,5 +10,5 @@ import (
 
 func init() {
 	// Initialize the seed for the math/rand default source
-	rand.Seed(time.Now().Unix())
+	rand.Seed(time.Now().UnixNano())
 }

--- a/pkg/process/rand.go
+++ b/pkg/process/rand.go
@@ -1,0 +1,14 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package process
+
+import (
+	"math/rand"
+	"time"
+)
+
+func init() {
+	// Initialize the seed for the math/rand default source
+	rand.Seed(time.Now().Unix())
+}


### PR DESCRIPTION
What: 
Seeds the default source in the math/rand package for processes using `pkg/process`.

Why:
Default source is used throughout the codebase. Not seeding the source will cause it to produce the same sequence, meaning the only variability will be based on the order of calls (maybe from different goroutines) on the default source.

Please describe the tests:
N/A
 
Please describe the performance impact:
None