### PR TITLE
satellite/metainfo: Improve piece hash validation

### DIFF
--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -526,7 +526,7 @@ func (endpoint *Endpoint) filterValidPieces(ctx context.Context, pointer *pb.Poi
 			invalidPieces = append(invalidPieces, invalidPiece{
 				NodeID:   piece.NodeId,
 				PieceNum: piece.PieceNum,
-				Reason:   "No order limit for validating the pice hash",
+				Reason:   "No order limit for validating the piece hash",
 			})
 			continue
 		}

--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -468,9 +468,12 @@ func createBucketID(projectID uuid.UUID, bucket []byte) []byte {
 
 // filterValidPieces filter out the invalid remote pieces held by pointer.
 //
+// This method expect the pointer to be valid, so it has to be validated before
+// calling it.
+//
 // The method always return a gRPC status error so the caller can directly
 // return it to the client.
-func (endpoint *Endpoint) filterValidPieces(ctx context.Context, pointer *pb.Pointer, limits []*pb.OrderLimit) (err error) {
+func (endpoint *Endpoint) filterValidPieces(ctx context.Context, pointer *pb.Pointer, originalLimits []*pb.OrderLimit) (err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	if pointer.Type != pb.Pointer_REMOTE {
@@ -514,7 +517,21 @@ func (endpoint *Endpoint) filterValidPieces(ctx context.Context, pointer *pb.Poi
 		}
 		signee := signing.SigneeFromPeerIdentity(peerID)
 
-		err = endpoint.validatePieceHash(ctx, piece, limits, signee)
+		limit := originalLimits[piece.PieceNum]
+		if limit == nil {
+			endpoint.log.Warn("There is not limit for the piece.  Piece removed from pointer",
+				zap.Int32("Piece ID", piece.PieceNum),
+			)
+
+			invalidPieces = append(invalidPieces, invalidPiece{
+				NodeID:   piece.NodeId,
+				PieceNum: piece.PieceNum,
+				Reason:   "No order limit for validating the pice hash",
+			})
+			continue
+		}
+
+		err = endpoint.validatePieceHash(ctx, piece, limit, signee)
 		if err != nil {
 			endpoint.log.Warn("Problem validating piece hash. Pieces removed from pointer", zap.Error(err))
 			invalidPieces = append(invalidPieces, invalidPiece{

--- a/satellite/metainfo/validation.go
+++ b/satellite/metainfo/validation.go
@@ -365,7 +365,7 @@ func (endpoint *Endpoint) validateRedundancy(ctx context.Context, redundancy *pb
 	return nil
 }
 
-func (endpoint *Endpoint) validatePieceHash(ctx context.Context, piece *pb.RemotePiece, limits []*pb.OrderLimit, signee signing.Signee) (err error) {
+func (endpoint *Endpoint) validatePieceHash(ctx context.Context, piece *pb.RemotePiece, originalLimit *pb.OrderLimit, signee signing.Signee) (err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	if piece.Hash == nil {
@@ -386,18 +386,16 @@ func (endpoint *Endpoint) validatePieceHash(ctx context.Context, piece *pb.Remot
 		)
 	}
 
-	limit := limits[piece.PieceNum]
-	if limit != nil {
-		switch {
-		case limit.PieceId != piece.Hash.PieceId:
-			return errs.New("piece hash pieceID (%v) doesn't match limit pieceID (%v). NodeID: %v, PieceNum: %d",
-				piece.Hash.PieceId, limit.PieceId, piece.NodeId, piece.PieceNum,
-			)
-		case limit.Limit < piece.Hash.PieceSize:
-			return errs.New("piece hash PieceSize (%d) is larger than order limit (%d). NodeID: %v, PieceNum: %d",
-				piece.Hash.PieceSize, limit.Limit, piece.NodeId, piece.PieceNum,
-			)
-		}
+	switch {
+	case originalLimit.PieceId != piece.Hash.PieceId:
+		return errs.New("piece hash pieceID (%v) doesn't match limit pieceID (%v). NodeID: %v, PieceNum: %d",
+			piece.Hash.PieceId, originalLimit.PieceId, piece.NodeId, piece.PieceNum,
+		)
+	case originalLimit.Limit < piece.Hash.PieceSize:
+		return errs.New("piece hash PieceSize (%d) is larger than order limit (%d). NodeID: %v, PieceNum: %d",
+			piece.Hash.PieceSize, originalLimit.Limit, piece.NodeId, piece.PieceNum,
+		)
 	}
+
 	return nil
 }


### PR DESCRIPTION
What: Improve the piece hash validation 
The commit also improves the documentation of an internal `metainfo`
method and rename the parameters of 2 methods for clarifying what they
are.

Why: Because we should filter out pieces which don't have an associated original order limit.

Please describe the tests: The current test must pass
Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
