### PR TITLE
private/sync2: unlink tmp Tee files immediately.

### DIFF
--- a/private/sync2/io.go
+++ b/private/sync2/io.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"os"
 	"sync/atomic"
-
-	"github.com/zeebo/errs"
 )
 
 // ReadAtWriteAtCloser implements all io.ReaderAt, io.WriterAt and io.Closer
@@ -77,10 +75,7 @@ func (file offsetFile) WriteAt(data []byte, at int64) (amount int, err error) {
 // Close implements io.Closer methods
 func (file offsetFile) Close() error {
 	if atomic.AddInt64(file.open, -1) == 0 {
-		return errs.Combine(
-			file.file.Close(),
-			os.Remove(file.file.Name()),
-		)
+		return file.file.Close()
 	}
 	return nil
 }

--- a/private/sync2/tee.go
+++ b/private/sync2/tee.go
@@ -6,6 +6,7 @@ package sync2
 import (
 	"io"
 	"io/ioutil"
+	"os"
 	"sync"
 	"sync/atomic"
 )
@@ -28,6 +29,15 @@ type tee struct {
 // NewTeeFile returns a tee that uses file-system to offload memory
 func NewTeeFile(readers int, tempdir string) ([]PipeReader, PipeWriter, error) {
 	tempfile, err := ioutil.TempFile(tempdir, "tee")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// https://pubs.opengroup.org/onlinepubs/9699919799/functions/unlink.html
+	// The file will still be available to this process, but will be
+	// cleaned up if this process exits unexpectedly. This is necessary to
+	// prevent filling up the temp space.
+	err = os.Remove(tempfile.Name())
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This is necessary to ensure the tee files are cleaned up if the process
should die. Otherwise it is possible for the process to exit fatally and
leave the temporary files on disk. This has resulted in some hosts
running out of disk space.

What: Unlink temporary tee files immediately.

Why: Otherwise files can be left in temp if the process is killed.

Please describe the tests:
 
Please describe the performance impact:

None

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
