### PR TITLE
storagenode/gracefulexit: fix wrong error handling for corrupted pieces

### DIFF
--- a/storagenode/gracefulexit/worker.go
+++ b/storagenode/gracefulexit/worker.go
@@ -235,6 +235,7 @@ func (worker *Worker) transferPiece(ctx context.Context, transferPiece *pb.Trans
 			zap.Stringer("Piece ID", pieceID),
 			zap.Error(errs.Wrap(err)))
 		worker.handleFailure(ctx, pb.TransferFailed_NOT_FOUND, pieceID, c.Send)
+		return err
 	}
 
 	if worker.minBytesPerSecond == 0 {


### PR DESCRIPTION
What: fix the graceful exit behavior when hitting a corrupted piece.

Why: The storage node noticed the corrupted piece but because of the missing `return err` the storage node was messing up an entire batch.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
