### PR TITLE
storagenode/trust: Use trusted-satellites list that aligns with the business

### DIFF
--- a/storagenode/trust/config.go
+++ b/storagenode/trust/config.go
@@ -12,7 +12,7 @@ import (
 
 // Config is the trust configuration
 type Config struct {
-	Sources         Sources       `help:"list of trust sources" devDefault:"" releaseDefault:"https://tardigrade.io/trusted-satellites"`
+	Sources         Sources       `help:"list of trust sources" devDefault:"" releaseDefault:"https://storj.io/trusted-satellites"`
 	Exclusions      Exclusions    `help:"list of trust exclusions" devDefault:"" releaseDefault:""`
 	RefreshInterval time.Duration `help:"how often the trust pool should be refreshed" default:"6h"`
 	CachePath       string        `help:"file path where trust lists should be cached" default:"${CONFDIR}/trust-cache.json"`


### PR DESCRIPTION
What: Use the trusted-satellites list on storj.io instead.

Why: The business feels SNOs and storagenodes align with the Storj
brand, not the Tardigrade brand. The SNOs shouldn't need resources on
the tardigrade.io domain then. I think the best way to communicate this
change is with a PR like this. There's a few other moving parts to make
this PR happen though, but if this is an approved change, those parts
can move before this is merged and deployed.

Please describe the tests: none

Please describe the performance impact: none

Before this is merged, the trusted-satellites file needs to be on
storj.io.

After the last storagenode version using tardigrade.io is deprecated,
remove the file on tardigrade.io

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible?
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?