### PR TITLE
web/invoices: display total invoice amount

### DIFF
--- a/satellite/payments/stripecoinpayments/invoices.go
+++ b/satellite/payments/stripecoinpayments/invoices.go
@@ -40,7 +40,7 @@ func (invoices *invoices) List(ctx context.Context, userID uuid.UUID) (invoicesL
 		invoicesList = append(invoicesList, payments.Invoice{
 			ID:          stripeInvoice.ID,
 			Description: stripeInvoice.Description,
-			Amount:      stripeInvoice.AmountDue,
+			Amount:      stripeInvoice.Total,
 			Status:      string(stripeInvoice.Status),
 			Link:        stripeInvoice.InvoicePDF,
 			End:         time.Unix(stripeInvoice.PeriodEnd, 0),


### PR DESCRIPTION
What: Display the total invoice amount.

Why: Previously we displayed only the amount we charged from credit cards. Customers with coinpayments always see a 0 amount invoices. That is confusing.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
