### PR TITLE
satellite/overlay: prototype to add a queue for selected storage nodes

### DIFF
--- a/satellite/overlay/config.go
+++ b/satellite/overlay/config.go
@@ -21,7 +21,9 @@ var (
 // Config is a configuration for overlay service.
 type Config struct {
 	Node                 NodeSelectionConfig
-	UpdateStatsBatchSize int `help:"number of update requests to process per transaction" default:"100"`
+	UpdateStatsBatchSize int       `help:"number of update requests to process per transaction" default:"100"`
+	QueueMaxSize         int       `help:"the max size of the select storage node queue" default:"1000"`
+	QueueExpiredTime     time.Time `help:"how long until items in the select storaage node queue are stale" default:"60s"`
 }
 
 // NodeSelectionConfig is a configuration struct to determine the minimum

--- a/satellite/overlay/queue.go
+++ b/satellite/overlay/queue.go
@@ -1,0 +1,143 @@
+// Copyright (C) 2019 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package overlay
+
+import (
+	"context"
+	"time"
+
+	"github.com/zeebo/errs"
+	"go.uber.org/zap"
+)
+
+// ErrEmptyQueue is returned when the queue is empty
+var ErrEmptyQueue = errs.New("empty queue")
+
+// selectedStorageNodeQueue is a queue for storing a selection of storage nodes that are used
+// to upload files to. When a request comes in from an uplink to upload a file, we retrieve a list
+// of storagenodes to use from the queue to reduce time processing this info in real time.
+// The queue will always try to have maxSize storage node selections queued up at all times.
+// Items in the queue older than the expiredLimit will be deleted.
+type selectedStorageNodeQueue struct {
+	log          *zap.Logger
+	maxSize      int
+	expiredLimit time.Time
+	data         []storageNodeSelection
+	ch           chan struct{}
+}
+
+func newQueue(log *zap.Logger, size int, expiredLimit time.Time) *selectedStorageNodeQueue {
+	return &selectedStorageNodeQueue{
+		log:          log,
+		maxSize:      size,
+		expiredLimit: expiredLimit,
+		data:         []storageNodeSelection{},
+		ch:           make(chan struct{}, size),
+	}
+}
+
+type storageNodeSelection struct {
+	nodes     []*NodeDossier
+	createdAt time.Time
+}
+
+func (s *storageNodeSelection) isExpired(ctx context.Context, expiredLimit time.Time) bool {
+	if s.createdAt.Sub(time.Now().UTC()) > time.Since(expiredLimit) {
+		return true
+	}
+	return false
+}
+
+func (q *selectedStorageNodeQueue) init(ctx context.Context) error {
+	select {
+	case q.ch <- struct{}{}: // if we can add to the channel, then add one to the queue
+		snSelect, err := q.selectNodes(ctx)
+		if err != nil {
+			return err
+		}
+		q.push(ctx, snSelect)
+	default:
+		// channel is full, meaning the queue is full so we are done
+		return nil
+	}
+	return nil
+}
+
+// Run fills the queue initially and then makes sure it always full
+func (q *selectedStorageNodeQueue) Run(ctx context.Context) error {
+	err := q.init(ctx)
+	if err != nil {
+		return err
+	}
+	go q.continuallyFillQueue(ctx)
+	return nil
+}
+
+func (q *selectedStorageNodeQueue) continuallyFillQueue(ctx context.Context) {
+	for {
+		// this blocks until there is space in the channel. When the channel is able to
+		// accept more that means the queue has space so lets add more items to fill the queue
+		q.ch <- struct{}{}
+		snSelect, err := q.selectNodes(ctx)
+		if err != nil {
+			q.log.Error("selecting nodes for queue", zap.Error(err))
+		}
+		q.push(ctx, snSelect)
+	}
+}
+
+func (q *selectedStorageNodeQueue) selectNodes(ctx context.Context) (_ storageNodeSelection, err error) {
+	defer mon.Task()(&ctx)(&err)
+	// TODO: implement, fill the queue using the same code thats currently used in production to select
+	// storage nodes: overlay.service.FindStorageNodesWithPreferences(ctx, req, &service.config.Node)
+	return storageNodeSelection{}, nil
+}
+
+// Pop gets the next item from the queue
+func (q *selectedStorageNodeQueue) Pop(ctx context.Context) (_ []*NodeDossier, err error) {
+	defer mon.Task()(&ctx)(&err)
+	// grab item out of queue
+	item, err := q.pop(ctx)
+	if err != nil {
+		return []*NodeDossier{}, err
+	}
+	// if the current item is expired then get next item until one is not expired
+	for item.isExpired(ctx, q.expiredLimit) {
+		item, err = q.pop(ctx)
+		if err != nil {
+			return []*NodeDossier{}, err
+		}
+	}
+	return item.nodes, nil
+}
+
+func (q *selectedStorageNodeQueue) pop(ctx context.Context) (_ storageNodeSelection, err error) {
+	defer mon.Task()(&ctx)(&err)
+	if len(q.ch) < 1 {
+		return storageNodeSelection{}, ErrEmptyQueue
+	}
+	nextItem := q.data[0]
+	<-q.ch
+	if len(q.ch) == 0 {
+		q.data = []storageNodeSelection{}
+		return nextItem, nil
+	}
+	q.data = q.data[1:]
+	return nextItem, nil
+}
+
+func (q *selectedStorageNodeQueue) push(ctx context.Context, newitem storageNodeSelection) (err error) {
+	defer mon.Task()(&ctx)(&err)
+	// if the queue is full then remove first item
+	// question: or do we want to return when the queue is full
+	if len(q.ch) == q.maxSize {
+		_, err := q.pop(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	// append to end
+	q.data = append(q.data, newitem)
+	return nil
+}


### PR DESCRIPTION
When an uplink performs some operation, the satellite does a lot of work in real time (i.e. create order limits, finds storage nodes). To improve performance, the satellite could do some or all of this work ahead of time in the background and be ready to go when the request comes in, that would make the uplink operations faster.

This PR is a prototype to explore what it would look like to select storage nodes in the background. 
This prototype does the following:
- Adds a queue to the overlay cache that is for storing selections of storage nodes that the uplink can use to upload files to
- In the background we keep the queue full of selections of storage nodes
- The selections of storage nodes need to expire if they are in the queue for too long

In implementing this prototype the following shortcomings:
- The longer a selection of storage nodes sits in the queue, the more likely it is out of sync with what data we have in the nodes table in the database since that is the source of truth. This seems like a risky tradeoff.
- Ideally we want the size of queue to be dependent on current traffic, increasing the items in the queue when there are a lot of requests coming in, but this could be tricky to implement, so hard coding the queue size seems like a tradeoff we might need to make.
- If we run out of items in the queue because traffic increases, we should default back to the current way we select storage nodes.
- Size of the queue is tricky because we risk the items all being stale if the queue is too large, but we risk defaulting back to default intensive work if we run out of items in the queue.




Please describe the tests:
wip
 
Please describe the performance impact:
wip



Change-Id: I497e7f3135b00b6b0396c8643dac6a9cfd1ff6a3


## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
