### PR TITLE
cockroach compatibility: rewrite unit tests using testplanet.Start to testplanet.Run

### DIFF
--- a/lib/uplinkc/testdata_test.go
+++ b/lib/uplinkc/testdata_test.go
@@ -11,32 +11,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 
 	"storj.io/storj/private/testcontext"
 	"storj.io/storj/private/testplanet"
 )
-
-func RunPlanet(t *testing.T, run func(ctx *testcontext.Context, planet *testplanet.Planet)) {
-	ctx := testcontext.New(t)
-	defer ctx.Cleanup()
-
-	planet, err := testplanet.NewCustom(
-		zaptest.NewLogger(t, zaptest.Level(zapcore.WarnLevel)),
-		testplanet.Config{
-			SatelliteCount:   1,
-			StorageNodeCount: 5,
-			UplinkCount:      1,
-			Reconfigure:      testplanet.DisablePeerCAWhitelist,
-		},
-	)
-	require.NoError(t, err)
-	defer ctx.Check(planet.Shutdown)
-	planet.Start(ctx)
-
-	run(ctx, planet)
-}
 
 func TestC(t *testing.T) {
 	ctx := testcontext.NewWithTimeout(t, 5*time.Minute)
@@ -71,7 +49,10 @@ func TestC(t *testing.T) {
 					},
 				})
 
-				RunPlanet(t, func(ctx *testcontext.Context, planet *testplanet.Planet) {
+				testplanet.Run(t, testplanet.Config{
+					SatelliteCount: 1, StorageNodeCount: 5, UplinkCount: 1,
+					Reconfigure: testplanet.DisablePeerCAWhitelist,
+				}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 					cmd := exec.Command(testexe)
 					cmd.Dir = filepath.Dir(testexe)
 					cmd.Env = append(os.Environ(),

--- a/pkg/peertls/tlsopts/options_test.go
+++ b/pkg/peertls/tlsopts/options_test.go
@@ -122,29 +122,24 @@ func TestNewOptions(t *testing.T) {
 }
 
 func TestOptions_ServerOption_Peer_CA_Whitelist(t *testing.T) {
-	ctx := testcontext.New(t)
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 0, StorageNodeCount: 2, UplinkCount: 0,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		target := planet.StorageNodes[1].Local()
+		testidentity.CompleteIdentityVersionsTest(t, func(t *testing.T, version storj.IDVersion, ident *identity.FullIdentity) {
+			tlsOptions, err := tlsopts.NewOptions(ident, tlsopts.Config{
+				PeerIDVersions: "*",
+			}, nil)
+			require.NoError(t, err)
 
-	planet, err := testplanet.New(t, 0, 2, 0)
-	require.NoError(t, err)
+			dialer := rpc.NewDefaultDialer(tlsOptions)
 
-	planet.Start(ctx)
-	defer ctx.Check(planet.Shutdown)
+			conn, err := dialer.DialNode(ctx, &target.Node)
+			assert.NotNil(t, conn)
+			assert.NoError(t, err)
 
-	target := planet.StorageNodes[1].Local()
-
-	testidentity.CompleteIdentityVersionsTest(t, func(t *testing.T, version storj.IDVersion, ident *identity.FullIdentity) {
-		tlsOptions, err := tlsopts.NewOptions(ident, tlsopts.Config{
-			PeerIDVersions: "*",
-		}, nil)
-		require.NoError(t, err)
-
-		dialer := rpc.NewDefaultDialer(tlsOptions)
-
-		conn, err := dialer.DialNode(ctx, &target.Node)
-		assert.NotNil(t, conn)
-		assert.NoError(t, err)
-
-		assert.NoError(t, conn.Close())
+			assert.NoError(t, conn.Close())
+		})
 	})
 }
 

--- a/pkg/rpc/rpc_test.go
+++ b/pkg/rpc/rpc_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 
 	"storj.io/storj/pkg/pb"
 	"storj.io/storj/pkg/peertls/tlsopts"
@@ -39,200 +38,180 @@ func TestRPCBuild(t *testing.T) {
 }
 
 func TestDialNode(t *testing.T) {
-	ctx := testcontext.New(t)
-	defer ctx.Cleanup()
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 0, StorageNodeCount: 2, UplinkCount: 0,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		whitelistPath, err := planet.WriteWhitelist(storj.LatestIDVersion())
+		require.NoError(t, err)
 
-	planet, err := testplanet.New(t, 0, 2, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ctx.Check(planet.Shutdown)
+		unsignedIdent, err := testidentity.PregeneratedIdentity(0, storj.LatestIDVersion())
+		require.NoError(t, err)
 
-	whitelistPath, err := planet.WriteWhitelist(storj.LatestIDVersion())
-	require.NoError(t, err)
+		signedIdent, err := testidentity.PregeneratedSignedIdentity(0, storj.LatestIDVersion())
+		require.NoError(t, err)
 
-	planet.Start(ctx)
+		tlsOptions, err := tlsopts.NewOptions(signedIdent, tlsopts.Config{
+			UsePeerCAWhitelist:  true,
+			PeerCAWhitelistPath: whitelistPath,
+			PeerIDVersions:      "*",
+		}, nil)
+		require.NoError(t, err)
 
-	unsignedIdent, err := testidentity.PregeneratedIdentity(0, storj.LatestIDVersion())
-	require.NoError(t, err)
+		dialer := rpc.NewDefaultDialer(tlsOptions)
 
-	signedIdent, err := testidentity.PregeneratedSignedIdentity(0, storj.LatestIDVersion())
-	require.NoError(t, err)
+		unsignedClientOpts, err := tlsopts.NewOptions(unsignedIdent, tlsopts.Config{
+			PeerIDVersions: "*",
+		}, nil)
+		require.NoError(t, err)
 
-	tlsOptions, err := tlsopts.NewOptions(signedIdent, tlsopts.Config{
-		UsePeerCAWhitelist:  true,
-		PeerCAWhitelistPath: whitelistPath,
-		PeerIDVersions:      "*",
-	}, nil)
-	require.NoError(t, err)
+		unsignedDialer := rpc.NewDefaultDialer(unsignedClientOpts)
 
-	dialer := rpc.NewDefaultDialer(tlsOptions)
-
-	unsignedClientOpts, err := tlsopts.NewOptions(unsignedIdent, tlsopts.Config{
-		PeerIDVersions: "*",
-	}, nil)
-	require.NoError(t, err)
-
-	unsignedDialer := rpc.NewDefaultDialer(unsignedClientOpts)
-
-	t.Run("DialNode with invalid targets", func(t *testing.T) {
-		targets := []*pb.Node{
-			{
-				Id:      storj.NodeID{},
-				Address: nil,
-			},
-			{
-				Id: storj.NodeID{},
-				Address: &pb.NodeAddress{
-					Transport: pb.NodeTransport_TCP_TLS_GRPC,
+		t.Run("DialNode with invalid targets", func(t *testing.T) {
+			targets := []*pb.Node{
+				{
+					Id:      storj.NodeID{},
+					Address: nil,
 				},
-			},
-			{
-				Id: storj.NodeID{123},
-				Address: &pb.NodeAddress{
-					Transport: pb.NodeTransport_TCP_TLS_GRPC,
-					Address:   "127.0.0.1:100",
+				{
+					Id: storj.NodeID{},
+					Address: &pb.NodeAddress{
+						Transport: pb.NodeTransport_TCP_TLS_GRPC,
+					},
 				},
-			},
-			{
-				Id: storj.NodeID{},
+				{
+					Id: storj.NodeID{123},
+					Address: &pb.NodeAddress{
+						Transport: pb.NodeTransport_TCP_TLS_GRPC,
+						Address:   "127.0.0.1:100",
+					},
+				},
+				{
+					Id: storj.NodeID{},
+					Address: &pb.NodeAddress{
+						Transport: pb.NodeTransport_TCP_TLS_GRPC,
+						Address:   planet.StorageNodes[1].Addr(),
+					},
+				},
+			}
+
+			for _, target := range targets {
+				tag := fmt.Sprintf("%+v", target)
+
+				timedCtx, cancel := context.WithTimeout(ctx, time.Second)
+				conn, err := dialer.DialNode(timedCtx, target)
+				cancel()
+				assert.Error(t, err, tag)
+				assert.Nil(t, conn, tag)
+			}
+		})
+
+		t.Run("DialNode with valid signed target", func(t *testing.T) {
+			target := &pb.Node{
+				Id: planet.StorageNodes[1].ID(),
 				Address: &pb.NodeAddress{
 					Transport: pb.NodeTransport_TCP_TLS_GRPC,
 					Address:   planet.StorageNodes[1].Addr(),
 				},
-			},
-		}
-
-		for _, target := range targets {
-			tag := fmt.Sprintf("%+v", target)
+			}
 
 			timedCtx, cancel := context.WithTimeout(ctx, time.Second)
 			conn, err := dialer.DialNode(timedCtx, target)
 			cancel()
-			assert.Error(t, err, tag)
-			assert.Nil(t, conn, tag)
-		}
-	})
 
-	t.Run("DialNode with valid signed target", func(t *testing.T) {
-		target := &pb.Node{
-			Id: planet.StorageNodes[1].ID(),
-			Address: &pb.NodeAddress{
-				Transport: pb.NodeTransport_TCP_TLS_GRPC,
-				Address:   planet.StorageNodes[1].Addr(),
-			},
-		}
+			assert.NoError(t, err)
+			require.NotNil(t, conn)
 
-		timedCtx, cancel := context.WithTimeout(ctx, time.Second)
-		conn, err := dialer.DialNode(timedCtx, target)
-		cancel()
+			assert.NoError(t, conn.Close())
+		})
 
-		assert.NoError(t, err)
-		require.NotNil(t, conn)
+		t.Run("DialNode with unsigned identity", func(t *testing.T) {
+			target := &pb.Node{
+				Id: planet.StorageNodes[1].ID(),
+				Address: &pb.NodeAddress{
+					Transport: pb.NodeTransport_TCP_TLS_GRPC,
+					Address:   planet.StorageNodes[1].Addr(),
+				},
+			}
 
-		assert.NoError(t, conn.Close())
-	})
+			timedCtx, cancel := context.WithTimeout(ctx, time.Second)
+			conn, err := unsignedDialer.DialNode(timedCtx, target)
+			cancel()
 
-	t.Run("DialNode with unsigned identity", func(t *testing.T) {
-		target := &pb.Node{
-			Id: planet.StorageNodes[1].ID(),
-			Address: &pb.NodeAddress{
-				Transport: pb.NodeTransport_TCP_TLS_GRPC,
-				Address:   planet.StorageNodes[1].Addr(),
-			},
-		}
+			assert.NotNil(t, conn)
+			require.NoError(t, err)
+			assert.NoError(t, conn.Close())
+		})
 
-		timedCtx, cancel := context.WithTimeout(ctx, time.Second)
-		conn, err := unsignedDialer.DialNode(timedCtx, target)
-		cancel()
+		t.Run("DialAddress with unsigned identity", func(t *testing.T) {
+			timedCtx, cancel := context.WithTimeout(ctx, time.Second)
+			conn, err := unsignedDialer.DialAddressInsecure(timedCtx, planet.StorageNodes[1].Addr())
+			cancel()
 
-		assert.NotNil(t, conn)
-		require.NoError(t, err)
-		assert.NoError(t, conn.Close())
-	})
+			assert.NotNil(t, conn)
+			require.NoError(t, err)
+			assert.NoError(t, conn.Close())
+		})
 
-	t.Run("DialAddress with unsigned identity", func(t *testing.T) {
-		timedCtx, cancel := context.WithTimeout(ctx, time.Second)
-		conn, err := unsignedDialer.DialAddressInsecure(timedCtx, planet.StorageNodes[1].Addr())
-		cancel()
+		t.Run("DialAddress with valid address", func(t *testing.T) {
+			timedCtx, cancel := context.WithTimeout(ctx, time.Second)
+			conn, err := dialer.DialAddressInsecure(timedCtx, planet.StorageNodes[1].Addr())
+			cancel()
 
-		assert.NotNil(t, conn)
-		require.NoError(t, err)
-		assert.NoError(t, conn.Close())
-	})
-
-	t.Run("DialAddress with valid address", func(t *testing.T) {
-		timedCtx, cancel := context.WithTimeout(ctx, time.Second)
-		conn, err := dialer.DialAddressInsecure(timedCtx, planet.StorageNodes[1].Addr())
-		cancel()
-
-		assert.NoError(t, err)
-		require.NotNil(t, conn)
-		assert.NoError(t, conn.Close())
+			assert.NoError(t, err)
+			require.NotNil(t, conn)
+			assert.NoError(t, conn.Close())
+		})
 	})
 }
 
 func TestDialNode_BadServerCertificate(t *testing.T) {
-	ctx := testcontext.New(t)
-	defer ctx.Cleanup()
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 0, StorageNodeCount: 2, UplinkCount: 0,
+		Reconfigure: testplanet.DisablePeerCAWhitelist,
+		Identities:  testidentity.NewPregeneratedIdentities(storj.LatestIDVersion()),
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 
-	planet, err := testplanet.NewCustom(
-		zaptest.NewLogger(t),
-		testplanet.Config{
-			SatelliteCount:   0,
-			StorageNodeCount: 2,
-			UplinkCount:      0,
-			Reconfigure:      testplanet.DisablePeerCAWhitelist,
-			Identities:       testidentity.NewPregeneratedIdentities(storj.LatestIDVersion()),
-		},
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ctx.Check(planet.Shutdown)
+		whitelistPath, err := planet.WriteWhitelist(storj.LatestIDVersion())
+		require.NoError(t, err)
 
-	whitelistPath, err := planet.WriteWhitelist(storj.LatestIDVersion())
-	require.NoError(t, err)
+		ident, err := testidentity.PregeneratedSignedIdentity(0, storj.LatestIDVersion())
+		require.NoError(t, err)
 
-	planet.Start(ctx)
+		tlsOptions, err := tlsopts.NewOptions(ident, tlsopts.Config{
+			UsePeerCAWhitelist:  true,
+			PeerCAWhitelistPath: whitelistPath,
+		}, nil)
+		require.NoError(t, err)
 
-	ident, err := testidentity.PregeneratedSignedIdentity(0, storj.LatestIDVersion())
-	require.NoError(t, err)
+		dialer := rpc.NewDefaultDialer(tlsOptions)
 
-	tlsOptions, err := tlsopts.NewOptions(ident, tlsopts.Config{
-		UsePeerCAWhitelist:  true,
-		PeerCAWhitelistPath: whitelistPath,
-	}, nil)
-	require.NoError(t, err)
+		t.Run("DialNode with bad server certificate", func(t *testing.T) {
+			target := &pb.Node{
+				Id: planet.StorageNodes[1].ID(),
+				Address: &pb.NodeAddress{
+					Transport: pb.NodeTransport_TCP_TLS_GRPC,
+					Address:   planet.StorageNodes[1].Addr(),
+				},
+			}
 
-	dialer := rpc.NewDefaultDialer(tlsOptions)
+			timedCtx, cancel := context.WithTimeout(ctx, time.Second)
+			conn, err := dialer.DialNode(timedCtx, target)
+			cancel()
 
-	t.Run("DialNode with bad server certificate", func(t *testing.T) {
-		target := &pb.Node{
-			Id: planet.StorageNodes[1].ID(),
-			Address: &pb.NodeAddress{
-				Transport: pb.NodeTransport_TCP_TLS_GRPC,
-				Address:   planet.StorageNodes[1].Addr(),
-			},
-		}
+			tag := fmt.Sprintf("%+v", target)
+			assert.Nil(t, conn, tag)
+			require.Error(t, err, tag)
+			assert.Contains(t, err.Error(), "not signed by any CA in the whitelist")
+		})
 
-		timedCtx, cancel := context.WithTimeout(ctx, time.Second)
-		conn, err := dialer.DialNode(timedCtx, target)
-		cancel()
+		t.Run("DialAddress with bad server certificate", func(t *testing.T) {
+			timedCtx, cancel := context.WithTimeout(ctx, time.Second)
+			conn, err := dialer.DialAddressID(timedCtx, planet.StorageNodes[1].Addr(), planet.StorageNodes[1].ID())
+			cancel()
 
-		tag := fmt.Sprintf("%+v", target)
-		assert.Nil(t, conn, tag)
-		require.Error(t, err, tag)
-		assert.Contains(t, err.Error(), "not signed by any CA in the whitelist")
-	})
-
-	t.Run("DialAddress with bad server certificate", func(t *testing.T) {
-		timedCtx, cancel := context.WithTimeout(ctx, time.Second)
-		conn, err := dialer.DialAddressID(timedCtx, planet.StorageNodes[1].Addr(), planet.StorageNodes[1].ID())
-		cancel()
-
-		assert.Nil(t, conn)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not signed by any CA in the whitelist")
+			assert.Nil(t, conn)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not signed by any CA in the whitelist")
+		})
 	})
 }

--- a/private/testplanet/planet_test.go
+++ b/private/testplanet/planet_test.go
@@ -18,48 +18,40 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	ctx := testcontext.New(t)
-	defer ctx.Cleanup()
-
-	test := func(version storj.IDVersion) {
-		planet, err := testplanet.NewWithIdentityVersion(t, &version, 2, 4, 1)
-		require.NoError(t, err)
-		defer ctx.Check(planet.Shutdown)
-
-		planet.Start(ctx)
-
-		for _, satellite := range planet.Satellites {
-			t.Log("SATELLITE", satellite.ID(), satellite.Addr())
-		}
-		for _, storageNode := range planet.StorageNodes {
-			t.Log("STORAGE", storageNode.ID(), storageNode.Addr())
-		}
-		for _, uplink := range planet.Uplinks {
-			t.Log("UPLINK", uplink.ID(), uplink.Addr())
-		}
-
-		for _, sat := range planet.Satellites {
-			satellite := sat.Local().Node
-			for _, sn := range planet.StorageNodes {
-				node := sn.Local()
-				conn, err := sn.Dialer.DialNode(ctx, &satellite)
-				require.NoError(t, err)
-				defer ctx.Check(conn.Close)
-				_, err = conn.NodeClient().CheckIn(ctx, &pb.CheckInRequest{
-					Address:  node.GetAddress().GetAddress(),
-					Version:  &node.Version,
-					Capacity: &node.Capacity,
-					Operator: &node.Operator,
-				})
-				require.NoError(t, err)
-			}
-		}
-		// wait a bit to see whether some failures occur
-		time.Sleep(time.Second)
-	}
-
 	for _, version := range storj.IDVersions {
-		test(version)
+		testplanet.Run(t, testplanet.Config{
+			SatelliteCount: 2, StorageNodeCount: 4, UplinkCount: 1,
+			IdentityVersion: &version,
+		}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+			for _, satellite := range planet.Satellites {
+				t.Log("SATELLITE", satellite.ID(), satellite.Addr())
+			}
+			for _, storageNode := range planet.StorageNodes {
+				t.Log("STORAGE", storageNode.ID(), storageNode.Addr())
+			}
+			for _, uplink := range planet.Uplinks {
+				t.Log("UPLINK", uplink.ID(), uplink.Addr())
+			}
+
+			for _, sat := range planet.Satellites {
+				satellite := sat.Local().Node
+				for _, sn := range planet.StorageNodes {
+					node := sn.Local()
+					conn, err := sn.Dialer.DialNode(ctx, &satellite)
+					require.NoError(t, err)
+					defer ctx.Check(conn.Close)
+					_, err = conn.NodeClient().CheckIn(ctx, &pb.CheckInRequest{
+						Address:  node.GetAddress().GetAddress(),
+						Version:  &node.Version,
+						Capacity: &node.Capacity,
+						Operator: &node.Operator,
+					})
+					require.NoError(t, err)
+				}
+			}
+			// wait a bit to see whether some failures occur
+			time.Sleep(time.Second)
+		})
 	}
 }
 

--- a/storagenode/gracefulexit/endpoint_test.go
+++ b/storagenode/gracefulexit/endpoint_test.go
@@ -15,89 +15,74 @@ import (
 )
 
 func TestGetNonExitingSatellites(t *testing.T) {
-	ctx := testcontext.New(t)
-	defer ctx.Cleanup()
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 3, StorageNodeCount: 1, UplinkCount: 1,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		totalSatelliteCount := len(planet.Satellites)
+		exitingSatelliteCount := 1
+		exitingSatellite := planet.Satellites[0]
+		storagenode := planet.StorageNodes[0]
 
-	totalSatelliteCount := 3
-	exitingSatelliteCount := 1
-	planet, err := testplanet.New(t, totalSatelliteCount, 1, 1)
-	require.NoError(t, err)
-	defer ctx.Check(planet.Shutdown)
+		// set a satellite to already be exiting
+		err := storagenode.DB.Satellites().InitiateGracefulExit(ctx, exitingSatellite.ID(), time.Now().UTC(), 0)
+		require.NoError(t, err)
 
-	planet.Start(ctx)
-	exitingSatellite := planet.Satellites[0]
-	storagenode := planet.StorageNodes[0]
+		nonExitingSatellites, err := storagenode.GracefulExit.Endpoint.GetNonExitingSatellites(ctx, &pb.GetNonExitingSatellitesRequest{})
+		require.NoError(t, err)
+		require.Len(t, nonExitingSatellites.GetSatellites(), totalSatelliteCount-exitingSatelliteCount)
 
-	// set a satellite to already be exiting
-	err = storagenode.DB.Satellites().InitiateGracefulExit(ctx, exitingSatellite.ID(), time.Now().UTC(), 0)
-	require.NoError(t, err)
-
-	nonExitingSatellites, err := storagenode.GracefulExit.Endpoint.GetNonExitingSatellites(ctx, &pb.GetNonExitingSatellitesRequest{})
-	require.NoError(t, err)
-	require.Len(t, nonExitingSatellites.GetSatellites(), totalSatelliteCount-exitingSatelliteCount)
-
-	for _, satellite := range nonExitingSatellites.GetSatellites() {
-		require.NotEqual(t, exitingSatellite.ID(), satellite.NodeId)
-	}
+		for _, satellite := range nonExitingSatellites.GetSatellites() {
+			require.NotEqual(t, exitingSatellite.ID(), satellite.NodeId)
+		}
+	})
 }
 
 func TestInitiateGracefulExit(t *testing.T) {
-	ctx := testcontext.New(t)
-	defer ctx.Cleanup()
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 3, StorageNodeCount: 1, UplinkCount: 1,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		storagenode := planet.StorageNodes[0]
+		exitingSatelliteID := planet.Satellites[0].ID()
 
-	totalSatelliteCount := 3
-	planet, err := testplanet.New(t, totalSatelliteCount, 1, 1)
-	require.NoError(t, err)
-	defer ctx.Check(planet.Shutdown)
+		req := &pb.InitiateGracefulExitRequest{
+			NodeId: exitingSatelliteID,
+		}
 
-	planet.Start(ctx)
-	storagenode := planet.StorageNodes[0]
+		resp, err := storagenode.GracefulExit.Endpoint.InitiateGracefulExit(ctx, req)
+		require.NoError(t, err)
+		// check progress is 0
+		require.EqualValues(t, 0, resp.GetPercentComplete())
+		require.False(t, resp.GetSuccessful())
 
-	exitingSatelliteID := planet.Satellites[0].ID()
-
-	req := &pb.InitiateGracefulExitRequest{
-		NodeId: exitingSatelliteID,
-	}
-
-	resp, err := storagenode.GracefulExit.Endpoint.InitiateGracefulExit(ctx, req)
-	require.NoError(t, err)
-	// check progress is 0
-	require.EqualValues(t, 0, resp.GetPercentComplete())
-	require.False(t, resp.GetSuccessful())
-
-	exitStatuses, err := storagenode.DB.Satellites().ListGracefulExits(ctx)
-	require.NoError(t, err)
-	require.Len(t, exitStatuses, 1)
-	require.Equal(t, exitingSatelliteID, exitStatuses[0].SatelliteID)
+		exitStatuses, err := storagenode.DB.Satellites().ListGracefulExits(ctx)
+		require.NoError(t, err)
+		require.Len(t, exitStatuses, 1)
+		require.Equal(t, exitingSatelliteID, exitStatuses[0].SatelliteID)
+	})
 }
 
 func TestGetExitProgress(t *testing.T) {
-	ctx := testcontext.New(t)
-	defer ctx.Cleanup()
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 3, StorageNodeCount: 1, UplinkCount: 1,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		exitingSatellite := planet.Satellites[0]
+		storagenode := planet.StorageNodes[0]
 
-	totalSatelliteCount := 3
-	planet, err := testplanet.New(t, totalSatelliteCount, 1, 1)
-	require.NoError(t, err)
-	defer ctx.Check(planet.Shutdown)
+		// start graceful exit
+		err := storagenode.DB.Satellites().InitiateGracefulExit(ctx, exitingSatellite.ID(), time.Now().UTC(), 100)
+		require.NoError(t, err)
+		err = storagenode.DB.Satellites().UpdateGracefulExit(ctx, exitingSatellite.ID(), 20)
+		require.NoError(t, err)
 
-	planet.Start(ctx)
-	exitingSatellite := planet.Satellites[0]
-	storagenode := planet.StorageNodes[0]
-
-	// start graceful exit
-	err = storagenode.DB.Satellites().InitiateGracefulExit(ctx, exitingSatellite.ID(), time.Now().UTC(), 100)
-	require.NoError(t, err)
-	err = storagenode.DB.Satellites().UpdateGracefulExit(ctx, exitingSatellite.ID(), 20)
-	require.NoError(t, err)
-
-	// check graceful exit progress
-	resp, err := storagenode.GracefulExit.Endpoint.GetExitProgress(ctx, &pb.GetExitProgressRequest{})
-	require.NoError(t, err)
-	require.Len(t, resp.GetProgress(), 1)
-	progress := resp.GetProgress()[0]
-	require.Equal(t, progress.GetDomainName(), exitingSatellite.Addr())
-	require.Equal(t, progress.NodeId, exitingSatellite.ID())
-	require.EqualValues(t, 20, progress.GetPercentComplete())
-	require.False(t, progress.GetSuccessful())
-	require.Empty(t, progress.GetCompletionReceipt())
+		// check graceful exit progress
+		resp, err := storagenode.GracefulExit.Endpoint.GetExitProgress(ctx, &pb.GetExitProgressRequest{})
+		require.NoError(t, err)
+		require.Len(t, resp.GetProgress(), 1)
+		progress := resp.GetProgress()[0]
+		require.Equal(t, progress.GetDomainName(), exitingSatellite.Addr())
+		require.Equal(t, progress.NodeId, exitingSatellite.ID())
+		require.EqualValues(t, 20, progress.GetPercentComplete())
+		require.False(t, progress.GetSuccessful())
+		require.Empty(t, progress.GetCompletionReceipt())
+	})
 }

--- a/storagenode/piecestore/verification_test.go
+++ b/storagenode/piecestore/verification_test.go
@@ -124,31 +124,147 @@ func TestOrderLimitPutValidation(t *testing.T) {
 	} {
 		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
-			ctx := testcontext.New(t)
-			defer ctx.Cleanup()
+			testplanet.Run(t, testplanet.Config{
+				SatelliteCount: 1, StorageNodeCount: 1, UplinkCount: 1,
+			}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 
-			planet, err := testplanet.New(t, 1, 1, 1)
+				// set desirable bandwidth
+				setBandwidth(ctx, t, planet, tt.availableBandwidth)
+				// set desirable space
+				setSpace(ctx, t, planet, tt.availableSpace)
+
+				client, err := planet.Uplinks[0].DialPiecestore(ctx, planet.StorageNodes[0])
+				require.NoError(t, err)
+				defer ctx.Check(client.Close)
+
+				signer := signing.SignerFromFullIdentity(planet.Satellites[0].Identity)
+				satellite := planet.Satellites[0].Identity
+				if tt.useUnknownSatellite {
+					unapprovedSatellite, err := planet.NewIdentity()
+					require.NoError(t, err)
+					signer = signing.SignerFromFullIdentity(unapprovedSatellite)
+					satellite = unapprovedSatellite
+				}
+
+				orderLimit, piecePrivateKey := GenerateOrderLimit(
+					t,
+					satellite.ID,
+					planet.StorageNodes[0].ID(),
+					tt.pieceID,
+					tt.action,
+					tt.serialNumber,
+					tt.pieceExpiration,
+					tt.orderExpiration,
+					tt.limit,
+				)
+
+				orderLimit, err = signing.SignOrderLimit(ctx, signer, orderLimit)
+				require.NoError(t, err)
+
+				uploader, err := client.Upload(ctx, orderLimit, piecePrivateKey)
+				require.NoError(t, err)
+
+				var writeErr error
+				buffer := make([]byte, memory.KiB)
+				for i := 0; i < 10; i++ {
+					testrand.Read(buffer)
+					_, writeErr = uploader.Write(buffer)
+					if writeErr != nil {
+						break
+					}
+				}
+				_, commitErr := uploader.Commit(ctx)
+				err = errs.Combine(writeErr, commitErr)
+				if tt.err != "" {
+					require.Error(t, err)
+					require.Contains(t, err.Error(), tt.err)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+		})
+	}
+}
+
+func TestOrderLimitGetValidation(t *testing.T) {
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1, StorageNodeCount: 1, UplinkCount: 1,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+
+		defaultPieceSize := 10 * memory.KiB
+
+		for _, storageNode := range planet.StorageNodes {
+			err := storageNode.DB.Bandwidth().Add(ctx, planet.Satellites[0].ID(), pb.PieceAction_GET, memory.TB.Int64()-(15*memory.KiB.Int64()), time.Now())
 			require.NoError(t, err)
-			defer ctx.Check(planet.Shutdown)
+		}
 
-			planet.Start(ctx)
-
-			// set desirable bandwidth
-			setBandwidth(ctx, t, planet, tt.availableBandwidth)
-			// set desirable space
-			setSpace(ctx, t, planet, tt.availableSpace)
-
+		{ // upload test piece
 			client, err := planet.Uplinks[0].DialPiecestore(ctx, planet.StorageNodes[0])
 			require.NoError(t, err)
 			defer ctx.Check(client.Close)
 
 			signer := signing.SignerFromFullIdentity(planet.Satellites[0].Identity)
 			satellite := planet.Satellites[0].Identity
-			if tt.useUnknownSatellite {
-				unapprovedSatellite, err := planet.NewIdentity()
-				require.NoError(t, err)
-				signer = signing.SignerFromFullIdentity(unapprovedSatellite)
-				satellite = unapprovedSatellite
+
+			orderLimit, piecePrivateKey := GenerateOrderLimit(
+				t,
+				satellite.ID,
+				planet.StorageNodes[0].ID(),
+				storj.PieceID{1},
+				pb.PieceAction_PUT,
+				storj.SerialNumber{0},
+				oneWeek,
+				oneWeek,
+				defaultPieceSize.Int64(),
+			)
+
+			orderLimit, err = signing.SignOrderLimit(ctx, signer, orderLimit)
+			require.NoError(t, err)
+
+			uploader, err := client.Upload(ctx, orderLimit, piecePrivateKey)
+			require.NoError(t, err)
+
+			data := testrand.Bytes(defaultPieceSize)
+
+			_, err = uploader.Write(data)
+			require.NoError(t, err)
+			_, err = uploader.Commit(ctx)
+			require.NoError(t, err)
+		}
+
+		// wait for all requests to finish to ensure that the upload usage has been
+		// accounted for.
+		waitForEndpointRequestsToDrain(t, planet)
+
+		for _, tt := range []struct {
+			satellite       *identity.FullIdentity
+			pieceID         storj.PieceID
+			action          pb.PieceAction
+			serialNumber    storj.SerialNumber
+			pieceExpiration time.Duration
+			orderExpiration time.Duration
+			limit           int64
+			err             string
+		}{
+			{ // allocated bandwidth limit
+				pieceID:         storj.PieceID{1},
+				action:          pb.PieceAction_GET,
+				serialNumber:    storj.SerialNumber{1},
+				pieceExpiration: oneWeek,
+				orderExpiration: oneWeek,
+				limit:           10 * memory.KiB.Int64(),
+				err:             "out of bandwidth",
+			},
+		} {
+			client, err := planet.Uplinks[0].DialPiecestore(ctx, planet.StorageNodes[0])
+			require.NoError(t, err)
+			defer ctx.Check(client.Close)
+
+			signer := signing.SignerFromFullIdentity(planet.Satellites[0].Identity)
+			satellite := planet.Satellites[0].Identity
+			if tt.satellite != nil {
+				signer = signing.SignerFromFullIdentity(tt.satellite)
+				satellite = tt.satellite
 			}
 
 			orderLimit, piecePrivateKey := GenerateOrderLimit(
@@ -166,145 +282,21 @@ func TestOrderLimitPutValidation(t *testing.T) {
 			orderLimit, err = signing.SignOrderLimit(ctx, signer, orderLimit)
 			require.NoError(t, err)
 
-			uploader, err := client.Upload(ctx, orderLimit, piecePrivateKey)
+			downloader, err := client.Download(ctx, orderLimit, piecePrivateKey, 0, tt.limit)
 			require.NoError(t, err)
 
-			var writeErr error
-			buffer := make([]byte, memory.KiB)
-			for i := 0; i < 10; i++ {
-				testrand.Read(buffer)
-				_, writeErr = uploader.Write(buffer)
-				if writeErr != nil {
-					break
-				}
-			}
-			_, commitErr := uploader.Commit(ctx)
-			err = errs.Combine(writeErr, commitErr)
+			buffer, readErr := ioutil.ReadAll(downloader)
+			closeErr := downloader.Close()
+			err = errs.Combine(readErr, closeErr)
 			if tt.err != "" {
+				assert.Equal(t, 0, len(buffer))
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.err)
 			} else {
 				require.NoError(t, err)
 			}
-		})
-	}
-}
-
-func TestOrderLimitGetValidation(t *testing.T) {
-	ctx := testcontext.New(t)
-	defer ctx.Cleanup()
-
-	planet, err := testplanet.New(t, 1, 1, 1)
-	require.NoError(t, err)
-	defer ctx.Check(planet.Shutdown)
-
-	planet.Start(ctx)
-
-	defaultPieceSize := 10 * memory.KiB
-
-	for _, storageNode := range planet.StorageNodes {
-		err = storageNode.DB.Bandwidth().Add(ctx, planet.Satellites[0].ID(), pb.PieceAction_GET, memory.TB.Int64()-(15*memory.KiB.Int64()), time.Now())
-		require.NoError(t, err)
-	}
-
-	{ // upload test piece
-		client, err := planet.Uplinks[0].DialPiecestore(ctx, planet.StorageNodes[0])
-		require.NoError(t, err)
-		defer ctx.Check(client.Close)
-
-		signer := signing.SignerFromFullIdentity(planet.Satellites[0].Identity)
-		satellite := planet.Satellites[0].Identity
-
-		orderLimit, piecePrivateKey := GenerateOrderLimit(
-			t,
-			satellite.ID,
-			planet.StorageNodes[0].ID(),
-			storj.PieceID{1},
-			pb.PieceAction_PUT,
-			storj.SerialNumber{0},
-			oneWeek,
-			oneWeek,
-			defaultPieceSize.Int64(),
-		)
-
-		orderLimit, err = signing.SignOrderLimit(ctx, signer, orderLimit)
-		require.NoError(t, err)
-
-		uploader, err := client.Upload(ctx, orderLimit, piecePrivateKey)
-		require.NoError(t, err)
-
-		data := testrand.Bytes(defaultPieceSize)
-
-		_, err = uploader.Write(data)
-		require.NoError(t, err)
-		_, err = uploader.Commit(ctx)
-		require.NoError(t, err)
-	}
-
-	// wait for all requests to finish to ensure that the upload usage has been
-	// accounted for.
-	waitForEndpointRequestsToDrain(t, planet)
-
-	for _, tt := range []struct {
-		satellite       *identity.FullIdentity
-		pieceID         storj.PieceID
-		action          pb.PieceAction
-		serialNumber    storj.SerialNumber
-		pieceExpiration time.Duration
-		orderExpiration time.Duration
-		limit           int64
-		err             string
-	}{
-		{ // allocated bandwidth limit
-			pieceID:         storj.PieceID{1},
-			action:          pb.PieceAction_GET,
-			serialNumber:    storj.SerialNumber{1},
-			pieceExpiration: oneWeek,
-			orderExpiration: oneWeek,
-			limit:           10 * memory.KiB.Int64(),
-			err:             "out of bandwidth",
-		},
-	} {
-		client, err := planet.Uplinks[0].DialPiecestore(ctx, planet.StorageNodes[0])
-		require.NoError(t, err)
-		defer ctx.Check(client.Close)
-
-		signer := signing.SignerFromFullIdentity(planet.Satellites[0].Identity)
-		satellite := planet.Satellites[0].Identity
-		if tt.satellite != nil {
-			signer = signing.SignerFromFullIdentity(tt.satellite)
-			satellite = tt.satellite
 		}
-
-		orderLimit, piecePrivateKey := GenerateOrderLimit(
-			t,
-			satellite.ID,
-			planet.StorageNodes[0].ID(),
-			tt.pieceID,
-			tt.action,
-			tt.serialNumber,
-			tt.pieceExpiration,
-			tt.orderExpiration,
-			tt.limit,
-		)
-
-		orderLimit, err = signing.SignOrderLimit(ctx, signer, orderLimit)
-		require.NoError(t, err)
-
-		downloader, err := client.Download(ctx, orderLimit, piecePrivateKey, 0, tt.limit)
-		require.NoError(t, err)
-
-		buffer, readErr := ioutil.ReadAll(downloader)
-		closeErr := downloader.Close()
-		err = errs.Combine(readErr, closeErr)
-		if tt.err != "" {
-			assert.Equal(t, 0, len(buffer))
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tt.err)
-		} else {
-			require.NoError(t, err)
-		}
-	}
+	})
 }
 
 func setBandwidth(ctx context.Context, t *testing.T, planet *testplanet.Planet, bandwidth int64) {

--- a/storagenode/trust/service_test.go
+++ b/storagenode/trust/service_test.go
@@ -18,43 +18,39 @@ import (
 )
 
 func TestGetSignee(t *testing.T) {
-	ctx := testcontext.New(t)
-	defer ctx.Cleanup()
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1, StorageNodeCount: 1, UplinkCount: 0,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
 
-	planet, err := testplanet.New(t, 1, 1, 0)
-	require.NoError(t, err)
-	defer ctx.Check(planet.Shutdown)
+		trust := planet.StorageNodes[0].Storage2.Trust
 
-	planet.Start(ctx)
+		canceledContext, cancel := context.WithCancel(ctx)
+		cancel()
 
-	trust := planet.StorageNodes[0].Storage2.Trust
-
-	canceledContext, cancel := context.WithCancel(ctx)
-	cancel()
-
-	var group errgroup.Group
-	group.Go(func() error {
-		_, err := trust.GetSignee(canceledContext, planet.Satellites[0].ID())
-		if errs2.IsCanceled(err) {
-			return nil
-		}
-		// if the other goroutine races us,
-		// then we might get the certificate from the cache, however we shouldn't get an error
-		return err
-	})
-
-	group.Go(func() error {
-		cert, err := trust.GetSignee(ctx, planet.Satellites[0].ID())
-		if err != nil {
+		var group errgroup.Group
+		group.Go(func() error {
+			_, err := trust.GetSignee(canceledContext, planet.Satellites[0].ID())
+			if errs2.IsCanceled(err) {
+				return nil
+			}
+			// if the other goroutine races us,
+			// then we might get the certificate from the cache, however we shouldn't get an error
 			return err
-		}
-		if cert == nil {
-			return errors.New("didn't get certificate")
-		}
-		return nil
-	})
+		})
 
-	assert.NoError(t, group.Wait())
+		group.Go(func() error {
+			cert, err := trust.GetSignee(ctx, planet.Satellites[0].ID())
+			if err != nil {
+				return err
+			}
+			if cert == nil {
+				return errors.New("didn't get certificate")
+			}
+			return nil
+		})
+
+		assert.NoError(t, group.Wait())
+	})
 }
 
 func TestGetAddress(t *testing.T) {


### PR DESCRIPTION
What: Rewrite most unit tests that use `planet.Start` to use `planet.Run`. Tests that are skipped for various reasons have not been rewritten. At the time of writing, tests in `pkg/miniogw/gateway_test.go` have not been rewritten due to a bug with pointerDB and running multiple backends.

Why: since we are adding support for cockroachDB in addition to postgres, we would like to run all of our tests with it. `testplanet.Run` runs the unit test with all supported DB backends, `testplanet.Start` does not

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
