### PR TITLE
Fix URL parsing exception for storagenode/trust test case 

### DIFF
--- a/storagenode/trust/excluder_test.go
+++ b/storagenode/trust/excluder_test.go
@@ -22,7 +22,7 @@ func TestNewExcluderFailure(t *testing.T) {
 		{
 			name:   "not a valid URL",
 			config: "://",
-			err:    "exclusion: node URL error: parse ://: missing protocol scheme",
+			err:    "exclusion: node URL error: parse \"://\": missing protocol scheme",
 		},
 		{
 			name:   "host exclusion must not include a port",

--- a/storagenode/trust/http_source_test.go
+++ b/storagenode/trust/http_source_test.go
@@ -25,7 +25,7 @@ func TestHTTPSourceNew(t *testing.T) {
 		{
 			name:    "not a valid URL",
 			httpURL: "://",
-			err:     `HTTP source: "://": not a URL: parse ://: missing protocol scheme`,
+			err:     `HTTP source: "://": not a URL: parse "://": missing protocol scheme`,
 		},
 		{
 			name:    "not an HTTP or HTTPS URL",

--- a/storagenode/trust/satellite_url_test.go
+++ b/storagenode/trust/satellite_url_test.go
@@ -49,7 +49,7 @@ func TestParseSatelliteURL(t *testing.T) {
 		{
 			name: "not a valid URL",
 			url:  "://",
-			err:  `invalid satellite URL: node URL error: parse ://: missing protocol scheme`,
+			err:  `invalid satellite URL: node URL error: parse "://": missing protocol scheme`,
 		},
 		{
 			name: "missing ID",


### PR DESCRIPTION
What: 
Unit tests failing for storagenode/trust

=== RUN   TestHTTPSourceNew/not_a_valid_URL
    TestHTTPSourceNew/not_a_valid_URL: http_source_test.go:54: 
        	Error Trace:	http_source_test.go:54
        	Error:      	Error message not equal:
        	            	expected: "HTTP source: \"://\": not a URL: parse ://: missing protocol scheme"
        	            	actual  : "HTTP source: \"://\": not a URL: parse \"://\": missing protocol scheme"
        	Test:       	TestHTTPSourceNew/not_a_valid_URL

Changed test to match exception.

Why:
Unit test are failing on master due to string format mismatch.

Please describe the tests:
 - Test 1:   go test -v ./storagenode/trust/
 
Please describe the performance impact:
None - updating unit test 

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
