### PR TITLE
private/dbutil: reduce db connection defaults

### DIFF
--- a/private/dbutil/defaults.go
+++ b/private/dbutil/defaults.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	maxIdleConns    = flag.Int("db.max_idle_conns", 20, "Maximum Amount of Idle Database connections, -1 means the stdlib default")
-	maxOpenConns    = flag.Int("db.max_open_conns", 25, "Maximum Amount of Open Database connections, -1 means the stdlib default")
+	maxIdleConns    = flag.Int("db.max_idle_conns", 1, "Maximum Amount of Idle Database connections, -1 means the stdlib default")
+	maxOpenConns    = flag.Int("db.max_open_conns", 5, "Maximum Amount of Open Database connections, -1 means the stdlib default")
 	connMaxLifetime = flag.Duration("db.conn_max_lifetime", -1, "Maximum Database Connection Lifetime, -1ns means the stdlib default")
 )
 

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -152,10 +152,10 @@ contact.external-address: ""
 # db.conn_max_lifetime: -1ns
 
 # Maximum Amount of Idle Database connections, -1 means the stdlib default
-# db.max_idle_conns: 20
+# db.max_idle_conns: 1
 
 # Maximum Amount of Open Database connections, -1 means the stdlib default
-# db.max_open_conns: 25
+# db.max_open_conns: 5
 
 # address to listen on for debug endpoints
 # debug.addr: 127.0.0.1:0


### PR DESCRIPTION
As we currently do not use even near to that many connections actively, we are just wasting resources.
Reducing the number does not have any  negative effect on performance and in fact might speed things up

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
