### PR TITLE
storagenode: add storagenode requests metric

### DIFF
--- a/storagenode/contact/chore.go
+++ b/storagenode/contact/chore.go
@@ -77,6 +77,9 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 			interval := initialBackOff
 			attempts := 0
 			for {
+
+				mon.Counter("satellite.request").Inc(1)
+
 				err := chore.pingSatellite(ctx, satellite)
 				attempts++
 				if err == nil {

--- a/storagenode/gracefulexit/chore.go
+++ b/storagenode/gracefulexit/chore.go
@@ -53,6 +53,9 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 
 	err = chore.Loop.Run(ctx, func(ctx context.Context) (err error) {
 		defer mon.Task()(&ctx)(&err)
+
+		mon.Counter("satellite.request").Inc(1)
+
 		chore.log.Debug("checking pending exits")
 
 		satellites, err := chore.satelliteDB.ListGracefulExits(ctx)


### PR DESCRIPTION
What: Add storage node satellite requests metric.

Why: Metric requested by the Data Science team.

Please describe the tests:

1 - Create a pipeline.lua file to run the statreceiver locally:
```lua
source = udpin("127.0.0.1:9000")
destination = parse(print())

deliver(source, destination)
```
2- Change at least one storage node configuration to be captured locally
Ex: `../storagenode/0/config.yaml`

Uncomment and change the following keys:
```yaml
metrics.addr: "127.0.0.1:9000"
metrics.interval: "5s"
```

3- `statreceiver --input pipeline.lua | grep "satellite.request"`
4 - `storj-sim network run`




 
Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
