### PR TITLE
jenkins/build: rename release binaries inside zip archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,8 +331,15 @@ push-images: ## Push Docker images to Docker Hub (jenkins)
 .PHONY: binaries-upload
 binaries-upload: ## Upload binaries to Google Storage (jenkins)
 	cd "release/${TAG}"; for f in *; do \
-		zipname=$$(echo $${f} | sed 's/.exe//g') && \
-		zip -r "$${zipname}.zip" "$${f}" \
+		zipname=$$(echo $${f} | sed 's/.exe//g') \
+		filename=$$(echo $${f} | sed 's/_.*\.exe/.exe/g' | sed 's/_.*//g' \
+		if [ $${f} != $${filename} ]; then \
+			ln $${f} $${filename} \
+			zip -r "$${zipname}.zip" "$${filename}" \
+			rm $${filename} \
+		else \
+			zip -r "$${zipname}.zip" "$${filename}" \
+		fi \
 	; done
 	cd "release/${TAG}"; gsutil -m cp -r *.zip "gs://storj-v3-alpha-builds/${TAG}/"
 


### PR DESCRIPTION
What: Rename release binaries so that we can upload them easier to github without having to manual rename the files.

Why: The build script adds _os_arch to every binary. For example uplink_windows_amd64.exe. We want to create a zip archive with an uplink.exe file in it.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
