### PR TITLE
docs/blueprints: Change adapt endpoint by creating

### DIFF
--- a/docs/blueprints/deletion-performance.md
+++ b/docs/blueprints/deletion-performance.md
@@ -151,7 +151,7 @@ Taking one of these approaches will require a study on how to keep the less amou
 
 1. Adapt protocol buffers definitions for delete operation.
        Satellite doesn't have to send order limits; it only has to send piece ID.
-1. Adapt the delete endpoint to receive requests from the satellite.
+1. Create a new endpoint to receive delete requests from the satellite.
 
 ### (2) Satellite:
 


### PR DESCRIPTION
What: Replace a sentence which indicates that we're creating and new endpoint
in the storage node side rather than adapting the current one.

Why: I forgot to apply that change after it was discussed in the arch meeting and we agreed to create a new one.

Please describe the tests: N/A
Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
