### PR TITLE
Slack the build team instead of everyone

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,7 @@ node('node') {
     echo "Setting build result to FAILURE"
     currentBuild.result = "FAILURE"
 
-    slackSend color: 'danger', message: "@channel ${env.BRANCH_NAME} build failed during stage ${env.STAGE_NAME} ${env.BUILD_URL}"
+    slackSend color: 'danger', message: "@build-team ${env.BRANCH_NAME} build failed during stage ${env.STAGE_NAME} ${env.BUILD_URL}"
 
     mail from: 'builds@storj.io',
       replyTo: 'builds@storj.io',


### PR DESCRIPTION
Change-Id: If55105fa99ebb32fa84dd595258f83838d3150f1



What: Only highlight the build team

Why: @channel is too noisy.

Please describe the tests: none

Please describe the performance impact: none

## Code Review Checklist (to be filled out by reviewer)