### PR TITLE
storagenode/web: Copy Node ID on click

### DIFF
--- a/web/storagenode/src/app/components/SNOHeader.vue
+++ b/web/storagenode/src/app/components/SNOHeader.vue
@@ -21,7 +21,8 @@
             <div class="header__content-holder__right-area">
                 <div class="header__content-holder__right-area__node-id-container">
                     <b class="header__content-holder__right-area__node-id-container__title">Node ID:</b>
-                    <p class="header__content-holder__right-area__node-id-container__id">{{this.nodeId}}</p>
+                    <input type="text" ref="nodeId" readonly v-bind:value=this.nodeId v-bind:size=this.nodeId.length+1 @focus="copyToClipboard" class="header__content-holder__right-area__node-id-container__id">
+
                 </div>
                 <div class="options-button" @click="openOptionsDropdown" >
                     <SettingsIcon  />
@@ -110,6 +111,11 @@ export default class SNOHeader extends Vue {
 
     public openOptionsDropdown(): void {
         setTimeout(() => this.isOptionsShown = true, 0);
+    }
+
+    public copyToClipboard(): void {
+        (this.$refs.nodeId as Vue & { select(): void }).select();
+        navigator.clipboard.writeText(this.nodeId);
     }
 
     public closeOptionsDropdown(): void {
@@ -246,6 +252,13 @@ export default class SNOHeader extends Vue {
 
                     &__id {
                         font-size: 11px;
+                        color: inherit;
+                        border-style: none;
+                    }
+
+                    &__id:focus {
+                        border-style: none;
+                        outline: none;
                     }
                 }
 


### PR DESCRIPTION
What: When you click on the Node ID bar in the SNOHeader it automatically selects and copies the Node ID to your clipboard.

Why: Adds a bit of polish and user friendliness to the storage node page. If someone is clicking the Node ID they most likely want to copy the entire ID. Would probably be useful for the wallet address as well. 

Please describe the tests:
 - Test 1: Ran storj-sim and viewed a storage node with my changes built. Clicked on the Node ID and pasted the ID to verify it was copied to the clipboard. Don't see any automated tests for UI.
 
Please describe the performance impact: Minimal to none.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
