### PR TITLE
cmd/satellite:  Install curl per default to docker image

### DIFF
--- a/cmd/satellite/Dockerfile
+++ b/cmd/satellite/Dockerfile
@@ -29,4 +29,5 @@ COPY --from=ca-cert /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 COPY release/${TAG}/satellite_linux_${GOARCH:-amd64} /app/satellite
 COPY release/${TAG}/inspector_linux_${GOARCH:-amd64} /app/inspector
 COPY cmd/satellite/entrypoint /entrypoint
+RUN apk add --no-cache curl
 ENTRYPOINT ["/entrypoint"]


### PR DESCRIPTION
What: Adds curl as preinstalled binary to our docker image.

Why: Its handy to do requests on the new admin API pods.

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
