### PR TITLE
Jt/release v1.27

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,6 +86,32 @@ node('node') {
       lastStage = env.STAGE_NAME
       sh 'make binaries'
 
+      stash name: "storagenode-binaries", includes: "release/**/storagenode*.exe"
+
+      echo "Current build result: ${currentBuild.result}"
+    }
+
+    stage('Build Windows Installer') {
+      lastStage = env.STAGE_NAME
+      node('windows') {
+        checkout scm
+
+        unstash "storagenode-binaries"
+
+        bat 'installer\\windows\\buildrelease.bat'
+
+        stash name: "storagenode-installer", includes: "release/**/storagenode*.msi"
+
+        echo "Current build result: ${currentBuild.result}"
+      }
+    }
+
+    stage('Sign Windows Installer') {
+      lastStage = env.STAGE_NAME
+      unstash "storagenode-installer"
+
+      sh 'make sign-windows-installer'
+
       echo "Current build result: ${currentBuild.result}"
     }
 

--- a/Makefile
+++ b/Makefile
@@ -168,12 +168,18 @@ satellite-wasm:
 	scripts/build-wasm.sh ;\
 
 .PHONY: images
-images: satellite-image ## Build satellite, storagenode, uplink, and versioncontrol Docker images
+images: satellite-image storagenode-image uplink-image versioncontrol-image ## Build satellite, storagenode, uplink, and versioncontrol Docker images
 	echo Built version: ${TAG}
 
 .PHONY: satellite-image
-satellite-image: satellite_linux_amd64 ## Build satellite Docker image
+satellite-image: satellite_linux_arm satellite_linux_arm64 satellite_linux_amd64 ## Build satellite Docker image
 	${DOCKER_BUILD} --pull=true -t storjlabs/satellite:${TAG}${CUSTOMTAG}-amd64 \
+		-f cmd/satellite/Dockerfile .
+	${DOCKER_BUILD} --pull=true -t storjlabs/satellite:${TAG}${CUSTOMTAG}-arm32v6 \
+		--build-arg=GOARCH=arm --build-arg=DOCKER_ARCH=arm32v6 \
+		-f cmd/satellite/Dockerfile .
+	${DOCKER_BUILD} --pull=true -t storjlabs/satellite:${TAG}${CUSTOMTAG}-arm64v8 \
+		--build-arg=GOARCH=arm --build-arg=DOCKER_ARCH=arm64v8 \
 		-f cmd/satellite/Dockerfile .
 
 .PHONY: storagenode-image
@@ -281,11 +287,11 @@ versioncontrol_%:
 	$(MAKE) binary-check COMPONENT=versioncontrol GOARCH=$(word 3, $(subst _, ,$@)) GOOS=$(word 2, $(subst _, ,$@))
 
 
-COMPONENTLIST := inspector satellite
-OSARCHLIST    := linux_amd64
+COMPONENTLIST := certificates identity inspector satellite storagenode storagenode-updater uplink versioncontrol
+OSARCHLIST    := darwin_amd64 linux_amd64 linux_arm linux_arm64 windows_amd64 freebsd_amd64
 BINARIES      := $(foreach C,$(COMPONENTLIST),$(foreach O,$(OSARCHLIST),$C_$O))
 .PHONY: binaries
-binaries: ${BINARIES}
+binaries: ${BINARIES} ## Build certificates, identity, inspector, satellite, storagenode, uplink, and versioncontrol binaries (jenkins)
 
 .PHONY: sign-windows-installer
 sign-windows-installer:
@@ -297,12 +303,18 @@ sign-windows-installer:
 push-images: ## Push Docker images to Docker Hub (jenkins)
 	# images have to be pushed before a manifest can be created
 	# satellite
-	for c in satellite ; do \
+	for c in satellite storagenode uplink versioncontrol ; do \
 		docker push storjlabs/$$c:${TAG}${CUSTOMTAG}-amd64 \
+		&& docker push storjlabs/$$c:${TAG}${CUSTOMTAG}-arm32v6 \
+		&& docker push storjlabs/$$c:${TAG}${CUSTOMTAG}-arm64v8 \
 		&& for t in ${TAG}${CUSTOMTAG} ${LATEST_TAG}; do \
 			docker manifest create storjlabs/$$c:$$t \
 			storjlabs/$$c:${TAG}${CUSTOMTAG}-amd64 \
+			storjlabs/$$c:${TAG}${CUSTOMTAG}-arm32v6 \
+			storjlabs/$$c:${TAG}${CUSTOMTAG}-arm64v8 \
 			&& docker manifest annotate storjlabs/$$c:$$t storjlabs/$$c:${TAG}${CUSTOMTAG}-amd64 --os linux --arch amd64 \
+			&& docker manifest annotate storjlabs/$$c:$$t storjlabs/$$c:${TAG}${CUSTOMTAG}-arm32v6 --os linux --arch arm --variant v6 \
+			&& docker manifest annotate storjlabs/$$c:$$t storjlabs/$$c:${TAG}${CUSTOMTAG}-arm64v8 --os linux --arch arm64 --variant v8 \
 			&& docker manifest push --purge storjlabs/$$c:$$t \
 		; done \
 	; done

--- a/cmd/uplink/cmd/access_test.go
+++ b/cmd/uplink/cmd/access_test.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os/exec"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"storj.io/common/testcontext"
 	"storj.io/storj/cmd/uplink/cmd"
 	"storj.io/uplink"
 )
@@ -53,4 +55,17 @@ func TestRegisterAccessTimeout(t *testing.T) {
 	assert.Equal(t, "", secretKey)
 	assert.Equal(t, "", endpoint)
 	close(ch)
+}
+
+func TestAccessImport(t *testing.T) {
+	ctx := testcontext.New(t)
+	defer ctx.Cleanup()
+
+	const testAccess = "12edqwjdy4fmoHasYrxLzmu8Ubv8Hsateq1LPYne6Jzd64qCsYgET53eJzhB4L2pWDKBpqMowxt8vqLCbYxu8Qz7BJVH1CvvptRt9omm24k5GAq1R99mgGjtmc6yFLqdEFgdevuQwH5yzXCEEtbuBYYgES8Stb1TnuSiU3sa62bd2G88RRgbTCtwYrB8HZ7CLjYWiWUphw7RNa3NfD1TW6aUJ6E5D1F9AM6sP58X3D4H7tokohs2rqCkwRT"
+
+	uplinkExe := ctx.Compile("storj.io/storj/cmd/uplink")
+
+	output, err := exec.Command(uplinkExe, "--config-dir", ctx.Dir("uplink"), "import", testAccess).CombinedOutput()
+	t.Log(string(output))
+	require.NoError(t, err)
 }

--- a/cmd/uplink/cmd/import.go
+++ b/cmd/uplink/cmd/import.go
@@ -207,11 +207,12 @@ func createConfigFile(path string) error {
 		return err
 	}
 
-	_, err = os.Create(path)
+	f, err := os.Create(path)
 	if err != nil {
 		return err
 	}
-	return nil
+
+	return f.Close()
 }
 
 func fileExists(path string) (bool, error) {

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	google.golang.org/api v0.20.0 // indirect
 	gopkg.in/segmentio/analytics-go.v3 v3.1.0
-	storj.io/common v0.0.0-20210412024514-5bcb1fff421e
+	storj.io/common v0.0.0-20210419144031-ad3ee05f6339
 	storj.io/drpc v0.0.20
 	storj.io/monkit-jaeger v0.0.0-20210225162224-66fb37637bf6
 	storj.io/private v0.0.0-20210403210935-5fd57695864c

--- a/go.sum
+++ b/go.sum
@@ -942,8 +942,8 @@ sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3
 storj.io/common v0.0.0-20200424175742-65ac59022f4f/go.mod h1:pZyXiIE7bGETIRXtfs0nICqMwp7PM8HqnDuyUeldNA0=
 storj.io/common v0.0.0-20201026135900-1aaeec90670b/go.mod h1:GqdmNf3fLm2UZX/7Zr0BLFCJ4gFjgm6eHrk/fnmr5jQ=
 storj.io/common v0.0.0-20210406151410-a1147267017f/go.mod h1:Udjm4roy/lhL7PHDWlNVhuVxlohcPiyHMeuigw94SDE=
-storj.io/common v0.0.0-20210412024514-5bcb1fff421e h1:/kXB89KYCVxgY37YjQXvCfNUpSTMDaJfCYeDnT4ar9A=
-storj.io/common v0.0.0-20210412024514-5bcb1fff421e/go.mod h1:Udjm4roy/lhL7PHDWlNVhuVxlohcPiyHMeuigw94SDE=
+storj.io/common v0.0.0-20210419144031-ad3ee05f6339 h1:0fk0OoTM845asE4xJs0psPeYDnykqNQyfTjgne4dU1g=
+storj.io/common v0.0.0-20210419144031-ad3ee05f6339/go.mod h1:Udjm4roy/lhL7PHDWlNVhuVxlohcPiyHMeuigw94SDE=
 storj.io/drpc v0.0.11/go.mod h1:TiFc2obNjL9/3isMW1Rpxjy8V9uE0B2HMeMFGiiI7Iw=
 storj.io/drpc v0.0.14/go.mod h1:82nfl+6YwRwF6UG31cEWWUqv/FaKvP5SGqUvoqTxCMA=
 storj.io/drpc v0.0.20 h1:nzOxsetLi0fJ8xCL92LPlYL0B6iYdDDk1Cpdbn0/r9Y=


### PR DESCRIPTION
What: windows uplink binaries are broken

Why: this is a bump of the release for just uplink binaries. we don't need new deploys.
