### PR TITLE
Raise warning to ensure early notification

### DIFF
--- a/web/storagenode/src/storagenode/satellite.ts
+++ b/web/storagenode/src/storagenode/satellite.ts
@@ -204,7 +204,7 @@ export class SatelliteScores {
     public auditScore: string;
     public suspensionScore: string;
     public statusClassName: string;
-    private readonly WARNING_MINIMUM_SCORE: number = 0.76;
+    private readonly WARNING_MINIMUM_SCORE: number = 0.95;
     private readonly WARNING_CLASSNAME: string = 'warning';
     private readonly DISQUALIFICATION_MINIMUM_SCORE: number = 0.6;
     private readonly DISQUALIFICATION_CLASSNAME: string = 'disqualification';


### PR DESCRIPTION
What: 
I suggest raising the warning minimum score a lot (0.95 in this example) to ensure SNO's actually get an early warning.

Why:
Any score dropping below 0.95 is already a good indication something is wrong. If you want to be conservative I can imagine going with 0.90, but 0.76 means you're already 2/3rds of the way towards serious consequences for the node. This is especially important since the suspension threshold for down time is likely to go up in the future as well.

Please describe the tests:
 - Test 1: NA
 - Test 2: NA
 
Please describe the performance impact: None

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
