### PR TITLE
satellite/overlay: enable node selection cache on all satellites

### DIFF
--- a/satellite/overlay/nodeselectioncache.go
+++ b/satellite/overlay/nodeselectioncache.go
@@ -23,7 +23,7 @@ type CacheDB interface {
 
 // CacheConfig is a configuration for overlay node selection cache.
 type CacheConfig struct {
-	Disabled  bool          `help:"disable node cache" releaseDefault:"true" devDefault:"false"`
+	Disabled  bool          `help:"disable node cache" default:"false"`
 	Staleness time.Duration `help:"how stale the node selection cache can be" releaseDefault:"3m" devDefault:"5m"`
 }
 

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -419,7 +419,7 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # orders.settlement-batch-size: 250
 
 # disable node cache
-# overlay.node-selection-cache.disabled: true
+# overlay.node-selection-cache.disabled: false
 
 # how stale the node selection cache can be
 # overlay.node-selection-cache.staleness: 3m0s


### PR DESCRIPTION
What: Enable node selection cache on all satellites.

Why: We have tested it on europe north, fixed it, and are now ready to enable it by default on all satellites.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
