### PR TITLE
test/rollingupgrade: fix stage 1 release version

### DIFF
--- a/scripts/tests/rollingupgrade/test-sim-rolling-upgrade.sh
+++ b/scripts/tests/rollingupgrade/test-sim-rolling-upgrade.sh
@@ -50,7 +50,7 @@ populate_sno_versions(){
 git fetch --tags
 current_commit=$(git rev-parse HEAD)
 current_release_version=$(git describe --tags $current_commit | cut -d '.' -f 1-2)
-previous_release_version=$(git describe --tags `git rev-list --exclude='*rc*' --exclude=$current_release_version --tags --max-count=1`)
+previous_release_version=$(git describe --tags `git rev-list --exclude='*rc*' --exclude=$current_release_version* --tags --max-count=1`)
 stage1_sat_version=$previous_release_version
 stage1_uplink_version=$previous_release_version
 stage1_storagenode_versions=$(populate_sno_versions $previous_release_version 10)


### PR DESCRIPTION
What: This time the rolling upgrade test was working as long as we are pushing only -rc tags. The second exclude was not working as expected.

Why:
```
root@kali:~/storj# echo $(git describe --tags `git rev-list --exclude='*rc*' --exclude=$current_release_version --tags --max-count=1`)
v0.35.2
root@kali:~/storj# echo $(git describe --tags `git rev-list --exclude='*rc*' --exclude=$current_release_version* --tags --max-count=1`)
v0.34.10
```

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
