### PR TITLE
satellite/satellitedb: Ensure we just return bucket usage for buckets that exist

### DIFF
--- a/satellite/satellitedb/projectaccounting.go
+++ b/satellite/satellitedb/projectaccounting.go
@@ -465,19 +465,15 @@ func (db *ProjectAccounting) GetBucketTotals(ctx context.Context, projectID uuid
 		Offset: uint64((cursor.Page - 1) * cursor.Limit),
 	}
 
-	bucketNameRange, incrPrefix, err := db.prefixMatch("bucket_name", bucketPrefix)
+	bucketNameRange, incrPrefix, err := db.prefixMatch("name", bucketPrefix)
 	if err != nil {
 		return nil, err
 	}
-	countQuery := db.db.Rebind(`SELECT COUNT(DISTINCT bucket_name)
-	FROM bucket_bandwidth_rollups
-	WHERE project_id = ? AND interval_start >= ? AND interval_start <= ?
-	AND ` + bucketNameRange)
+	countQuery := db.db.Rebind(`SELECT COUNT(name) FROM bucket_metainfos
+	WHERE project_id = ? AND ` + bucketNameRange)
 
 	args := []interface{}{
 		projectID[:],
-		since,
-		before,
 		bucketPrefix,
 	}
 	if incrPrefix != nil {
@@ -499,16 +495,11 @@ func (db *ProjectAccounting) GetBucketTotals(ctx context.Context, projectID uuid
 	}
 
 	var buckets []string
-	bucketsQuery := db.db.Rebind(`SELECT DISTINCT bucket_name
-	FROM bucket_bandwidth_rollups
-	WHERE project_id = ? AND interval_start >= ? AND interval_start <= ?
-	AND ` + bucketNameRange + ` ORDER BY bucket_name ASC
-	LIMIT ? OFFSET ?`)
+	bucketsQuery := db.db.Rebind(`SELECT name FROM bucket_metainfos 
+	WHERE project_id = ? AND ` + bucketNameRange + `ORDER BY name ASC LIMIT ? OFFSET ?`)
 
 	args = []interface{}{
 		projectID[:],
-		since,
-		before,
 		bucketPrefix,
 	}
 	if incrPrefix != nil {


### PR DESCRIPTION
What: Changes the DB Queries to just return data for buckets that still exist to be displayed in the Satellite UI

Why: Currently we return all buckets for the current period, even when deleted.
 
Please describe the performance impact: slightly quicker, due to smaller table/information amount

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
