### PR TITLE
satellite/config: move repair override from config to default

### DIFF
--- a/satellite/repair/checker/checker.go
+++ b/satellite/repair/checker/checker.go
@@ -34,7 +34,7 @@ type Config struct {
 	IrreparableInterval time.Duration `help:"how frequently irrepairable checker should check for lost pieces" releaseDefault:"30m" devDefault:"0h0m5s"`
 
 	ReliabilityCacheStaleness time.Duration `help:"how stale reliable node cache can be" releaseDefault:"5m" devDefault:"5m"`
-	RepairOverride            int           `help:"override value for repair threshold" default:"0"`
+	RepairOverride            int           `help:"override value for repair threshold" releaseDefault:"52" devDefault:"0"`
 }
 
 // durabilityStats remote segment information.

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -35,7 +35,7 @@
 # checker.reliability-cache-staleness: 5m0s
 
 # override value for repair threshold
-# checker.repair-override: 0
+# checker.repair-override: 52
 
 # percent of held amount disposed to node after leaving withheld
 compensation.dispose-percent: 50


### PR DESCRIPTION
What: Move the repair override from config into the default value

Why: We are going to change the repair override behavior in the future. Because the value is currently specified on all of our satellite configs this means some extra coordination to make sure we don't mess up the release. With this PR we can split that work into 2 steps. First get rid of the override in the satellite configs without the risk to mess up production and in a following release the new implementation with a new default value will get released without having to touch the satellite configs or risk that we forget to update it.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
