### PR TITLE
satellite/accounting: make batch sizes configurable

### DIFF
--- a/private/testplanet/satellite.go
+++ b/private/testplanet/satellite.go
@@ -528,7 +528,10 @@ func (planet *Planet) newSatellites(count int, satelliteDatabases satellitedbtes
 				DeleteTallies:       false,
 			},
 			ReportedRollup: reportedrollup.Config{
-				Interval: defaultInterval,
+				Interval:                defaultInterval,
+				QueueBatchSize:          10000,
+				RollupBatchSize:         1000,
+				ConsumedSerialBatchSize: 10000,
 			},
 			LiveAccounting: live.Config{
 				StorageBackend: "redis://" + redis.Addr() + "?db=0",

--- a/satellite/accounting/reportedrollup/chore.go
+++ b/satellite/accounting/reportedrollup/chore.go
@@ -46,6 +46,16 @@ type Chore struct {
 
 // NewChore creates new chore for flushing the reported serials to the database as rollups.
 func NewChore(log *zap.Logger, db orders.DB, config Config) *Chore {
+	if config.QueueBatchSize == 0 {
+		config.QueueBatchSize = 10000
+	}
+	if config.RollupBatchSize == 0 {
+		config.RollupBatchSize = 1000
+	}
+	if config.ConsumedSerialBatchSize == 0 {
+		config.ConsumedSerialBatchSize = 10000
+	}
+
 	return &Chore{
 		log:    log,
 		db:     db,

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -562,8 +562,17 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # time limit for an entire repair job, from queue pop to upload completion
 # repairer.total-timeout: 45m0s
 
+# default consumed serial batch size
+# reported-rollup.consumed-serial-batch-size: 10000
+
 # how often to flush the reported serial rollups to the database
 # reported-rollup.interval: 5m0s
+
+# default queue batch size
+# reported-rollup.queue-batch-size: 10000
+
+# default rollup batch size
+# reported-rollup.rollup-batch-size: 1000
 
 # the default bandwidth usage limit
 # rollup.default-max-bandwidth: 50.0 GB


### PR DESCRIPTION
What: Plumbs the batch size configuration in to be configurable via a config setting.

Why: We want to go faster..

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
