### PR TITLE
satellite/admin: obvious project name in documentation

### DIFF
--- a/satellite/admin/README.md
+++ b/satellite/admin/README.md
@@ -63,7 +63,7 @@ A successful request:
 ```json
 {
     "ownerId": "ca7aa0fb-442a-4d4e-aa36-a49abddae837",
-    "projectName": "2af8dc53-cadf-4ced-9b5c-e554afdadb51",
+    "projectName": "My Second Project",
 }
 ```
 


### PR DESCRIPTION
What: Update documentation for admin interface

Why: To make it obvious that the admin interface expects a project name and not an id.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
