### PR TITLE
storagenode/gracefulexit: improve logging

### DIFF
--- a/storagenode/gracefulexit/worker.go
+++ b/storagenode/gracefulexit/worker.go
@@ -247,7 +247,7 @@ func (worker *Worker) transferPiece(ctx context.Context, transferPiece *pb.Trans
 			},
 		},
 	}
-	worker.log.Info("piece transfered to new storagenode",
+	worker.log.Info("piece transferred to new storagenode",
 		zap.Stringer("Storagenode ID", addrLimit.Limit.StorageNodeId),
 		zap.Stringer("Satellite ID", worker.satelliteID),
 		zap.Stringer("Piece ID", pieceID))

--- a/storagenode/gracefulexit/worker.go
+++ b/storagenode/gracefulexit/worker.go
@@ -98,7 +98,9 @@ func (worker *Worker) Run(ctx context.Context, done func()) (err error) {
 			worker.limiter.Go(ctx, func() {
 				err = worker.transferPiece(ctx, transferPieceMsg, c)
 				if err != nil {
-					worker.log.Error("failed to transfer piece.", zap.Stringer("Satellite ID", worker.satelliteID), zap.Error(errs.Wrap(err)))
+					worker.log.Error("failed to transfer piece.",
+						zap.Stringer("Satellite ID", worker.satelliteID),
+						zap.Error(errs.Wrap(err)))
 				}
 			})
 
@@ -245,6 +247,10 @@ func (worker *Worker) transferPiece(ctx context.Context, transferPiece *pb.Trans
 			},
 		},
 	}
+	worker.log.Info("piece transfered to new storagenode",
+		zap.Stringer("Storagenode ID", addrLimit.Limit.StorageNodeId),
+		zap.Stringer("Satellite ID", worker.satelliteID),
+		zap.Stringer("Piece ID", pieceID))
 	return c.Send(success)
 }
 
@@ -297,6 +303,9 @@ func (worker *Worker) deleteOnePieceOrAll(ctx context.Context, pieceID *storj.Pi
 			}
 			continue
 		}
+		worker.log.Debug("delete piece",
+			zap.Stringer("Satellite ID", worker.satelliteID),
+			zap.Stringer("Piece ID", id))
 		totalDeleted += size
 	}
 


### PR DESCRIPTION
What: Improve logging.

Why: The graceful exit node was transfering a lot of pieces but didn't print out any log messages.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
