### PR TITLE
uplinkc: Add function restrict_scope

### DIFF
--- a/lib/uplinkc/access_scope.go
+++ b/lib/uplinkc/access_scope.go
@@ -12,6 +12,65 @@ import (
 	libuplink "storj.io/storj/lib/uplink"
 )
 
+//export new_scope
+// new_scope creates new Scope
+func new_scope(satelliteAddress *C.char, apikeyRef C.APIKeyRef, encAccessRef C.EncryptionAccessRef, cerr **C.char) C.ScopeRef {
+	apikey, ok := universe.Get(apikeyRef._handle).(libuplink.APIKey)
+	if !ok {
+		*cerr = C.CString("invalid apikey")
+		return C.ScopeRef{}
+	}
+
+	encAccess, ok := universe.Get(encAccessRef._handle).(*libuplink.EncryptionAccess)
+	if !ok {
+		*cerr = C.CString("invalid encryption access")
+		return C.ScopeRef{}
+	}
+
+	scope := &libuplink.Scope{
+		SatelliteAddr:    C.GoString(satelliteAddress),
+		APIKey:           apikey,
+		EncryptionAccess: encAccess,
+	}
+	return C.ScopeRef{_handle: universe.Add(scope)}
+}
+
+//export get_scope_satellite_address
+// get_scope_satellite_address gets Scope satellite address
+func get_scope_satellite_address(scopeRef C.ScopeRef, cerr **C.char) *C.char {
+	scope, ok := universe.Get(scopeRef._handle).(*libuplink.Scope)
+	if !ok {
+		*cerr = C.CString("invalid scope")
+		return nil
+	}
+
+	return C.CString(scope.SatelliteAddr)
+}
+
+//export get_scope_api_key
+// get_scope_api_key gets Scope APIKey
+func get_scope_api_key(scopeRef C.ScopeRef, cerr **C.char) C.APIKeyRef {
+	scope, ok := universe.Get(scopeRef._handle).(*libuplink.Scope)
+	if !ok {
+		*cerr = C.CString("invalid scope")
+		return C.APIKeyRef{}
+	}
+
+	return C.APIKeyRef{_handle: universe.Add(scope.APIKey)}
+}
+
+//export get_scope_enc_access
+// get_scope_enc_access gets Scope encryption access
+func get_scope_enc_access(scopeRef C.ScopeRef, cerr **C.char) C.EncryptionAccessRef {
+	scope, ok := universe.Get(scopeRef._handle).(*libuplink.Scope)
+	if !ok {
+		*cerr = C.CString("invalid scope")
+		return C.EncryptionAccessRef{}
+	}
+
+	return C.EncryptionAccessRef{_handle: universe.Add(scope.EncryptionAccess)}
+}
+
 //export parse_scope
 // parse_scope parses an Scope
 func parse_scope(val *C.char, cerr **C.char) C.ScopeRef {

--- a/lib/uplinkc/scope.go
+++ b/lib/uplinkc/scope.go
@@ -3,10 +3,17 @@
 
 package main
 
+// #include "uplink_definitions.h"
+import "C"
+
 import (
+	"fmt"
 	"context"
+	"unsafe"
 
 	"storj.io/storj/private/fpath"
+	"storj.io/storj/pkg/macaroon"
+	libuplink "storj.io/storj/lib/uplink"
 )
 
 // scope implements nesting context for foreign api.
@@ -31,4 +38,57 @@ func rootScope(tempDir string) scope {
 func (parent *scope) child() scope {
 	ctx, cancel := context.WithCancel(parent.ctx)
 	return scope{ctx, cancel}
+}
+
+//export restrict_scope
+// restricts a given scope with the provided caveat and encryptionRestrictions
+func restrict_scope(scopeRef C.ScopeRef, caveatRef C.CaveatRef, restrictions **C.EncryptionRestriction, cerr **C.char) C.ScopeRef {
+	//Get apiKey from scope
+	scope, ok := universe.Get(scopeRef._handle).(*libuplink.Scope)
+	if !ok {
+		*cerr = C.CString("invalid scope")
+		return C.ScopeRef{}
+	}
+
+	//Get caveat from ref
+	caveat, ok := universe.Get(caveatRef._handle).(macaroon.Caveat)
+	if !ok {
+		*cerr = C.CString("invalid caveat")
+		return C.ScopeRef{}
+	}
+
+	//Restrict apiKey using caveat
+	//problem: caveat needs to know about encryptionsRestrictions before vv
+	apiKeyRestricted, err := scope.APIKey.Restrict(caveat)
+	if err != nil {
+		*cerr = C.CString("could not restrict apiKey")
+		return C.ScopeRef{}
+	}
+
+	//Convert EncryptionRestrictions to Go
+	restrictionsArray := (*[1 << 30 / unsafe.Sizeof(C.EncryptionRestriction{})]C.EncryptionRestriction)(unsafe.Pointer(restrictions))
+	restrictionsGo := make([]libuplink.EncryptionRestriction, 0)
+	for i := 0; i < len(restrictionsArray); i++ {
+		restrictionsGo = append(restrictionsGo, libuplink.EncryptionRestriction{
+			Bucket:     C.GoString(restrictionsArray[i].bucket),
+			PathPrefix: C.GoString(restrictionsArray[i].path_prefix),
+		})
+	}
+
+	//Create new EncryptionAccess with restrictions
+	//problem: it uses it's own caveat internally
+	_, encAccessRestricted, err := scope.EncryptionAccess.Restrict(apiKeyRestricted, restrictionsGo...) 
+	if err != nil { 
+		*cerr = C.CString(fmt.Sprintf("%+v", err)) 
+		return C.ScopeRef{} 
+	}
+
+	
+	//Construct new scope with the new apikey and restricted encAccess.
+	scopeRestricted := &libuplink.Scope{
+		SatelliteAddr:    scope.SatelliteAddr,
+		APIKey:           apiKeyRestricted,
+		EncryptionAccess: encAccessRestricted,
+	}
+	return C.ScopeRef{_handle: universe.Add(scopeRestricted)}
 }

--- a/lib/uplinkc/uplink_definitions.h
+++ b/lib/uplinkc/uplink_definitions.h
@@ -32,6 +32,7 @@ typedef struct Downloader       { long _handle; } DownloaderRef;
 typedef struct Uploader         { long _handle; } UploaderRef;
 typedef struct EncryptionAccess { long _handle; } EncryptionAccessRef;
 typedef struct Scope            { long _handle; } ScopeRef;
+typedef struct Caveat           { long _handle; } CaveatRef;
 
 typedef struct UplinkConfig {
     struct {
@@ -50,6 +51,12 @@ typedef struct EncryptionParameters {
     CipherSuite cipher_suite;
     int32_t     block_size;
 } EncryptionParameters;
+
+
+typedef struct EncryptionRestriction {
+    char *bucket;
+    char *path_prefix;
+} EncryptionRestriction;
 
 typedef struct RedundancyScheme {
     RedundancyAlgorithm algorithm;


### PR DESCRIPTION
With this PR the function "restrict_scope" is made available to uplinkc.

What: Include "restrict_scope" within uplinkc

Why: uplinkc lacks that feature currently. This implementation uses the more-widely-spread "Scope" instead of only the api_key as PR #3417 uses.
 
Please describe the performance impact: none

## Code Review Checklist (to be filled out by reviewer)
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
