### PR TITLE
satellite/overlay: [WIP] Add AS OF SYSTEM TIME to nodes queries

### DIFF
--- a/private/testplanet/satellite.go
+++ b/private/testplanet/satellite.go
@@ -439,6 +439,11 @@ func (planet *Planet) newSatellite(ctx context.Context, prefix string, index int
 				AuditReputationDQ:           0.6,
 				SuspensionGracePeriod:       time.Hour,
 				SuspensionDQEnabled:         true,
+
+				AsOfSystemTime: overlay.AsOfSystemTimeConfig{
+					Enabled:         true,
+					DefaultDuration: time.Nanosecond,
+				},
 			},
 			NodeSelectionCache: overlay.CacheConfig{
 				Staleness: 3 * time.Minute,

--- a/private/testplanet/satellite.go
+++ b/private/testplanet/satellite.go
@@ -442,7 +442,7 @@ func (planet *Planet) newSatellite(ctx context.Context, prefix string, index int
 
 				AsOfSystemTime: overlay.AsOfSystemTimeConfig{
 					Enabled:         true,
-					DefaultDuration: time.Nanosecond,
+					DefaultDuration: -time.Microsecond,
 				},
 			},
 			NodeSelectionCache: overlay.CacheConfig{

--- a/satellite/overlay/config.go
+++ b/satellite/overlay/config.go
@@ -26,6 +26,12 @@ type Config struct {
 	AuditHistory         AuditHistoryConfig
 }
 
+// AsOfSystemTimeConfig is a configuration struct to enable 'AS OF SYSTEM TIME' to CRDB queries
+type AsOfSystemTimeConfig struct {
+	Enabled         bool          `help:"enables the use of the AS OF SYSTEM TIME feature in CRDB" devDefault:"true" releaseDefault:"false"`
+	DefaultDuration time.Duration `help:"default duration for AS OF SYSTEM TIME" devDefault:"1µs" releaseDefault:"10s"`
+}
+
 // NodeSelectionConfig is a configuration struct to determine the minimum
 // values for nodes to select.
 type NodeSelectionConfig struct {
@@ -44,6 +50,8 @@ type NodeSelectionConfig struct {
 	AuditReputationDQ           float64       `help:"the reputation cut-off for disqualifying SNs based on audit history" default:"0.6"`
 	SuspensionGracePeriod       time.Duration `help:"the time period that must pass before suspended nodes will be disqualified" releaseDefault:"168h" devDefault:"1h"`
 	SuspensionDQEnabled         bool          `help:"whether nodes will be disqualified if they have been suspended for longer than the suspended grace period" releaseDefault:"false" devDefault:"true"`
+
+	AsOfSystemTime AsOfSystemTimeConfig
 }
 
 // AuditHistoryConfig is a configuration struct defining time periods and thresholds for penalizing nodes for being offline.

--- a/satellite/overlay/config.go
+++ b/satellite/overlay/config.go
@@ -29,7 +29,7 @@ type Config struct {
 // AsOfSystemTimeConfig is a configuration struct to enable 'AS OF SYSTEM TIME' to CRDB queries
 type AsOfSystemTimeConfig struct {
 	Enabled         bool          `help:"enables the use of the AS OF SYSTEM TIME feature in CRDB" devDefault:"true" releaseDefault:"false"`
-	DefaultDuration time.Duration `help:"default duration for AS OF SYSTEM TIME" devDefault:"1µs" releaseDefault:"10s"`
+	DefaultDuration time.Duration `help:"default duration for AS OF SYSTEM TIME" devDefault:"-1µs" releaseDefault:"-10s"`
 }
 
 // NodeSelectionConfig is a configuration struct to determine the minimum

--- a/satellite/overlay/service.go
+++ b/satellite/overlay/service.go
@@ -131,19 +131,21 @@ type InfoResponse struct {
 
 // FindStorageNodesRequest defines easy request parameters.
 type FindStorageNodesRequest struct {
-	RequestedCount int
-	ExcludedIDs    []storj.NodeID
-	MinimumVersion string // semver or empty
+	RequestedCount         int
+	ExcludedIDs            []storj.NodeID
+	MinimumVersion         string        // semver or empty
+	AsOfSystemTimeDuration time.Duration // only used by CRDB
 }
 
 // NodeCriteria are the requirements for selecting nodes.
 type NodeCriteria struct {
-	FreeDisk         int64
-	ExcludedIDs      []storj.NodeID
-	ExcludedNetworks []string // the /24 subnet IPv4 or /64 subnet IPv6 for nodes
-	MinimumVersion   string   // semver or empty
-	OnlineWindow     time.Duration
-	DistinctIP       bool
+	FreeDisk               int64
+	ExcludedIDs            []storj.NodeID
+	ExcludedNetworks       []string // the /24 subnet IPv4 or /64 subnet IPv6 for nodes
+	MinimumVersion         string   // semver or empty
+	OnlineWindow           time.Duration
+	DistinctIP             bool
+	AsOfSystemTimeDuration time.Duration // only used by CRDB
 }
 
 // AuditType is an enum representing the outcome of a particular audit reported to the overlay.
@@ -323,6 +325,9 @@ func (service *Service) IsOnline(node *NodeDossier) bool {
 // The main difference between this method and the normal FindStorageNodes is that here we avoid using the cache.
 func (service *Service) FindStorageNodesForGracefulExit(ctx context.Context, req FindStorageNodesRequest) (_ []*SelectedNode, err error) {
 	defer mon.Task()(&ctx)(&err)
+	if service.config.Node.AsOfSystemTime.Enabled {
+		req.AsOfSystemTimeDuration = service.config.Node.AsOfSystemTime.DefaultDuration
+	}
 	return service.FindStorageNodesWithPreferences(ctx, req, &service.config.Node)
 }
 
@@ -332,6 +337,10 @@ func (service *Service) FindStorageNodesForGracefulExit(ctx context.Context, req
 // When the node selection from the cache fails, it falls back to the old implementation.
 func (service *Service) FindStorageNodesForUpload(ctx context.Context, req FindStorageNodesRequest) (_ []*SelectedNode, err error) {
 	defer mon.Task()(&ctx)(&err)
+	if service.config.Node.AsOfSystemTime.Enabled {
+		req.AsOfSystemTimeDuration = service.config.Node.AsOfSystemTime.DefaultDuration
+	}
+
 	if service.config.NodeSelectionCache.Disabled {
 		return service.FindStorageNodesWithPreferences(ctx, req, &service.config.Node)
 	}
@@ -340,6 +349,7 @@ func (service *Service) FindStorageNodesForUpload(ctx context.Context, req FindS
 	if err != nil {
 		service.log.Warn("error selecting from node selection cache", zap.String("err", err.Error()))
 	}
+
 	if len(selectedNodes) < req.RequestedCount {
 		mon.Event("default_node_selection")
 		return service.FindStorageNodesWithPreferences(ctx, req, &service.config.Node)
@@ -352,7 +362,6 @@ func (service *Service) FindStorageNodesForUpload(ctx context.Context, req FindS
 // This does not use a cache.
 func (service *Service) FindStorageNodesWithPreferences(ctx context.Context, req FindStorageNodesRequest, preferences *NodeSelectionConfig) (nodes []*SelectedNode, err error) {
 	defer mon.Task()(&ctx)(&err)
-
 	// TODO: add sanity limits to requested node count
 	// TODO: add sanity limits to excluded nodes
 	totalNeededNodes := req.RequestedCount
@@ -374,12 +383,13 @@ func (service *Service) FindStorageNodesWithPreferences(ctx context.Context, req
 	}
 
 	criteria := NodeCriteria{
-		FreeDisk:         preferences.MinimumDiskSpace.Int64(),
-		ExcludedIDs:      excludedIDs,
-		ExcludedNetworks: excludedNetworks,
-		MinimumVersion:   preferences.MinimumVersion,
-		OnlineWindow:     preferences.OnlineWindow,
-		DistinctIP:       preferences.DistinctIP,
+		FreeDisk:               preferences.MinimumDiskSpace.Int64(),
+		ExcludedIDs:            excludedIDs,
+		ExcludedNetworks:       excludedNetworks,
+		MinimumVersion:         preferences.MinimumVersion,
+		OnlineWindow:           preferences.OnlineWindow,
+		DistinctIP:             preferences.DistinctIP,
+		AsOfSystemTimeDuration: req.AsOfSystemTimeDuration,
 	}
 	nodes, err = service.db.SelectStorageNodes(ctx, totalNeededNodes, newNodeCount, &criteria)
 	if err != nil {

--- a/satellite/satellitedb/nodeselection.go
+++ b/satellite/satellitedb/nodeselection.go
@@ -291,7 +291,7 @@ func (partial partialQuery) asQuery() query {
 		fmt.Fprint(&q, " LIMIT ? ")
 		args = append(args, partial.limit)
 	} else {
-		fmt.Fprintf(&q, ") %s filtered ORDER BY RANDOM() LIMIT ?", asOf)
+		fmt.Fprintf(&q, ") filtered %s ORDER BY RANDOM() LIMIT ?", asOf)
 		args = append(args, partial.limit)
 	}
 

--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -19,6 +19,7 @@ import (
 	"storj.io/common/pb"
 	"storj.io/common/storj"
 	"storj.io/private/version"
+	"storj.io/storj/private/dbutil"
 	"storj.io/storj/private/dbutil/cockroachutil"
 	"storj.io/storj/private/dbutil/pgutil"
 	"storj.io/storj/private/tagsql"
@@ -57,7 +58,7 @@ func (cache *overlaycache) selectAllStorageNodesUpload(ctx context.Context, sele
 	defer mon.Task()(&ctx)(&err)
 
 	var asOf string
-	if selectionCfg.AsOfSystemTime.Enabled && selectionCfg.AsOfSystemTime.DefaultDuration != 0 {
+	if cache.db.implementation == dbutil.Cockroach && selectionCfg.AsOfSystemTime.Enabled && selectionCfg.AsOfSystemTime.DefaultDuration != 0 {
 		asOf = fmt.Sprintf(" AS OF SYSTEM TIME '%s'", selectionCfg.AsOfSystemTime.DefaultDuration.String())
 	}
 
@@ -259,7 +260,7 @@ func (cache *overlaycache) knownOffline(ctx context.Context, criteria *overlay.N
 	}
 
 	var asOf string
-	if criteria.AsOfSystemTimeDuration != 0 {
+	if cache.db.implementation == dbutil.Cockroach && criteria.AsOfSystemTimeDuration != 0 {
 		asOf = fmt.Sprintf(" AS OF SYSTEM TIME '%s'", criteria.AsOfSystemTimeDuration.String())
 	}
 
@@ -311,7 +312,7 @@ func (cache *overlaycache) knownUnreliableOrOffline(ctx context.Context, criteri
 	}
 
 	var asOf string
-	if criteria.AsOfSystemTimeDuration != 0 {
+	if cache.db.implementation == dbutil.Cockroach && criteria.AsOfSystemTimeDuration != 0 {
 		asOf = fmt.Sprintf(" AS OF SYSTEM TIME '%s'", criteria.AsOfSystemTimeDuration.String())
 	}
 
@@ -420,7 +421,7 @@ func (cache *overlaycache) Reliable(ctx context.Context, criteria *overlay.NodeC
 
 func (cache *overlaycache) reliable(ctx context.Context, criteria *overlay.NodeCriteria) (nodes storj.NodeIDList, err error) {
 	var asOf string
-	if criteria.AsOfSystemTimeDuration != 0 {
+	if cache.db.implementation == dbutil.Cockroach && criteria.AsOfSystemTimeDuration != 0 {
 		asOf = fmt.Sprintf(" AS OF SYSTEM TIME '%s'", criteria.AsOfSystemTimeDuration.String())
 	}
 


### PR DESCRIPTION
Change-Id: I98ab994eba28edc7c314bff69004411fe70f4708

What: 
Add AS OF SYSTEM TIME to nodes lookups that don't require the data to be the most current.

Why:
Recommendations from CRDB. This is for a custom build for SLC for testing.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
