### PR TITLE
cmd/storj-sim: fix gateway changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ install-sim: ## install storj-sim
 	## install exact version of storj/gateway
 	mkdir -p .build/gateway-tmp
 	-cd .build/gateway-tmp && go mod init gatewaybuild
-	cd .build/gateway-tmp && go mod edit -replace github.com/minio/minio=github.com/storj/minio@storj && GO111MODULE=on go get storj.io/gateway@master
+	cd .build/gateway-tmp && GO111MODULE=on go get storj.io/gateway@latest
 
 ##@ Test
 

--- a/scripts/tests/rollingupgrade/test-sim-rolling-upgrade.sh
+++ b/scripts/tests/rollingupgrade/test-sim-rolling-upgrade.sh
@@ -110,7 +110,7 @@ install_sim(){
         rm -rf .build/gateway-tmp
         mkdir -p .build/gateway-tmp
         pushd .build/gateway-tmp
-            go mod init gatewaybuild && go mod edit -replace github.com/minio/minio=github.com/storj/minio@storj && GOBIN=${bin_dir} GO111MODULE=on go get storj.io/gateway@master
+            go mod init gatewaybuild && GOBIN=${bin_dir} GO111MODULE=on go get storj.io/gateway@latest
         popd
     fi
 }


### PR DESCRIPTION
What: 

We need to revert some changes to storj-sim and gateway testing.

Why:

When adding multi-tenant (for stargate) features to gateway we changed some stuff with storj-sim. Now that we moved the stargate into its own repo, we need to revert these changes so that storj-sim tests can still work with the gateway without stargate multi-tenant functionality.

For reference, this PR started over in [gerrit](https://review.dev.storj.io/c/storj/storj/+/2837), but moved to github because it was easier to branch off the release branch.

Please describe the tests:
Reverted the stargate support for multi-tenant.
 
Please describe the performance impact:
n/a

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
