### PR TITLE
script/release: fix error in regex

### DIFF
--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -19,7 +19,7 @@ set -o pipefail
 
 VERSION="${1-}"
 
-if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc+(-.*)?)?+$ ]]; then
+if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc+(-.*)?)?$ ]]; then
   echo "usage: $0 vMAJOR.MINOR.PATCH[-rc[-*]]"
   exit 1
 fi


### PR DESCRIPTION
What: Fix regex error in tag-release script.

Why: ? means 0 or 1 + means at least 1 or more. The combination ?+ was a mistake that works on linux but doesn't work on osx. This fix should make it so that it works on all OS.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
