### PR TITLE
storagenode: add bandwidth metrics

### DIFF
--- a/monkit.lock
+++ b/monkit.lock
@@ -63,3 +63,6 @@ storj.io/storj/satellite/satellitedb."audit_reputation_alpha" FloatVal
 storj.io/storj/satellite/satellitedb."audit_reputation_beta" FloatVal
 storj.io/storj/storagenode/contact."satellite_contact_request" Meter
 storj.io/storj/storagenode/gracefulexit."satellite_gracefulexit_request" Meter
+storj.io/storj/storagenode/monitor."allocated_bandwidth" IntVal
+storj.io/storj/storagenode/monitor."available_bandwidth" IntVal
+storj.io/storj/storagenode/monitor."usage_bandwidth" IntVal

--- a/monkit.lock
+++ b/monkit.lock
@@ -64,5 +64,4 @@ storj.io/storj/satellite/satellitedb."audit_reputation_beta" FloatVal
 storj.io/storj/storagenode/contact."satellite_contact_request" Meter
 storj.io/storj/storagenode/gracefulexit."satellite_gracefulexit_request" Meter
 storj.io/storj/storagenode/monitor."allocated_bandwidth" IntVal
-storj.io/storj/storagenode/monitor."available_bandwidth" IntVal
-storj.io/storj/storagenode/monitor."usage_bandwidth" IntVal
+storj.io/storj/storagenode/monitor."used_bandwidth" IntVal

--- a/storagenode/monitor/monitor.go
+++ b/storagenode/monitor/monitor.go
@@ -197,5 +197,11 @@ func (service *Service) AvailableBandwidth(ctx context.Context) (_ int64, err er
 		return 0, Error.Wrap(err)
 	}
 	allocatedBandwidth := service.allocatedBandwidth
-	return allocatedBandwidth - usage, nil
+	availableBandwidth := allocatedBandwidth - usage
+
+	mon.IntVal("allocated_bandwidth").Observe(allocatedBandwidth) //locked
+	mon.IntVal("usage_bandwidth").Observe(usage)                  //locked
+	mon.IntVal("available_bandwidth").Observe(availableBandwidth) //locked
+
+	return availableBandwidth, nil
 }

--- a/storagenode/monitor/monitor.go
+++ b/storagenode/monitor/monitor.go
@@ -197,11 +197,9 @@ func (service *Service) AvailableBandwidth(ctx context.Context) (_ int64, err er
 		return 0, Error.Wrap(err)
 	}
 	allocatedBandwidth := service.allocatedBandwidth
-	availableBandwidth := allocatedBandwidth - usage
 
 	mon.IntVal("allocated_bandwidth").Observe(allocatedBandwidth) //locked
-	mon.IntVal("usage_bandwidth").Observe(usage)                  //locked
-	mon.IntVal("available_bandwidth").Observe(availableBandwidth) //locked
+	mon.IntVal("used_bandwidth").Observe(usage)                   //locked
 
-	return availableBandwidth, nil
+	return allocatedBandwidth - usage, nil
 }


### PR DESCRIPTION
What: Add storage node bandwidth metrics

Metrics:
- allocated_bandwidth
- usage_bandwidth
- available_bandwidth

Why: Requested by DS team

1 - Create a pipeline.lua file to run the statreceiver locally:
```lua
source = udpin("127.0.0.1:9000")
destination = parse(print())

deliver(source, destination)
```
2- Change at least one storage node configuration to be captured locally
Ex: `../storagenode/0/config.yaml`

Uncomment and change the following keys:
```yaml
metrics.addr: "127.0.0.1:9000"
metrics.interval: "5s"
```

3- `statreceiver --input pipeline.lua | grep -E "allocated_bandwidth|usage_bandwidth|available_bandwidth"`


4 - `storj-sim network run`

_You should see something similar from **stareceiver** :_

![Screen Shot 2019-11-20 at 5 20 48 PM](https://user-images.githubusercontent.com/7319476/69275913-232b0300-0bbc-11ea-9867-b728df6ccffe.png)


 
Please describe the performance impact:


## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
