### PR TITLE
satellite/metainfo: don't leak error implementation detail

### DIFF
--- a/satellite/audit/verifier.go
+++ b/satellite/audit/verifier.go
@@ -27,7 +27,6 @@ import (
 	"storj.io/storj/satellite/metainfo"
 	"storj.io/storj/satellite/orders"
 	"storj.io/storj/satellite/overlay"
-	"storj.io/storj/storage"
 	"storj.io/storj/uplink/eestream"
 	"storj.io/storj/uplink/piecestore"
 )
@@ -89,7 +88,7 @@ func (verifier *Verifier) Verify(ctx context.Context, path storj.Path, skip map[
 
 	pointerBytes, pointer, err := verifier.metainfo.GetWithBytes(ctx, path)
 	if err != nil {
-		if storage.ErrKeyNotFound.Has(err) {
+		if storj.ErrObjectNotFound.Has(err) {
 			return Report{}, ErrSegmentDeleted.New("%q", path)
 		}
 		return Report{}, err
@@ -375,7 +374,7 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 
 	pointerBytes, pointer, err := verifier.metainfo.GetWithBytes(ctx, path)
 	if err != nil {
-		if storage.ErrKeyNotFound.Has(err) {
+		if storj.ErrObjectNotFound.Has(err) {
 			return Report{}, ErrSegmentDeleted.New("%q", path)
 		}
 		return Report{}, err
@@ -434,7 +433,7 @@ func (verifier *Verifier) Reverify(ctx context.Context, path storj.Path) (report
 		go func(pending *PendingAudit) {
 			pendingPointerBytes, pendingPointer, err := verifier.metainfo.GetWithBytes(ctx, pending.Path)
 			if err != nil {
-				if storage.ErrKeyNotFound.Has(err) {
+				if storj.ErrObjectNotFound.Has(err) {
 					// segment has been deleted since node was contained
 					_, errDelete := verifier.containment.Delete(ctx, pending.NodeID)
 					if errDelete != nil {
@@ -726,7 +725,7 @@ func (verifier *Verifier) checkIfSegmentAltered(ctx context.Context, segmentPath
 
 	newPointer, err = verifier.metainfo.Get(ctx, segmentPath)
 	if err != nil {
-		if storage.ErrKeyNotFound.Has(err) {
+		if storj.ErrObjectNotFound.Has(err) {
 			return nil, ErrSegmentDeleted.New("%q", segmentPath)
 		}
 		return nil, err

--- a/satellite/metainfo/metainfo.go
+++ b/satellite/metainfo/metainfo.go
@@ -29,7 +29,6 @@ import (
 	"storj.io/storj/satellite/orders"
 	"storj.io/storj/satellite/overlay"
 	"storj.io/storj/satellite/rewards"
-	"storj.io/storj/storage"
 	"storj.io/storj/uplink/eestream"
 	"storj.io/storj/uplink/storage/meta"
 )
@@ -401,7 +400,7 @@ func (endpoint *Endpoint) DeleteSegmentOld(ctx context.Context, req *pb.SegmentD
 	// TODO refactor to use []byte directly
 	pointer, err := endpoint.metainfo.Get(ctx, path)
 	if err != nil {
-		if storage.ErrKeyNotFound.Has(err) {
+		if storj.ErrObjectNotFound.Has(err) {
 			return nil, rpcstatus.Error(rpcstatus.NotFound, err.Error())
 		}
 		return nil, rpcstatus.Error(rpcstatus.Internal, err.Error())
@@ -1300,7 +1299,7 @@ func (endpoint *Endpoint) GetObject(ctx context.Context, req *pb.ObjectGetReques
 
 			pointer, err = endpoint.metainfo.Get(ctx, path)
 			if err != nil {
-				if storage.ErrKeyNotFound.Has(err) {
+				if storj.ErrObjectNotFound.Has(err) {
 					break
 				}
 
@@ -1864,7 +1863,7 @@ func (endpoint *Endpoint) ListSegments(ctx context.Context, req *pb.SegmentListR
 
 	pointer, err := endpoint.metainfo.Get(ctx, path)
 	if err != nil {
-		if storage.ErrKeyNotFound.Has(err) {
+		if storj.ErrObjectNotFound.Has(err) {
 			return nil, rpcstatus.Error(rpcstatus.NotFound, err.Error())
 		}
 		return nil, rpcstatus.Error(rpcstatus.Internal, err.Error())
@@ -1939,7 +1938,7 @@ func (endpoint *Endpoint) listSegmentsManually(ctx context.Context, projectID uu
 		}
 		_, err = endpoint.metainfo.Get(ctx, path)
 		if err != nil {
-			if storage.ErrKeyNotFound.Has(err) {
+			if storj.ErrObjectNotFound.Has(err) {
 				break
 			}
 			return nil, rpcstatus.Error(rpcstatus.Internal, err.Error())
@@ -2097,7 +2096,7 @@ func (endpoint *Endpoint) getPointer(ctx context.Context, projectID uuid.UUID, s
 
 	pointer, err := endpoint.metainfo.Get(ctx, path)
 	if err != nil {
-		if storage.ErrKeyNotFound.Has(err) {
+		if storj.ErrObjectNotFound.Has(err) {
 			return nil, "", rpcstatus.Error(rpcstatus.NotFound, err.Error())
 		}
 		return nil, "", rpcstatus.Error(rpcstatus.Internal, err.Error())

--- a/satellite/metainfo/service.go
+++ b/satellite/metainfo/service.go
@@ -165,6 +165,9 @@ func (s *Service) Get(ctx context.Context, path string) (pointer *pb.Pointer, er
 	defer mon.Task()(&ctx)(&err)
 	pointerBytes, err := s.db.Get(ctx, []byte(path))
 	if err != nil {
+		if storage.ErrKeyNotFound.Has(err) {
+			err = storj.ErrObjectNotFound.Wrap(err)
+		}
 		return nil, Error.Wrap(err)
 	}
 
@@ -183,6 +186,9 @@ func (s *Service) GetWithBytes(ctx context.Context, path string) (pointerBytes [
 
 	pointerBytes, err = s.db.Get(ctx, []byte(path))
 	if err != nil {
+		if storage.ErrKeyNotFound.Has(err) {
+			err = storj.ErrObjectNotFound.Wrap(err)
+		}
 		return nil, nil, Error.Wrap(err)
 	}
 
@@ -280,13 +286,22 @@ func (s *Service) setMetadata(item *pb.ListResponse_Item, data []byte, metaFlags
 func (s *Service) Delete(ctx context.Context, path string, oldPointerBytes []byte) (err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	return Error.Wrap(s.db.CompareAndSwap(ctx, []byte(path), oldPointerBytes, nil))
+	err = s.db.CompareAndSwap(ctx, []byte(path), oldPointerBytes, nil)
+	if storage.ErrKeyNotFound.Has(err) {
+		err = storj.ErrObjectNotFound.Wrap(err)
+	}
+	return Error.Wrap(err)
 }
 
 // UnsynchronizedDelete deletes from item from db without verifying whether the pointer has changed in the database.
 func (s *Service) UnsynchronizedDelete(ctx context.Context, path string) (err error) {
 	defer mon.Task()(&ctx)(&err)
-	return s.db.Delete(ctx, []byte(path))
+
+	err = s.db.Delete(ctx, []byte(path))
+	if storage.ErrKeyNotFound.Has(err) {
+		err = storj.ErrObjectNotFound.Wrap(err)
+	}
+	return Error.Wrap(err)
 }
 
 // CreateBucket creates a new bucket in the buckets db

--- a/satellite/metainfo/service.go
+++ b/satellite/metainfo/service.go
@@ -71,6 +71,9 @@ func (s *Service) UpdatePiecesCheckDuplicates(ctx context.Context, path string, 
 		// read the pointer
 		oldPointerBytes, err := s.db.Get(ctx, []byte(path))
 		if err != nil {
+			if storage.ErrKeyNotFound.Has(err) {
+				err = storj.ErrObjectNotFound.Wrap(err)
+			}
 			return nil, Error.Wrap(err)
 		}
 
@@ -154,6 +157,9 @@ func (s *Service) UpdatePiecesCheckDuplicates(ctx context.Context, path string, 
 			continue
 		}
 		if err != nil {
+			if storage.ErrKeyNotFound.Has(err) {
+				err = storj.ErrObjectNotFound.Wrap(err)
+			}
 			return nil, Error.Wrap(err)
 		}
 		return pointer, nil

--- a/satellite/repair/repairer/segments.go
+++ b/satellite/repair/repairer/segments.go
@@ -18,7 +18,6 @@ import (
 	"storj.io/storj/satellite/metainfo"
 	"storj.io/storj/satellite/orders"
 	"storj.io/storj/satellite/overlay"
-	"storj.io/storj/storage"
 	"storj.io/storj/uplink/eestream"
 )
 
@@ -81,7 +80,7 @@ func (repairer *SegmentRepairer) Repair(ctx context.Context, path storj.Path) (s
 	// Read the segment pointer from the metainfo
 	pointer, err := repairer.metainfo.Get(ctx, path)
 	if err != nil {
-		if storage.ErrKeyNotFound.Has(err) {
+		if storj.ErrObjectNotFound.Has(err) {
 			mon.Meter("repair_unnecessary").Mark(1)
 			repairer.log.Debug("segment was deleted", zap.Binary("Segment", []byte(path)))
 			return true, nil


### PR DESCRIPTION
What: Currently packages were directly using `storage.ErrKeyNotFound` to check for errors from `metainfo.Service`, however `storage` package is an implementation detail for `metainfo`. Users of `metainfo.Service` shouldn't use `storage` package for checking errors. `storj.ErrObjectNotFound` is slightly better, however maybe not perfect.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
