### PR TITLE
satellite/contact: rm unhelpful verbose logging

### DIFF
--- a/satellite/contact/service.go
+++ b/satellite/contact/service.go
@@ -88,7 +88,7 @@ func (service *Service) PingBack(ctx context.Context, address string, peerID sto
 		pingErrorMessage = fmt.Sprintf("failed to dial storage node (ID: %s) at address %s: %q",
 			peerID, address, err,
 		)
-		service.log.Info("pingBack failed to dial storage node",
+		service.log.Debug("pingBack failed to dial storage node",
 			zap.String("pingErrorMessage", pingErrorMessage),
 		)
 		return pingNodeSuccess, pingErrorMessage, nil
@@ -100,7 +100,7 @@ func (service *Service) PingBack(ctx context.Context, address string, peerID sto
 		mon.Event("failed ping node")
 		pingNodeSuccess = false
 		pingErrorMessage = fmt.Sprintf("failed to ping storage node, your node indicated error code: %d, %q", rpcstatus.Code(err), err)
-		service.log.Info("pingBack pingNode error",
+		service.log.Debug("pingBack pingNode error",
 			zap.Stringer("Node ID", peerID),
 			zap.String("pingErrorMessage", pingErrorMessage),
 		)

--- a/satellite/contact/service.go
+++ b/satellite/contact/service.go
@@ -85,8 +85,12 @@ func (service *Service) PingBack(ctx context.Context, address string, peerID sto
 		// node contact info and do not want to terminate execution by returning an err
 		mon.Event("failed dial")
 		pingNodeSuccess = false
-		pingErrorMessage = fmt.Sprintf("failed to dial storage node (ID: %s) at address %s: %q", peerID, address, err)
-		service.log.Info("pingBack failed to dial storage node", zap.Stringer("Node ID", peerID), zap.String("node address", address), zap.String("pingErrorMessage", pingErrorMessage), zap.Error(err))
+		pingErrorMessage = fmt.Sprintf("failed to dial storage node (ID: %s) at address %s: %q",
+			peerID, address, err,
+		)
+		service.log.Info("pingBack failed to dial storage node",
+			zap.String("pingErrorMessage", pingErrorMessage),
+		)
 		return pingNodeSuccess, pingErrorMessage, nil
 	}
 	defer func() { err = errs.Combine(err, client.Close()) }()
@@ -96,7 +100,10 @@ func (service *Service) PingBack(ctx context.Context, address string, peerID sto
 		mon.Event("failed ping node")
 		pingNodeSuccess = false
 		pingErrorMessage = fmt.Sprintf("failed to ping storage node, your node indicated error code: %d, %q", rpcstatus.Code(err), err)
-		service.log.Info("pingBack pingNode error", zap.Stringer("Node ID", peerID), zap.String("pingErrorMessage", pingErrorMessage), zap.Error(err))
+		service.log.Info("pingBack pingNode error",
+			zap.Stringer("Node ID", peerID),
+			zap.String("pingErrorMessage", pingErrorMessage),
+		)
 	}
 
 	return pingNodeSuccess, pingErrorMessage, nil


### PR DESCRIPTION
Change-Id: I74dc29f18969250fa6838fed9bec8ba7ea160b77


What/Why:
Remove the verbose logging of the contact service ping back errors since it makes up at 99% of the production logs atm and it is not useful.



Please describe the tests:
n/a
 
Please describe the performance impact:
n/a

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
