### PR TITLE
Do accounting rollups on a per node basis

### DIFF
--- a/satellite/accounting/db.go
+++ b/satellite/accounting/db.go
@@ -163,7 +163,7 @@ type StoragenodeAccounting interface {
 	// QueryStorageNodeUsage returns slice of StorageNodeUsage for given period
 	QueryStorageNodeUsage(ctx context.Context, nodeID storj.NodeID, start time.Time, end time.Time) ([]StorageNodeUsage, error)
 	// DeleteTalliesBefore deletes all tallies prior to some time
-	DeleteTalliesBefore(ctx context.Context, latestRollup time.Time) error
+	DeleteTalliesBefore(ctx context.Context, nodeID storj.NodeID, latestRollup time.Time) error
 }
 
 // ProjectAccounting stores information about bandwidth and storage usage for projects

--- a/satellite/accounting/db.go
+++ b/satellite/accounting/db.go
@@ -147,11 +147,13 @@ type StoragenodeAccounting interface {
 	// GetTallies retrieves all tallies
 	GetTallies(ctx context.Context) ([]*StoragenodeStorageTally, error)
 	// GetTalliesSince retrieves all tallies since latestRollup
-	GetTalliesSince(ctx context.Context, latestRollup time.Time) ([]*StoragenodeStorageTally, error)
+	GetTalliesSince(ctx context.Context, nodeID storj.NodeID, latestRollup time.Time) ([]*StoragenodeStorageTally, error)
 	// GetBandwidthSince retrieves all bandwidth rollup entires since latestRollup
-	GetBandwidthSince(ctx context.Context, latestRollup time.Time) ([]*StoragenodeBandwidthRollup, error)
+	GetBandwidthSince(ctx context.Context, nodeID storj.NodeID, latestRollup time.Time) ([]*StoragenodeBandwidthRollup, error)
 	// SaveRollup records tally and bandwidth rollup aggregations to the database
 	SaveRollup(ctx context.Context, latestTally time.Time, stats RollupStats) error
+	// NodeLastTimestamp returns the last tallied time by node, or nil
+	NodeLastTimestamp(ctx context.Context, nodeID storj.NodeID, timestampType string) (time.Time, error)
 	// LastTimestamp records and returns the latest last tallied time.
 	LastTimestamp(ctx context.Context, timestampType string) (time.Time, error)
 	// QueryPaymentInfo queries Nodes and Accounting_Rollup on nodeID

--- a/satellite/accounting/rollup/rollup.go
+++ b/satellite/accounting/rollup/rollup.go
@@ -82,7 +82,6 @@ func (r *Service) Rollup(ctx context.Context) (err error) {
 		if !nodeLastRollup.IsZero() {
 			nodeLastRollup = nodeLastRollup.Add(-r.OrderExpiration)
 		}
-
 		rollupStats := make(accounting.RollupStats)
 		latestTally, err := r.RollupStorage(ctx, id, nodeLastRollup, rollupStats)
 		if err != nil {
@@ -99,7 +98,7 @@ func (r *Service) Rollup(ctx context.Context) (err error) {
 		delete(rollupStats, latestTally)
 		if len(rollupStats) == 0 {
 			r.logger.Info("RollupStats is empty")
-			return nil
+			continue
 		}
 
 		err = r.sdb.SaveRollup(ctx, latestTally, rollupStats)
@@ -124,6 +123,7 @@ func (r *Service) Rollup(ctx context.Context) (err error) {
 func (r *Service) RollupStorage(ctx context.Context, nodeID storj.NodeID, lastRollup time.Time, rollupStats accounting.RollupStats) (latestTally time.Time, err error) {
 	defer mon.Task()(&ctx)(&err)
 	tallies, err := r.sdb.GetTalliesSince(ctx, nodeID, lastRollup)
+
 	if err != nil {
 		return lastRollup, Error.Wrap(err)
 	}

--- a/satellite/accounting/rollup/rollup.go
+++ b/satellite/accounting/rollup/rollup.go
@@ -73,7 +73,6 @@ func (r *Service) Rollup(ctx context.Context) (err error) {
 		return Error.Wrap(err)
 	}
 
-	var overallLatestTally time.Time
 	for _, id := range nodeIDs {
 		nodeLastRollup, err := r.sdb.NodeLastTimestamp(ctx, id, accounting.LastRollup)
 		if err != nil {
@@ -108,15 +107,13 @@ func (r *Service) Rollup(ctx context.Context) (err error) {
 			return Error.Wrap(err)
 		}
 
-		overallLatestTally = latestTally
-	}
-
-	if r.deleteTallies {
-		// Delete already rolled up tallies
-		overallLatestTally = overallLatestTally.Add(-r.OrderExpiration)
-		err = r.sdb.DeleteTalliesBefore(ctx, overallLatestTally)
-		if err != nil {
-			return Error.Wrap(err)
+		if r.deleteTallies {
+			// Delete already rolled up tallies
+			latestTally = latestTally.Add(-r.OrderExpiration)
+			err = r.sdb.DeleteTalliesBefore(ctx, id, latestTally)
+			if err != nil {
+				return Error.Wrap(err)
+			}
 		}
 	}
 

--- a/satellite/accounting/rollup/rollup.go
+++ b/satellite/accounting/rollup/rollup.go
@@ -78,7 +78,6 @@ func (r *Service) Rollup(ctx context.Context) (err error) {
 		if err != nil {
 			return Error.Wrap(err)
 		}
-
 		// unexpired orders with created at times before the last rollup timestamp could still have been added later
 		if !nodeLastRollup.IsZero() {
 			nodeLastRollup = nodeLastRollup.Add(-r.OrderExpiration)

--- a/satellite/accounting/rollup/rollup.go
+++ b/satellite/accounting/rollup/rollup.go
@@ -73,6 +73,7 @@ func (r *Service) Rollup(ctx context.Context) (err error) {
 		return Error.Wrap(err)
 	}
 
+	var overallLatestTally time.Time
 	for _, id := range nodeIDs {
 		nodeLastRollup, err := r.sdb.NodeLastTimestamp(ctx, id, accounting.LastRollup)
 		if err != nil {
@@ -107,15 +108,18 @@ func (r *Service) Rollup(ctx context.Context) (err error) {
 			return Error.Wrap(err)
 		}
 
-		if r.deleteTallies {
-			// Delete already rolled up tallies
-			latestTally = latestTally.Add(-r.OrderExpiration)
-			err = r.sdb.DeleteTalliesBefore(ctx, latestTally)
-			if err != nil {
-				return Error.Wrap(err)
-			}
+		overallLatestTally = latestTally
+	}
+
+	if r.deleteTallies {
+		// Delete already rolled up tallies
+		overallLatestTally = overallLatestTally.Add(-r.OrderExpiration)
+		err = r.sdb.DeleteTalliesBefore(ctx, overallLatestTally)
+		if err != nil {
+			return Error.Wrap(err)
 		}
 	}
+
 	return nil
 }
 

--- a/satellite/accounting/tally/tally_test.go
+++ b/satellite/accounting/tally/tally_test.go
@@ -52,7 +52,7 @@ func TestDeleteTalliesBefore(t *testing.T) {
 			err := planet.Satellites[0].DB.StoragenodeAccounting().SaveTallies(ctx, time.Now(), nodeData)
 			require.NoError(t, err)
 
-			err = planet.Satellites[0].DB.StoragenodeAccounting().DeleteTalliesBefore(ctx, test.eraseBefore)
+			err = planet.Satellites[0].DB.StoragenodeAccounting().DeleteTalliesBefore(ctx, id, test.eraseBefore)
 			require.NoError(t, err)
 
 			raws, err := planet.Satellites[0].DB.StoragenodeAccounting().GetTallies(ctx)

--- a/satellite/core.go
+++ b/satellite/core.go
@@ -416,7 +416,7 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB,
 
 		// Lets add 1 more day so we catch any off by one errors when deleting tallies
 		orderExpirationPlusDay := config.Orders.Expiration + config.Rollup.Interval
-		peer.Accounting.Rollup = rollup.New(peer.Log.Named("accounting:rollup"), peer.DB.StoragenodeAccounting(), config.Rollup.Interval, config.Rollup.DeleteTallies, orderExpirationPlusDay)
+		peer.Accounting.Rollup = rollup.New(peer.Log.Named("accounting:rollup"), peer.DB.StoragenodeAccounting(), peer.DB.OverlayCache(), config.Rollup.Interval, config.Rollup.DeleteTallies, orderExpirationPlusDay)
 		peer.Services.Add(lifecycle.Item{
 			Name:  "accounting:rollup",
 			Run:   peer.Accounting.Rollup.Run,

--- a/satellite/overlay/service.go
+++ b/satellite/overlay/service.go
@@ -47,6 +47,8 @@ type DB interface {
 	// SelectAllStorageNodesUpload returns all nodes that qualify to store data, organized as reputable nodes and new nodes
 	SelectAllStorageNodesUpload(ctx context.Context, selectionCfg NodeSelectionConfig) (reputable, new []*SelectedNode, err error)
 
+	// GetAllNodeIDs returns all node IDs
+	GetAllNodeIDs(ctx context.Context) ([]storj.NodeID, error)
 	// Get looks up the node by nodeID
 	Get(ctx context.Context, nodeID storj.NodeID) (*NodeDossier, error)
 	// KnownOffline filters a set of nodes to offline nodes

--- a/satellite/overlay/service.go
+++ b/satellite/overlay/service.go
@@ -15,6 +15,7 @@ import (
 	"storj.io/common/pb"
 	"storj.io/common/storj"
 	"storj.io/storj/satellite/internalpb"
+	"storj.io/storj/satellite/satellitedb/dbx"
 	"storj.io/storj/storage"
 )
 
@@ -47,8 +48,8 @@ type DB interface {
 	// SelectAllStorageNodesUpload returns all nodes that qualify to store data, organized as reputable nodes and new nodes
 	SelectAllStorageNodesUpload(ctx context.Context, selectionCfg NodeSelectionConfig) (reputable, new []*SelectedNode, err error)
 
-	// GetAllNodeIDs returns all node IDs
-	GetAllNodeIDs(ctx context.Context) ([]storj.NodeID, error)
+	// GetNodeIDs returns node IDs, paged
+	GetNodeIDs(ctx context.Context, limit int, start *dbx.Paged_Node_Id_Continuation) (_ []storj.NodeID, next *dbx.Paged_Node_Id_Continuation, err error)
 	// Get looks up the node by nodeID
 	Get(ctx context.Context, nodeID storj.NodeID) (*NodeDossier, error)
 	// KnownOffline filters a set of nodes to offline nodes

--- a/satellite/satellitedb/dbx/satellitedb.dbx
+++ b/satellite/satellitedb/dbx/satellitedb.dbx
@@ -693,6 +693,12 @@ read all (
 	where storagenode_bandwidth_rollup_phase2.interval_start >= ?
 )
 
+read all (
+	select storagenode_bandwidth_rollup_phase2
+	where storagenode_bandwidth_rollup_phase2.storagenode_id = ?
+	where storagenode_bandwidth_rollup_phase2.interval_start >= ?
+)
+
 model storagenode_storage_tally (
 	// this primary key will enforce uniqueness on interval_end_time,node_id
 	// and also creates an index on interval_end_time implicitly.
@@ -716,6 +722,12 @@ read all (
 read all (
     select storagenode_storage_tally
     where storagenode_storage_tally.interval_end_time >= ?
+)
+
+read all (
+    select storagenode_storage_tally
+    where storagenode_storage_tally.node_id = ?
+	where storagenode_storage_tally.interval_end_time >= ?
 )
 
 // --- storage node payment tables --- //

--- a/satellite/satellitedb/dbx/satellitedb.dbx
+++ b/satellite/satellitedb/dbx/satellitedb.dbx
@@ -200,7 +200,7 @@ read one (
 	where  node.id = ?
 )
 
-read all (
+read paged (
 	select node.id
 )
 

--- a/satellite/satellitedb/dbx/satellitedb.dbx
+++ b/satellite/satellitedb/dbx/satellitedb.dbx
@@ -668,6 +668,12 @@ read all (
 	where storagenode_bandwidth_rollup.interval_start = ?
 )
 
+read all (
+	select storagenode_bandwidth_rollup
+	where storagenode_bandwidth_rollup.storagenode_id = ?
+	where storagenode_bandwidth_rollup.interval_start >= ?
+)
+
 ///////////////////////////////////////
 // orders phase2->phase3 rollout table
 ///////////////////////////////////////

--- a/satellite/satellitedb/dbx/satellitedb.dbx.go
+++ b/satellite/satellitedb/dbx/satellitedb.dbx.go
@@ -11782,6 +11782,41 @@ func (obj *pgxImpl) All_StoragenodeBandwidthRollup_By_StoragenodeId_And_Interval
 
 }
 
+func (obj *pgxImpl) All_StoragenodeBandwidthRollup_By_StoragenodeId_And_IntervalStart_GreaterOrEqual(ctx context.Context,
+	storagenode_bandwidth_rollup_storagenode_id StoragenodeBandwidthRollup_StoragenodeId_Field,
+	storagenode_bandwidth_rollup_interval_start_greater_or_equal StoragenodeBandwidthRollup_IntervalStart_Field) (
+	rows []*StoragenodeBandwidthRollup, err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	var __embed_stmt = __sqlbundle_Literal("SELECT storagenode_bandwidth_rollups.storagenode_id, storagenode_bandwidth_rollups.interval_start, storagenode_bandwidth_rollups.interval_seconds, storagenode_bandwidth_rollups.action, storagenode_bandwidth_rollups.allocated, storagenode_bandwidth_rollups.settled FROM storagenode_bandwidth_rollups WHERE storagenode_bandwidth_rollups.storagenode_id = ? AND storagenode_bandwidth_rollups.interval_start >= ?")
+
+	var __values []interface{}
+	__values = append(__values, storagenode_bandwidth_rollup_storagenode_id.value(), storagenode_bandwidth_rollup_interval_start_greater_or_equal.value())
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	__rows, err := obj.driver.QueryContext(ctx, __stmt, __values...)
+	if err != nil {
+		return nil, obj.makeErr(err)
+	}
+	defer __rows.Close()
+
+	for __rows.Next() {
+		storagenode_bandwidth_rollup := &StoragenodeBandwidthRollup{}
+		err = __rows.Scan(&storagenode_bandwidth_rollup.StoragenodeId, &storagenode_bandwidth_rollup.IntervalStart, &storagenode_bandwidth_rollup.IntervalSeconds, &storagenode_bandwidth_rollup.Action, &storagenode_bandwidth_rollup.Allocated, &storagenode_bandwidth_rollup.Settled)
+		if err != nil {
+			return nil, obj.makeErr(err)
+		}
+		rows = append(rows, storagenode_bandwidth_rollup)
+	}
+	if err := __rows.Err(); err != nil {
+		return nil, obj.makeErr(err)
+	}
+	return rows, nil
+
+}
+
 func (obj *pgxImpl) All_StoragenodeBandwidthRollupPhase2_By_IntervalStart_GreaterOrEqual(ctx context.Context,
 	storagenode_bandwidth_rollup_phase2_interval_start_greater_or_equal StoragenodeBandwidthRollupPhase2_IntervalStart_Field) (
 	rows []*StoragenodeBandwidthRollupPhase2, err error) {
@@ -18132,6 +18167,41 @@ func (obj *pgxcockroachImpl) All_StoragenodeBandwidthRollup_By_StoragenodeId_And
 
 }
 
+func (obj *pgxcockroachImpl) All_StoragenodeBandwidthRollup_By_StoragenodeId_And_IntervalStart_GreaterOrEqual(ctx context.Context,
+	storagenode_bandwidth_rollup_storagenode_id StoragenodeBandwidthRollup_StoragenodeId_Field,
+	storagenode_bandwidth_rollup_interval_start_greater_or_equal StoragenodeBandwidthRollup_IntervalStart_Field) (
+	rows []*StoragenodeBandwidthRollup, err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	var __embed_stmt = __sqlbundle_Literal("SELECT storagenode_bandwidth_rollups.storagenode_id, storagenode_bandwidth_rollups.interval_start, storagenode_bandwidth_rollups.interval_seconds, storagenode_bandwidth_rollups.action, storagenode_bandwidth_rollups.allocated, storagenode_bandwidth_rollups.settled FROM storagenode_bandwidth_rollups WHERE storagenode_bandwidth_rollups.storagenode_id = ? AND storagenode_bandwidth_rollups.interval_start >= ?")
+
+	var __values []interface{}
+	__values = append(__values, storagenode_bandwidth_rollup_storagenode_id.value(), storagenode_bandwidth_rollup_interval_start_greater_or_equal.value())
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	__rows, err := obj.driver.QueryContext(ctx, __stmt, __values...)
+	if err != nil {
+		return nil, obj.makeErr(err)
+	}
+	defer __rows.Close()
+
+	for __rows.Next() {
+		storagenode_bandwidth_rollup := &StoragenodeBandwidthRollup{}
+		err = __rows.Scan(&storagenode_bandwidth_rollup.StoragenodeId, &storagenode_bandwidth_rollup.IntervalStart, &storagenode_bandwidth_rollup.IntervalSeconds, &storagenode_bandwidth_rollup.Action, &storagenode_bandwidth_rollup.Allocated, &storagenode_bandwidth_rollup.Settled)
+		if err != nil {
+			return nil, obj.makeErr(err)
+		}
+		rows = append(rows, storagenode_bandwidth_rollup)
+	}
+	if err := __rows.Err(); err != nil {
+		return nil, obj.makeErr(err)
+	}
+	return rows, nil
+
+}
+
 func (obj *pgxcockroachImpl) All_StoragenodeBandwidthRollupPhase2_By_IntervalStart_GreaterOrEqual(ctx context.Context,
 	storagenode_bandwidth_rollup_phase2_interval_start_greater_or_equal StoragenodeBandwidthRollupPhase2_IntervalStart_Field) (
 	rows []*StoragenodeBandwidthRollupPhase2, err error) {
@@ -21913,6 +21983,17 @@ func (rx *Rx) All_StoragenodeBandwidthRollup_By_StoragenodeId_And_IntervalStart(
 	return tx.All_StoragenodeBandwidthRollup_By_StoragenodeId_And_IntervalStart(ctx, storagenode_bandwidth_rollup_storagenode_id, storagenode_bandwidth_rollup_interval_start)
 }
 
+func (rx *Rx) All_StoragenodeBandwidthRollup_By_StoragenodeId_And_IntervalStart_GreaterOrEqual(ctx context.Context,
+	storagenode_bandwidth_rollup_storagenode_id StoragenodeBandwidthRollup_StoragenodeId_Field,
+	storagenode_bandwidth_rollup_interval_start_greater_or_equal StoragenodeBandwidthRollup_IntervalStart_Field) (
+	rows []*StoragenodeBandwidthRollup, err error) {
+	var tx *Tx
+	if tx, err = rx.getTx(ctx); err != nil {
+		return
+	}
+	return tx.All_StoragenodeBandwidthRollup_By_StoragenodeId_And_IntervalStart_GreaterOrEqual(ctx, storagenode_bandwidth_rollup_storagenode_id, storagenode_bandwidth_rollup_interval_start_greater_or_equal)
+}
+
 func (rx *Rx) All_StoragenodeStorageTally(ctx context.Context) (
 	rows []*StoragenodeStorageTally, err error) {
 	var tx *Tx
@@ -23634,6 +23715,11 @@ type Methods interface {
 	All_StoragenodeBandwidthRollup_By_StoragenodeId_And_IntervalStart(ctx context.Context,
 		storagenode_bandwidth_rollup_storagenode_id StoragenodeBandwidthRollup_StoragenodeId_Field,
 		storagenode_bandwidth_rollup_interval_start StoragenodeBandwidthRollup_IntervalStart_Field) (
+		rows []*StoragenodeBandwidthRollup, err error)
+
+	All_StoragenodeBandwidthRollup_By_StoragenodeId_And_IntervalStart_GreaterOrEqual(ctx context.Context,
+		storagenode_bandwidth_rollup_storagenode_id StoragenodeBandwidthRollup_StoragenodeId_Field,
+		storagenode_bandwidth_rollup_interval_start_greater_or_equal StoragenodeBandwidthRollup_IntervalStart_Field) (
 		rows []*StoragenodeBandwidthRollup, err error)
 
 	All_StoragenodeStorageTally(ctx context.Context) (

--- a/satellite/satellitedb/dbx/satellitedb.dbx.go
+++ b/satellite/satellitedb/dbx/satellitedb.dbx.go
@@ -11816,6 +11816,41 @@ func (obj *pgxImpl) All_StoragenodeBandwidthRollupPhase2_By_IntervalStart_Greate
 
 }
 
+func (obj *pgxImpl) All_StoragenodeBandwidthRollupPhase2_By_StoragenodeId_And_IntervalStart_GreaterOrEqual(ctx context.Context,
+	storagenode_bandwidth_rollup_phase2_storagenode_id StoragenodeBandwidthRollupPhase2_StoragenodeId_Field,
+	storagenode_bandwidth_rollup_phase2_interval_start_greater_or_equal StoragenodeBandwidthRollupPhase2_IntervalStart_Field) (
+	rows []*StoragenodeBandwidthRollupPhase2, err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	var __embed_stmt = __sqlbundle_Literal("SELECT storagenode_bandwidth_rollups_phase2.storagenode_id, storagenode_bandwidth_rollups_phase2.interval_start, storagenode_bandwidth_rollups_phase2.interval_seconds, storagenode_bandwidth_rollups_phase2.action, storagenode_bandwidth_rollups_phase2.allocated, storagenode_bandwidth_rollups_phase2.settled FROM storagenode_bandwidth_rollups_phase2 WHERE storagenode_bandwidth_rollups_phase2.storagenode_id = ? AND storagenode_bandwidth_rollups_phase2.interval_start >= ?")
+
+	var __values []interface{}
+	__values = append(__values, storagenode_bandwidth_rollup_phase2_storagenode_id.value(), storagenode_bandwidth_rollup_phase2_interval_start_greater_or_equal.value())
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	__rows, err := obj.driver.QueryContext(ctx, __stmt, __values...)
+	if err != nil {
+		return nil, obj.makeErr(err)
+	}
+	defer __rows.Close()
+
+	for __rows.Next() {
+		storagenode_bandwidth_rollup_phase2 := &StoragenodeBandwidthRollupPhase2{}
+		err = __rows.Scan(&storagenode_bandwidth_rollup_phase2.StoragenodeId, &storagenode_bandwidth_rollup_phase2.IntervalStart, &storagenode_bandwidth_rollup_phase2.IntervalSeconds, &storagenode_bandwidth_rollup_phase2.Action, &storagenode_bandwidth_rollup_phase2.Allocated, &storagenode_bandwidth_rollup_phase2.Settled)
+		if err != nil {
+			return nil, obj.makeErr(err)
+		}
+		rows = append(rows, storagenode_bandwidth_rollup_phase2)
+	}
+	if err := __rows.Err(); err != nil {
+		return nil, obj.makeErr(err)
+	}
+	return rows, nil
+
+}
+
 func (obj *pgxImpl) All_StoragenodeStorageTally(ctx context.Context) (
 	rows []*StoragenodeStorageTally, err error) {
 	defer mon.Task()(&ctx)(&err)
@@ -11857,6 +11892,41 @@ func (obj *pgxImpl) All_StoragenodeStorageTally_By_IntervalEndTime_GreaterOrEqua
 
 	var __values []interface{}
 	__values = append(__values, storagenode_storage_tally_interval_end_time_greater_or_equal.value())
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	__rows, err := obj.driver.QueryContext(ctx, __stmt, __values...)
+	if err != nil {
+		return nil, obj.makeErr(err)
+	}
+	defer __rows.Close()
+
+	for __rows.Next() {
+		storagenode_storage_tally := &StoragenodeStorageTally{}
+		err = __rows.Scan(&storagenode_storage_tally.NodeId, &storagenode_storage_tally.IntervalEndTime, &storagenode_storage_tally.DataTotal)
+		if err != nil {
+			return nil, obj.makeErr(err)
+		}
+		rows = append(rows, storagenode_storage_tally)
+	}
+	if err := __rows.Err(); err != nil {
+		return nil, obj.makeErr(err)
+	}
+	return rows, nil
+
+}
+
+func (obj *pgxImpl) All_StoragenodeStorageTally_By_NodeId_And_IntervalEndTime_GreaterOrEqual(ctx context.Context,
+	storagenode_storage_tally_node_id StoragenodeStorageTally_NodeId_Field,
+	storagenode_storage_tally_interval_end_time_greater_or_equal StoragenodeStorageTally_IntervalEndTime_Field) (
+	rows []*StoragenodeStorageTally, err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	var __embed_stmt = __sqlbundle_Literal("SELECT storagenode_storage_tallies.node_id, storagenode_storage_tallies.interval_end_time, storagenode_storage_tallies.data_total FROM storagenode_storage_tallies WHERE storagenode_storage_tallies.node_id = ? AND storagenode_storage_tallies.interval_end_time >= ?")
+
+	var __values []interface{}
+	__values = append(__values, storagenode_storage_tally_node_id.value(), storagenode_storage_tally_interval_end_time_greater_or_equal.value())
 
 	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
 	obj.logStmt(__stmt, __values...)
@@ -18096,6 +18166,41 @@ func (obj *pgxcockroachImpl) All_StoragenodeBandwidthRollupPhase2_By_IntervalSta
 
 }
 
+func (obj *pgxcockroachImpl) All_StoragenodeBandwidthRollupPhase2_By_StoragenodeId_And_IntervalStart_GreaterOrEqual(ctx context.Context,
+	storagenode_bandwidth_rollup_phase2_storagenode_id StoragenodeBandwidthRollupPhase2_StoragenodeId_Field,
+	storagenode_bandwidth_rollup_phase2_interval_start_greater_or_equal StoragenodeBandwidthRollupPhase2_IntervalStart_Field) (
+	rows []*StoragenodeBandwidthRollupPhase2, err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	var __embed_stmt = __sqlbundle_Literal("SELECT storagenode_bandwidth_rollups_phase2.storagenode_id, storagenode_bandwidth_rollups_phase2.interval_start, storagenode_bandwidth_rollups_phase2.interval_seconds, storagenode_bandwidth_rollups_phase2.action, storagenode_bandwidth_rollups_phase2.allocated, storagenode_bandwidth_rollups_phase2.settled FROM storagenode_bandwidth_rollups_phase2 WHERE storagenode_bandwidth_rollups_phase2.storagenode_id = ? AND storagenode_bandwidth_rollups_phase2.interval_start >= ?")
+
+	var __values []interface{}
+	__values = append(__values, storagenode_bandwidth_rollup_phase2_storagenode_id.value(), storagenode_bandwidth_rollup_phase2_interval_start_greater_or_equal.value())
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	__rows, err := obj.driver.QueryContext(ctx, __stmt, __values...)
+	if err != nil {
+		return nil, obj.makeErr(err)
+	}
+	defer __rows.Close()
+
+	for __rows.Next() {
+		storagenode_bandwidth_rollup_phase2 := &StoragenodeBandwidthRollupPhase2{}
+		err = __rows.Scan(&storagenode_bandwidth_rollup_phase2.StoragenodeId, &storagenode_bandwidth_rollup_phase2.IntervalStart, &storagenode_bandwidth_rollup_phase2.IntervalSeconds, &storagenode_bandwidth_rollup_phase2.Action, &storagenode_bandwidth_rollup_phase2.Allocated, &storagenode_bandwidth_rollup_phase2.Settled)
+		if err != nil {
+			return nil, obj.makeErr(err)
+		}
+		rows = append(rows, storagenode_bandwidth_rollup_phase2)
+	}
+	if err := __rows.Err(); err != nil {
+		return nil, obj.makeErr(err)
+	}
+	return rows, nil
+
+}
+
 func (obj *pgxcockroachImpl) All_StoragenodeStorageTally(ctx context.Context) (
 	rows []*StoragenodeStorageTally, err error) {
 	defer mon.Task()(&ctx)(&err)
@@ -18137,6 +18242,41 @@ func (obj *pgxcockroachImpl) All_StoragenodeStorageTally_By_IntervalEndTime_Grea
 
 	var __values []interface{}
 	__values = append(__values, storagenode_storage_tally_interval_end_time_greater_or_equal.value())
+
+	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
+	obj.logStmt(__stmt, __values...)
+
+	__rows, err := obj.driver.QueryContext(ctx, __stmt, __values...)
+	if err != nil {
+		return nil, obj.makeErr(err)
+	}
+	defer __rows.Close()
+
+	for __rows.Next() {
+		storagenode_storage_tally := &StoragenodeStorageTally{}
+		err = __rows.Scan(&storagenode_storage_tally.NodeId, &storagenode_storage_tally.IntervalEndTime, &storagenode_storage_tally.DataTotal)
+		if err != nil {
+			return nil, obj.makeErr(err)
+		}
+		rows = append(rows, storagenode_storage_tally)
+	}
+	if err := __rows.Err(); err != nil {
+		return nil, obj.makeErr(err)
+	}
+	return rows, nil
+
+}
+
+func (obj *pgxcockroachImpl) All_StoragenodeStorageTally_By_NodeId_And_IntervalEndTime_GreaterOrEqual(ctx context.Context,
+	storagenode_storage_tally_node_id StoragenodeStorageTally_NodeId_Field,
+	storagenode_storage_tally_interval_end_time_greater_or_equal StoragenodeStorageTally_IntervalEndTime_Field) (
+	rows []*StoragenodeStorageTally, err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	var __embed_stmt = __sqlbundle_Literal("SELECT storagenode_storage_tallies.node_id, storagenode_storage_tallies.interval_end_time, storagenode_storage_tallies.data_total FROM storagenode_storage_tallies WHERE storagenode_storage_tallies.node_id = ? AND storagenode_storage_tallies.interval_end_time >= ?")
+
+	var __values []interface{}
+	__values = append(__values, storagenode_storage_tally_node_id.value(), storagenode_storage_tally_interval_end_time_greater_or_equal.value())
 
 	var __stmt = __sqlbundle_Render(obj.dialect, __embed_stmt)
 	obj.logStmt(__stmt, __values...)
@@ -21741,6 +21881,17 @@ func (rx *Rx) All_StoragenodeBandwidthRollupPhase2_By_IntervalStart_GreaterOrEqu
 	return tx.All_StoragenodeBandwidthRollupPhase2_By_IntervalStart_GreaterOrEqual(ctx, storagenode_bandwidth_rollup_phase2_interval_start_greater_or_equal)
 }
 
+func (rx *Rx) All_StoragenodeBandwidthRollupPhase2_By_StoragenodeId_And_IntervalStart_GreaterOrEqual(ctx context.Context,
+	storagenode_bandwidth_rollup_phase2_storagenode_id StoragenodeBandwidthRollupPhase2_StoragenodeId_Field,
+	storagenode_bandwidth_rollup_phase2_interval_start_greater_or_equal StoragenodeBandwidthRollupPhase2_IntervalStart_Field) (
+	rows []*StoragenodeBandwidthRollupPhase2, err error) {
+	var tx *Tx
+	if tx, err = rx.getTx(ctx); err != nil {
+		return
+	}
+	return tx.All_StoragenodeBandwidthRollupPhase2_By_StoragenodeId_And_IntervalStart_GreaterOrEqual(ctx, storagenode_bandwidth_rollup_phase2_storagenode_id, storagenode_bandwidth_rollup_phase2_interval_start_greater_or_equal)
+}
+
 func (rx *Rx) All_StoragenodeBandwidthRollup_By_IntervalStart_GreaterOrEqual(ctx context.Context,
 	storagenode_bandwidth_rollup_interval_start_greater_or_equal StoragenodeBandwidthRollup_IntervalStart_Field) (
 	rows []*StoragenodeBandwidthRollup, err error) {
@@ -21779,6 +21930,17 @@ func (rx *Rx) All_StoragenodeStorageTally_By_IntervalEndTime_GreaterOrEqual(ctx 
 		return
 	}
 	return tx.All_StoragenodeStorageTally_By_IntervalEndTime_GreaterOrEqual(ctx, storagenode_storage_tally_interval_end_time_greater_or_equal)
+}
+
+func (rx *Rx) All_StoragenodeStorageTally_By_NodeId_And_IntervalEndTime_GreaterOrEqual(ctx context.Context,
+	storagenode_storage_tally_node_id StoragenodeStorageTally_NodeId_Field,
+	storagenode_storage_tally_interval_end_time_greater_or_equal StoragenodeStorageTally_IntervalEndTime_Field) (
+	rows []*StoragenodeStorageTally, err error) {
+	var tx *Tx
+	if tx, err = rx.getTx(ctx); err != nil {
+		return
+	}
+	return tx.All_StoragenodeStorageTally_By_NodeId_And_IntervalEndTime_GreaterOrEqual(ctx, storagenode_storage_tally_node_id, storagenode_storage_tally_interval_end_time_greater_or_equal)
 }
 
 func (rx *Rx) All_UserCredit_By_UserId_And_ExpiresAt_Greater_And_CreditsUsedInCents_Less_CreditsEarnedInCents_OrderBy_Asc_ExpiresAt(ctx context.Context,
@@ -23460,6 +23622,11 @@ type Methods interface {
 		storagenode_bandwidth_rollup_phase2_interval_start_greater_or_equal StoragenodeBandwidthRollupPhase2_IntervalStart_Field) (
 		rows []*StoragenodeBandwidthRollupPhase2, err error)
 
+	All_StoragenodeBandwidthRollupPhase2_By_StoragenodeId_And_IntervalStart_GreaterOrEqual(ctx context.Context,
+		storagenode_bandwidth_rollup_phase2_storagenode_id StoragenodeBandwidthRollupPhase2_StoragenodeId_Field,
+		storagenode_bandwidth_rollup_phase2_interval_start_greater_or_equal StoragenodeBandwidthRollupPhase2_IntervalStart_Field) (
+		rows []*StoragenodeBandwidthRollupPhase2, err error)
+
 	All_StoragenodeBandwidthRollup_By_IntervalStart_GreaterOrEqual(ctx context.Context,
 		storagenode_bandwidth_rollup_interval_start_greater_or_equal StoragenodeBandwidthRollup_IntervalStart_Field) (
 		rows []*StoragenodeBandwidthRollup, err error)
@@ -23473,6 +23640,11 @@ type Methods interface {
 		rows []*StoragenodeStorageTally, err error)
 
 	All_StoragenodeStorageTally_By_IntervalEndTime_GreaterOrEqual(ctx context.Context,
+		storagenode_storage_tally_interval_end_time_greater_or_equal StoragenodeStorageTally_IntervalEndTime_Field) (
+		rows []*StoragenodeStorageTally, err error)
+
+	All_StoragenodeStorageTally_By_NodeId_And_IntervalEndTime_GreaterOrEqual(ctx context.Context,
+		storagenode_storage_tally_node_id StoragenodeStorageTally_NodeId_Field,
 		storagenode_storage_tally_interval_end_time_greater_or_equal StoragenodeStorageTally_IntervalEndTime_Field) (
 		rows []*StoragenodeStorageTally, err error)
 

--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -36,6 +36,25 @@ type overlaycache struct {
 	db *satelliteDB
 }
 
+func (cache *overlaycache) GetAllNodeIDs(ctx context.Context) (_ []storj.NodeID, err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	dbxNodeIDs, err := cache.db.All_Node_Id(ctx)
+	if err != nil {
+		return nil, err
+	}
+	nodeIDs := []storj.NodeID{}
+	for _, id := range dbxNodeIDs {
+		nID, err := storj.NodeIDFromBytes(id.Id)
+		if err != nil {
+			continue
+		}
+		nodeIDs = append(nodeIDs, nID)
+	}
+
+	return nodeIDs, err
+}
+
 // SelectAllStorageNodesUpload returns all nodes that qualify to store data, organized as reputable nodes and new nodes.
 func (cache *overlaycache) SelectAllStorageNodesUpload(ctx context.Context, selectionCfg overlay.NodeSelectionConfig) (reputable, new []*overlay.SelectedNode, err error) {
 	defer mon.Task()(&ctx)(&err)

--- a/satellite/satellitedb/storagenodeaccounting.go
+++ b/satellite/satellitedb/storagenodeaccounting.go
@@ -6,7 +6,6 @@ package satellitedb
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"time"
 
 	"github.com/zeebo/errs"
@@ -169,7 +168,7 @@ func (db *StoragenodeAccounting) SaveRollup(ctx context.Context, latestRollup ti
 				getRepair := dbx.AccountingRollup_GetRepairTotal(ar.GetRepairTotal)
 				putRepair := dbx.AccountingRollup_PutRepairTotal(ar.PutRepairTotal)
 				atRest := dbx.AccountingRollup_AtRestTotal(ar.AtRestTotal)
-				fmt.Printf("%v %v %v %v %v %v %v %v\n", nID, start, put, get, audit, getRepair, putRepair, atRest)
+
 				err := tx.ReplaceNoReturn_AccountingRollup(ctx, nID, start, put, get, audit, getRepair, putRepair, atRest)
 				if err != nil {
 					return err

--- a/satellite/satellitedb/storagenodeaccounting.go
+++ b/satellite/satellitedb/storagenodeaccounting.go
@@ -6,6 +6,7 @@ package satellitedb
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/zeebo/errs"
@@ -106,7 +107,7 @@ func (db *StoragenodeAccounting) GetTalliesSince(ctx context.Context, nodeID sto
 func (db *StoragenodeAccounting) GetBandwidthSince(ctx context.Context, nodeID storj.NodeID, latestRollup time.Time) (out []*accounting.StoragenodeBandwidthRollup, err error) {
 	defer mon.Task()(&ctx)(&err)
 	// get everything from the current rollups table
-	rollups, err := db.db.All_StoragenodeBandwidthRollup_By_StoragenodeId_And_IntervalStart(ctx,
+	rollups, err := db.db.All_StoragenodeBandwidthRollup_By_StoragenodeId_And_IntervalStart_GreaterOrEqual(ctx,
 		dbx.StoragenodeBandwidthRollup_StoragenodeId(nodeID.Bytes()),
 		dbx.StoragenodeBandwidthRollup_IntervalStart(latestRollup))
 	if err != nil {
@@ -168,7 +169,7 @@ func (db *StoragenodeAccounting) SaveRollup(ctx context.Context, latestRollup ti
 				getRepair := dbx.AccountingRollup_GetRepairTotal(ar.GetRepairTotal)
 				putRepair := dbx.AccountingRollup_PutRepairTotal(ar.PutRepairTotal)
 				atRest := dbx.AccountingRollup_AtRestTotal(ar.AtRestTotal)
-
+				fmt.Printf("%v %v %v %v %v %v %v %v\n", nID, start, put, get, audit, getRepair, putRepair, atRest)
 				err := tx.ReplaceNoReturn_AccountingRollup(ctx, nID, start, put, get, audit, getRepair, putRepair, atRest)
 				if err != nil {
 					return err

--- a/satellite/satellitedb/storagenodeaccounting.go
+++ b/satellite/satellitedb/storagenodeaccounting.go
@@ -404,10 +404,10 @@ func (db *StoragenodeAccounting) QueryStorageNodeUsage(ctx context.Context, node
 }
 
 // DeleteTalliesBefore deletes all raw tallies prior to some time.
-func (db *StoragenodeAccounting) DeleteTalliesBefore(ctx context.Context, latestRollup time.Time) (err error) {
+func (db *StoragenodeAccounting) DeleteTalliesBefore(ctx context.Context, nodeID storj.NodeID, latestRollup time.Time) (err error) {
 	defer mon.Task()(&ctx)(&err)
-	deleteRawSQL := `DELETE FROM storagenode_storage_tallies WHERE interval_end_time < ?`
-	_, err = db.db.DB.ExecContext(ctx, db.db.Rebind(deleteRawSQL), latestRollup)
+	deleteRawSQL := `DELETE FROM storagenode_storage_tallies WHERE node_id = ? AND interval_end_time < ?`
+	_, err = db.db.DB.ExecContext(ctx, db.db.Rebind(deleteRawSQL), nodeID, latestRollup)
 	return err
 }
 


### PR DESCRIPTION
Change-Id: I518ae4fa819074495eb278ea1c3e1adad079291b


What: 
Do rollups on a per node bases to contain the size of the transactions in SaveRollup.  This change will likely be a problem in the future when we have 100s of thousands of SNs, but with 10K, I believe we'll be OK.

We should probably also set rollup.delete-tallies: false to be safe.

Why:
SaveRollups times out in CRDB

Please describe the tests:
 - Test 1: Existing
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
