### PR TITLE
satellite/rolluparchive: archiveAge use 90d prod default for storj-sim

### DIFF
--- a/satellite/accounting/rolluparchive/rolluparchive.go
+++ b/satellite/accounting/rolluparchive/rolluparchive.go
@@ -24,7 +24,7 @@ var (
 // Config contains configurable values for rollup archiver.
 type Config struct {
 	Interval   time.Duration `help:"how frequently rollup archiver should run" releaseDefault:"24h" devDefault:"120s"`
-	ArchiveAge time.Duration `help:"age at which a rollup is archived" releaseDefault:"2160h" devDefault:"24h"`
+	ArchiveAge time.Duration `help:"age at which a rollup is archived" default:"2160h"`
 	BatchSize  int           `help:"number of records to delete per delete execution. Used only for crdb which is slow without limit." default:"500"`
 	Enabled    bool          `help:"whether or not the rollup archive is enabled." default:"true"`
 }


### PR DESCRIPTION
What: Remove the 24h devDefault and use the 90d prod default instead.

Why: The 24h devDefault makes it hard to test billing locally. The traffic gets moved into an archive before we can generate any invoices.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
