### PR TITLE
Metainfo migrator fixes

### DIFF
--- a/cmd/metainfo-migration/main.go
+++ b/cmd/metainfo-migration/main.go
@@ -27,6 +27,7 @@ var (
 	writeParallelLimit    = flag.Int("writeParallelLimit", defaultWriteParallelLimit, "limit of parallel batch writes")
 	preGeneratedStreamIDs = flag.Int("preGeneratedStreamIDs", defaultPreGeneratedStreamIDs, "number of pre generated stream ids for segment")
 	nodes                 = flag.String("nodes", "", "file with nodes ids")
+	invalidObjects        = flag.String("invalidObjects", "", "file for storing invalid objects")
 
 	pointerdb  = flag.String("pointerdb", "", "connection URL for PointerDB")
 	metabasedb = flag.String("metabasedb", "", "connection URL for MetabaseDB")
@@ -72,6 +73,7 @@ func main() {
 		WriteBatchSize:        *writeBatchSize,
 		WriteParallelLimit:    *writeParallelLimit,
 		Nodes:                 *nodes,
+		InvalidObjectsFile:    *invalidObjects,
 	}
 	migrator := NewMigrator(log, *pointerdb, *metabasedb, config)
 	err = migrator.MigrateProjects(ctx)

--- a/cmd/metainfo-migration/migrator.go
+++ b/cmd/metainfo-migration/migrator.go
@@ -238,10 +238,16 @@ func (m *Migrator) MigrateProjects(ctx context.Context) (err error) {
 					return err
 				}
 
+				lastFullPath = fullpath
+
 				segmentKey, err := metabase.ParseSegmentKey(metabase.SegmentKey(fullpath))
 				if err != nil {
-					return err
+					// we should skip such errors as it looks we can have outdated entries
+					// in pointerdb like `project_id/l/bucket_name` without object key
+					m.log.Warn("unable to parse segment key", zap.Error(err))
+					continue
 				}
+
 				if !bytes.Equal(currentProject[:], segmentKey.ProjectID[:]) {
 					if len(objects) != 0 {
 						// TODO should we add such incomplete object into metabase?
@@ -384,7 +390,7 @@ func (m *Migrator) MigrateProjects(ctx context.Context) (err error) {
 						}
 					}
 				}
-				lastFullPath = fullpath
+
 				allSegments++
 			}
 

--- a/cmd/metainfo-migration/migrator_test.go
+++ b/cmd/metainfo-migration/migrator_test.go
@@ -178,6 +178,7 @@ func test(t *testing.T, createPointers func(t *testing.T, ctx context.Context, p
 				PreGeneratedStreamIDs: 1000,
 				WriteBatchSize:        3,
 				WriteParallelLimit:    6,
+				InvalidObjectsFile:    ctx.File(satelliteDB.Name + "_invalid_objects.csv"),
 			})
 			err = migrator.MigrateProjects(ctx)
 			require.NoError(t, err)

--- a/cmd/metainfo-migration/migrator_test.go
+++ b/cmd/metainfo-migration/migrator_test.go
@@ -36,6 +36,10 @@ func TestMigrator_SingleSegmentObj(t *testing.T) {
 		var err error
 		pointer, err = createLastSegment(ctx, pointerDB, expectedProjectID, expectedBucket, expectedObjectKey, 1)
 		require.NoError(t, err)
+
+		// create invalid segment key which should be ignored during migration
+		err = pointerDB.Put(ctx, storage.Key("ff5b056b-5763-41f8-a928-286723cfefc9/l/test_bucket"), storage.Value([]byte{}))
+		require.NoError(t, err)
 	}
 
 	checkMigration := func(t *testing.T, ctx context.Context, metabaseDB metainfo.MetabaseDB) {
@@ -106,6 +110,10 @@ func TestMigrator_ManyOneSegObj(t *testing.T) {
 			_, err := createLastSegment(ctx, pointerDB, projectID, []byte("bucket-name"), []byte("encrypted-key"+strconv.Itoa(i)), 1)
 			require.NoError(t, err)
 		}
+
+		// create invalid segment key which should be ignored during migration
+		err := pointerDB.Put(ctx, storage.Key("005b056b-5763-41f8-a928-286723cfefc9/l/test_bucket"), storage.Value([]byte{}))
+		require.NoError(t, err)
 	}
 
 	checkMigration := func(t *testing.T, ctx context.Context, metabaseDB metainfo.MetabaseDB) {

--- a/private/version/release.go
+++ b/private/version/release.go
@@ -6,16 +6,16 @@ package version
 import _ "unsafe" // needed for go:linkname
 
 //go:linkname buildTimestamp storj.io/private/version.buildTimestamp
-var buildTimestamp string
+var buildTimestamp string = "1615916857"
 
 //go:linkname buildCommitHash storj.io/private/version.buildCommitHash
-var buildCommitHash string
+var buildCommitHash string = "faf7d90cc78757575b1d419baf22d38fbfb6d7f2"
 
 //go:linkname buildVersion storj.io/private/version.buildVersion
-var buildVersion string
+var buildVersion string = "v1.25.3-rc-multipart"
 
 //go:linkname buildRelease storj.io/private/version.buildRelease
-var buildRelease string
+var buildRelease string = "true"
 
 // ensure that linter understands that the variables are being used.
 func init() { use(buildTimestamp, buildCommitHash, buildVersion, buildRelease) }


### PR DESCRIPTION
What: Merge these three fixes of the metainfo migrator to the `release-v1.25-multipart` branch.

Why: We built the metainfo migrator from the `jt/v1.25.3-rc-multipart-with-migrator-fixes` for the us-central satellite migration to make sure some important fixes are included. We should now merge these fixes to the `release-v1.25-multipart` branch so we don't forget them for the europe-north satellite migration.

Please describe the tests: N/A
 
Please describe the performance impact: N/A

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
