### PR TITLE
installer/windows: fix minor typo

### DIFF
--- a/installer/windows/PublicAddressConfig.wxs
+++ b/installer/windows/PublicAddressConfig.wxs
@@ -17,7 +17,7 @@
 
         <Control Id="PublicAddressLabel" Type="Text" X="20" Y="60" Width="320" Height="16" NoPrefix="yes" Text="External address (&lt;ip&gt;:&lt;port&gt;):" />
         <Control Id="PublicAddress" Type="Edit" Property="STORJ_PUBLIC_ADDRESS" X="20" Y="100" Width="320" Height="18" />
-        <Control Id="PublicAddressDesc" Type="Text" X="20" Y="150" Width="320" Height="32" NoPrefix="yes" Text="The storage node will listen for requests on port 28967. You must configure your router to make this port available for public access. When ready, enter the external IP address or the DDNS you configured and the port your opened on your router." />
+        <Control Id="PublicAddressDesc" Type="Text" X="20" Y="150" Width="320" Height="32" NoPrefix="yes" Text="The storage node will listen for requests on port 28967. You must configure your router to make this port available for public access. When ready, enter the external IP address or the DDNS you configured and the port you opened on your router." />
         <Control Id="PublicAddressHowto" Type="Hyperlink" X="20" Y="190" Width="320" Height="16">
           <Text><![CDATA[<a href="https://documentation.storj.io/dependencies/port-forwarding">Learn how to setup Port Forwarding.</a>]]></Text>
         </Control>


### PR DESCRIPTION
What: Change "your opened" to "you opened"

Why: because it's how it should be

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
