### PR TITLE
accounting/projectlimit: remove expansion factor

### DIFF
--- a/satellite/accounting/projectusage.go
+++ b/satellite/accounting/projectusage.go
@@ -20,9 +20,6 @@ var mon = monkit.Package()
 const (
 	// AverageDaysInMonth is how many days in a month
 	AverageDaysInMonth = 30
-	// ExpansionFactor is the expansion for redundancy, based on the default
-	// redundancy scheme for the uplink.
-	ExpansionFactor = 3
 )
 
 var (
@@ -75,8 +72,7 @@ func (usage *Service) ExceedsBandwidthUsage(ctx context.Context, projectID uuid.
 		return false, 0, ErrProjectUsage.Wrap(err)
 	}
 
-	maxUsage := limit.Int64() * int64(ExpansionFactor)
-	if bandwidthGetTotal >= maxUsage {
+	if bandwidthGetTotal >= limit.Int64() {
 		return true, limit, nil
 	}
 

--- a/satellite/accounting/projectusage_test.go
+++ b/satellite/accounting/projectusage_test.go
@@ -228,8 +228,8 @@ func setUpBucketBandwidthAllocations(ctx *testcontext.Context, projectID uuid.UU
 		bucketName := fmt.Sprintf("%s%d", "testbucket", i)
 
 		// In order to exceed the project limits, create bandwidth allocation records
-		// that sum greater than the maxAlphaUsage * expansionFactor
-		amount := 10 * memory.GB.Int64() * accounting.ExpansionFactor
+		// that sum greater than the maxAlphaUsage
+		amount := 10 * memory.GB.Int64()
 		action := pb.PieceAction_GET
 		intervalStart := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), 0, 0, 0, now.Location())
 		err := orderDB.UpdateBucketBandwidthAllocation(ctx, projectID, []byte(bucketName), action, amount, intervalStart)


### PR DESCRIPTION
What: Remove the expansion factor from the download traffic limit.

Why: Once upon a time we created up to 80 GET orders and they all count against the project limit. We had to factor in the expansion factor. Later we reduce the number of GET orders but we missed to remove the expansion factor.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
