### PR TITLE
revert to use the config for storagesync

### DIFF
--- a/storagenode/nodestats/cache.go
+++ b/storagenode/nodestats/cache.go
@@ -67,7 +67,7 @@ func NewCache(log *zap.Logger, config Config, db CacheStorage, service *Service,
 		trust:             trust,
 		maxSleep:          config.MaxSleep,
 		Reputation:        sync2.NewCycle(config.ReputationSync),
-		Storage:           sync2.NewCycle(10 * time.Second),
+		Storage:           sync2.NewCycle(config.StorageSync),
 	}
 }
 


### PR DESCRIPTION
Change-Id: I11920b54736e7e548f5638a9ba5f6380a94d99c4

What: 

An accidental change got merged that was probably for debugging, but now its causing the prod databases to be a 100% cpu use. This PR fixes it.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
