### PR TITLE
satellite/segment-reaper: Increase maxNumOfSegments

### DIFF
--- a/cmd/segment-reaper/bitmask.go
+++ b/cmd/segment-reaper/bitmask.go
@@ -17,13 +17,13 @@ var errorBitmaskInvalidIdx = errs.Class("invalid index")
 type bitmask uint64
 
 // Set tracks index in mask. It returns an error if index is negative or it's
-// greater than 63.
+// greater than or equal to 15625000.
 func (mask *bitmask) Set(index int) error {
 	switch {
 	case index < 0:
 		return errorBitmaskInvalidIdx.New("negative value (%d)", index)
-	case index > 63:
-		return errorBitmaskInvalidIdx.New("index is greater than 63 (%d)", index)
+	case index >= 15625000:
+		return errorBitmaskInvalidIdx.New("index is greater than or equal to 15625000 (%d)", index)
 	}
 
 	bit := uint64(1) << index
@@ -32,13 +32,13 @@ func (mask *bitmask) Set(index int) error {
 }
 
 // Unset removes bit from index in mask. It returns an error if index is negative or it's
-// greater than 63.
+// greater than or equal to 15625000.
 func (mask *bitmask) Unset(index int) error {
 	switch {
 	case index < 0:
 		return errorBitmaskInvalidIdx.New("negative value (%d)", index)
-	case index > 63:
-		return errorBitmaskInvalidIdx.New("index is greater than 63 (%d)", index)
+	case index >= 15625000:
+		return errorBitmaskInvalidIdx.New("index is greater than or equal to 15625000 (%d)", index)
 	}
 
 	bit := uint64(1) << index
@@ -47,13 +47,13 @@ func (mask *bitmask) Unset(index int) error {
 }
 
 // Has returns true if the index is tracked in mask otherwise false.
-// It returns an error if index is negative or it's greater than 63.
+// It returns an error if index is negative or it's greater than or equal to 15625000.
 func (mask *bitmask) Has(index int) (bool, error) {
 	switch {
 	case index < 0:
 		return false, errorBitmaskInvalidIdx.New("negative value (%d)", index)
-	case index > 63:
-		return false, errorBitmaskInvalidIdx.New("index is greater than 63 (%d)", index)
+	case index >= 15625000:
+		return false, errorBitmaskInvalidIdx.New("index is greater than or equal to 15625000 (%d)", index)
 	}
 
 	bit := uint64(1) << index

--- a/cmd/segment-reaper/observer.go
+++ b/cmd/segment-reaper/observer.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	maxNumOfSegments = 64
+	maxNumOfSegments = 15625000 // max 1 PB files
 	lastSegment      = int(-1)
 	rateLimit        = 0
 )


### PR DESCRIPTION
What: Increase maxNumOfSegments to support files up to 1 PB.

Why: Th3van wanted to stream a 1 TB logfile to storj. Somehow he managed to end up with a bunch of zombie segments. The segment reaper is currently ignoring these files because they have too many segments. Long term we want to redesign the segment reaper but short term we want to make sure it catches even 1 TB files.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
