### PR TITLE
cmd: ensure proper arch is used for docker container

### DIFF
--- a/cmd/storagenode/Dockerfile
+++ b/cmd/storagenode/Dockerfile
@@ -1,8 +1,9 @@
+ARG DOCKER_ARCH
+
 # Fetch ca-certificates file for arch independent builds below
 FROM alpine as ca-cert
 RUN apk -U add ca-certificates
 
-ARG DOCKER_ARCH
 FROM ${DOCKER_ARCH:-amd64}/alpine
 ARG TAG
 ARG GOARCH

--- a/cmd/uplink/Dockerfile
+++ b/cmd/uplink/Dockerfile
@@ -1,8 +1,9 @@
+ARG DOCKER_ARCH
+
 # Fetch ca-certificates file for arch independent builds below
 FROM alpine as ca-cert
 RUN apk -U add ca-certificates
 
-ARG DOCKER_ARCH
 FROM ${DOCKER_ARCH:-amd64}/alpine
 ARG TAG
 ARG GOARCH


### PR DESCRIPTION
What: Ensures that the passed in arch is used for creating the container.

Why: The storagenode containers were build unsuccessfully all with amd64 instead of the requested arch.

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
