### PR TITLE
satellite/overlay: add changes to selected node benchmarks

### DIFF
--- a/satellite/overlay/benchmark_test.go
+++ b/satellite/overlay/benchmark_test.go
@@ -350,10 +350,8 @@ func BenchmarkNodeSelection(b *testing.B) {
 		})
 
 		b.Run("GetNodesNetwork", func(b *testing.B) {
-			var excludedNetworks = []string{}
-			var err error
 			for i := 0; i < b.N; i++ {
-				excludedNetworks, err = overlaydb.GetNodesNetwork(ctx, excludedIDs)
+				excludedNetworks, err := overlaydb.GetNodesNetwork(ctx, excludedIDs)
 				require.NoError(b, err)
 				require.NotEmpty(b, excludedNetworks)
 			}


### PR DESCRIPTION
Change-Id: I0259af155f9151cc2c7830d10f8907634c5e494f

What/Why: 

Make modifications to the benchmarks for select node cache.  Changes include:
- add a benchmark that selects both new nodes and reputable nodes, with new nodes being newnodefraction amount of new nodes, this simulates how the code is used in production
- add separate bencmarks for `FindStorageNodesWithPreference` and also `GetNodesNetwork` since this will be helpful to understand performance of the selected nodes cache from this [PR](https://github.com/storj/storj/pull/3859)

Please describe the tests:
same as what/why above

 
Please describe the performance impact:

```
count = 5
-benchtime 5s

$ benchstat master.txt benchbranch.txt
name                                                               old time/op  new time/op  delta
NodeSelection/Postgres/Postgres/SelectStorageNodes-12              9.46ms ± 1%  9.50ms ± 2%    ~     (p=0.690 n=5+5)
NodeSelection/Postgres/Postgres/SelectNewStorageNodes-12           9.91ms ± 3%  9.89ms ± 3%    ~     (p=0.841 n=5+5)
NodeSelection/Postgres/Postgres/SelectStorageNodesExclusion-12     21.4ms ± 1%  21.6ms ± 1%    ~     (p=0.056 n=5+5)
NodeSelection/Postgres/Postgres/SelectNewStorageNodesExclusion-12  21.9ms ± 1%  21.8ms ± 1%    ~     (p=0.286 n=5+4)
NodeSelection/Postgres/Postgres/FindStorageNodes-12                40.1ms ± 0%  39.7ms ± 0%  -0.99%  (p=0.008 n=5+5)
NodeSelection/Postgres/Postgres/FindStorageNodesExclusion-12       76.6ms ± 0%  76.6ms ± 1%    ~     (p=0.690 n=5+5)
```

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
