### PR TITLE
satellite/satellitedb/satellitedbtest: flag to run cockroach tests

### DIFF
--- a/satellite/satellitedb/satellitedbtest/run.go
+++ b/satellite/satellitedb/satellitedbtest/run.go
@@ -6,6 +6,7 @@ package satellitedbtest
 // This package should be referenced only in test files!
 
 import (
+	"flag"
 	"strconv"
 	"strings"
 	"testing"
@@ -30,6 +31,8 @@ type Database struct {
 	URL     string
 	Message string
 }
+
+var RunCockroachTests = flag.Bool("run-cockroach-tests", false, "If set, don't skip the CockroachDB-using tests, even though they are not yet fully supported")
 
 // Databases returns default databases.
 func Databases() []SatelliteDatabases {
@@ -101,8 +104,8 @@ func Run(t *testing.T, test func(t *testing.T, db satellite.DB)) {
 		t.Run(dbInfo.MasterDB.Name+"/"+dbInfo.PointerDB.Name, func(t *testing.T) {
 			t.Parallel()
 
-			// TODO: remove this skip once all the sql is cockroachdb compatible
-			if dbInfo.MasterDB.Name == "Cockroach" {
+			// TODO: remove this skip and this flag once all the sql is cockroachdb compatible
+			if dbInfo.MasterDB.Name == "Cockroach" && !*RunCockroachTests {
 				t.Skip("CockroachDB not supported yet")
 			}
 

--- a/satellite/satellitedb/satellitedbtest/run.go
+++ b/satellite/satellitedb/satellitedbtest/run.go
@@ -32,7 +32,7 @@ type Database struct {
 	Message string
 }
 
-var RunCockroachTests = flag.Bool("run-cockroach-tests", false, "If set, don't skip the CockroachDB-using tests, even though they are not yet fully supported")
+var runCockroachTests = flag.Bool("run-cockroach-tests", false, "If set, don't skip the CockroachDB-using tests, even though they are not yet fully supported")
 
 // Databases returns default databases.
 func Databases() []SatelliteDatabases {
@@ -105,7 +105,7 @@ func Run(t *testing.T, test func(t *testing.T, db satellite.DB)) {
 			t.Parallel()
 
 			// TODO: remove this skip and this flag once all the sql is cockroachdb compatible
-			if dbInfo.MasterDB.Name == "Cockroach" && !*RunCockroachTests {
+			if dbInfo.MasterDB.Name == "Cockroach" && !*runCockroachTests {
 				t.Skip("CockroachDB not supported yet")
 			}
 


### PR DESCRIPTION
What:

Add a flag that makes it so CockroachDB-using tests aren't skipped.

Why:

This will make it so we don't need to comment out those lines every time
we want to enable the cockroachdb tests during development.

Once it's ready this flag can go away.

Please describe the tests:
 - No tests exercise this behavior, because it only affects tests and shouldn't affect production use of code in any way.
 
Please describe the performance impact:
 - None

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
