### PR TITLE
storagenode-updater: re-enable auto-update storagenode-updater

### DIFF
--- a/cmd/storagenode-updater/main.go
+++ b/cmd/storagenode-updater/main.go
@@ -121,12 +121,11 @@ func cmdRun(cmd *cobra.Command, args []string) (err error) {
 			log.Println(err)
 		}
 
-		// TODO: enable self-autoupdate back when having reliable recovery mechanism
-		//updaterBinName := os.Args[0]
-		//if err := update(ctx, updaterBinName, updaterServiceName); err != nil {
-		//	// don't finish loop in case of error just wait for another execution
-		//	log.Println(err)
-		//}
+		updaterBinName := os.Args[0]
+		if err := update(ctx, updaterBinName, updaterServiceName); err != nil {
+			// don't finish loop in case of error just wait for another execution
+			log.Println(err)
+		}
 		return nil
 	}
 

--- a/cmd/storagenode-updater/main_test.go
+++ b/cmd/storagenode-updater/main_test.go
@@ -105,10 +105,9 @@ func TestAutoUpdater(t *testing.T) {
 		if !assert.Contains(t, logStr, "storagenode restarted successfully") {
 			t.Log(logStr)
 		}
-		// TODO: re-enable when updater is self-updating
-		//if !assert.Contains(t, logStr, "storagenode-updater restarted successfully") {
-		//	t.Log(logStr)
-		//}
+		if !assert.Contains(t, logStr, "storagenode-updater restarted successfully") {
+			t.Log(logStr)
+		}
 	} else {
 		t.Log(string(out))
 	}
@@ -122,12 +121,11 @@ func TestAutoUpdater(t *testing.T) {
 	require.NotNil(t, oldStoragenodeInfo)
 	require.NotZero(t, oldStoragenodeInfo.Size())
 
-	// TODO: re-enable when updater is self-updating
-	//backupUpdater := ctx.File("fake", "storagenode-updater.old.exe")
-	//backupUpdaterInfo, err := os.Stat(backupUpdater)
-	//require.NoError(t, err)
-	//require.NotNil(t, backupUpdaterInfo)
-	//require.NotZero(t, backupUpdaterInfo.Size())
+	backupUpdater := ctx.File("fake", "storagenode-updater.old.exe")
+	backupUpdaterInfo, err := os.Stat(backupUpdater)
+	require.NoError(t, err)
+	require.NotNil(t, backupUpdaterInfo)
+	require.NotZero(t, backupUpdaterInfo.Size())
 }
 
 func move(t *testing.T, src, dst string) {


### PR DESCRIPTION
What: We are re-enabling the self-auto-updating of stragenode-updater after we fixed the issue with the recovery mechanism.

Why: See https://storjlabs.atlassian.net/browse/V3-2882

Please describe the tests:
 - Test 1: The auto-updating part of the storagenode-updater is re-enabled in TestAutoupater.
 
Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
