### PR TITLE
jenkins/rollingupgrade: sleep 5 seconds between old api startup and database migration

### DIFF
--- a/scripts/tests/rollingupgrade/test-sim-rolling-upgrade.sh
+++ b/scripts/tests/rollingupgrade/test-sim-rolling-upgrade.sh
@@ -274,6 +274,8 @@ old_api_cmd="${test_dir}/local-network/satellite/0/old_satellite run api --confi
 nohup $old_api_cmd &
 # Storing the background process' PID.
 old_api_pid=$!
+# Give the old api endpoint 5 seconds to start to avoid a race condition with the database migration
+sleep 5
 
 # Downloading every file uploaded in stage 1 from the network using the latest commit from master branch for each uplink version
 for ul_version in ${stage2_uplink_versions}; do


### PR DESCRIPTION
What: Sleep 5 seconds between old api startup and database migration

Why: Currently we start storj-sim almost in parallel. If the api endpoint takes more time to start than storj-sim needs to run the database migration the old api endpoint will error out with a database version missmatch. The sleep statement will allow the old api endpoint to come up and we can continue the rolling upgrade test.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
