### PR TITLE
satellite/console : remove code for creating user credit in CreateUser, skip TestUserCredits

### DIFF
--- a/satellite/console/service.go
+++ b/satellite/console/service.go
@@ -368,6 +368,8 @@ func (s *Service) CreateUser(ctx context.Context, user CreateUser, tokenSecret R
 		}
 
 		if currentReward != nil {
+			_ = currentReward
+			// NB: Uncomment this block when UserCredits().Create is cockroach compatible
 			// var refID *uuid.UUID
 			// if refUserID != "" {
 			// 	refID, err = uuid.Parse(refUserID)

--- a/satellite/console/service.go
+++ b/satellite/console/service.go
@@ -368,21 +368,21 @@ func (s *Service) CreateUser(ctx context.Context, user CreateUser, tokenSecret R
 		}
 
 		if currentReward != nil {
-			var refID *uuid.UUID
-			if refUserID != "" {
-				refID, err = uuid.Parse(refUserID)
-				if err != nil {
-					return Error.Wrap(err)
-				}
-			}
-			newCredit, err := NewCredit(currentReward, Invitee, u.ID, refID)
-			if err != nil {
-				return err
-			}
-			err = tx.UserCredits().Create(ctx, *newCredit)
-			if err != nil {
-				return err
-			}
+			// var refID *uuid.UUID
+			// if refUserID != "" {
+			// 	refID, err = uuid.Parse(refUserID)
+			// 	if err != nil {
+			// 		return Error.Wrap(err)
+			// 	}
+			// }
+			// newCredit, err := NewCredit(currentReward, Invitee, u.ID, refID)
+			// if err != nil {
+			// 	return err
+			// }
+			// err = tx.UserCredits().Create(ctx, *newCredit)
+			// if err != nil {
+			// 	return err
+			// }
 		}
 
 		return nil

--- a/satellite/console/usercredits_test.go
+++ b/satellite/console/usercredits_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestUserCredits(t *testing.T) {
+	t.Skip("Skip until usercredits.Create method is cockroach compatible")
 	satellitedbtest.Run(t, func(t *testing.T, db satellite.DB) {
 		ctx := testcontext.New(t)
 		defer ctx.Cleanup()

--- a/satellite/console/usercredits_test.go
+++ b/satellite/console/usercredits_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestUserCredits(t *testing.T) {
-	t.Skip("Skip until usercredits.Create method is cockroach compatible")
+	t.Skip("Skip until usercredits.Create method is cockroach compatible. https://github.com/cockroachdb/cockroach/issues/42881")
 	satellitedbtest.Run(t, func(t *testing.T, db satellite.DB) {
 		ctx := testcontext.New(t)
 		defer ctx.Cleanup()


### PR DESCRIPTION
What: Comment out code that creates user credit in satellite console service CreateUser and skip TestUserCredits

Why: We are trying to make sure all of our queries are cockroach compatible. The sql query in `usercredits.Create` is not. In the interest of time, and on the advice of the person who wrote the usercredits system, we are simply bypassing the user credits issue for now, as it is not being used in production

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
