### PR TITLE
cmd/storj-sim: Increase storj-sim max-alpha-usage

### DIFF
--- a/cmd/storj-sim/network.go
+++ b/cmd/storj-sim/network.go
@@ -384,6 +384,7 @@ func newNetwork(flags *Flags) (*Processes, error) {
 		coreProcess.Arguments = withCommon(apiProcess.Directory, Arguments{
 			"run": {
 				"--debug.addr", net.JoinHostPort(host, port(satellitePeer, i, debugPeerHTTP)),
+				"--rollup.max-alpha-usage", "200GB",
 			},
 		})
 		coreProcess.WaitForExited(migrationProcess)

--- a/cmd/storj-sim/network.go
+++ b/cmd/storj-sim/network.go
@@ -384,7 +384,6 @@ func newNetwork(flags *Flags) (*Processes, error) {
 		coreProcess.Arguments = withCommon(apiProcess.Directory, Arguments{
 			"run": {
 				"--debug.addr", net.JoinHostPort(host, port(satellitePeer, i, debugPeerHTTP)),
-				"--rollup.max-alpha-usage", "200GB",
 			},
 		})
 		coreProcess.WaitForExited(migrationProcess)

--- a/satellite/accounting/rollup/rollup.go
+++ b/satellite/accounting/rollup/rollup.go
@@ -19,7 +19,7 @@ import (
 // Config contains configurable values for rollup
 type Config struct {
 	Interval      time.Duration `help:"how frequently rollup should run" releaseDefault:"24h" devDefault:"120s"`
-	MaxAlphaUsage memory.Size   `help:"the bandwidth and storage usage limit for the alpha release" releaseDefault:"5GB" devDefault:"25GB"`
+	MaxAlphaUsage memory.Size   `help:"the bandwidth and storage usage limit for the alpha release" releaseDefault:"5GB" devDefault:"200GB"`
 	DeleteTallies bool          `help:"option for deleting tallies after they are rolled up" default:"true"`
 }
 


### PR DESCRIPTION
What: Sets the default max-alpha-usage to 200GB, from a default of 25GB.

Why: Tests can take require more than 25GB.

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
