### PR TITLE
Add storjlabs/watchtower storagenode autoupdater config to docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,3 +62,9 @@ services:
     - POSTGRES_PASSWORD=postgres
     - POSTGRES_USER=postgres
     - POSTGRES_DB=satellite
+
+  watchtower:
+    image: storjlabs/watchtower
+    command: storagenode watchtower --stop-timeout 300s
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
What: 

This adds the watchtower configuration recommended here to the `docker-compose.yml` file: https://docs.storj.io/node/setup/cli/software-updates

Why:

Watchtower is vital to running Storj unattended with docker-compose, otherwise your node will get kicked off the network for being out-of-date (as mine almost did before I learned about this).

I also recommend explaining how to setup watchtower correctly docker-compose in the docs too (or at least referencing it in this file):
https://docs.storj.io/node/setup/cli/software-updates

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
