### PR TITLE
storage/filestore: test interaction between VerifyDir Readable and Writeable

### DIFF
--- a/storage/filestore/store_test.go
+++ b/storage/filestore/store_test.go
@@ -894,6 +894,10 @@ func TestStorageDirVerification(t *testing.T) {
 	// test nonexistent file returns error
 	require.Error(t, store.VerifyStorageDir(ctx, ident0.ID))
 
+	// test VerifyWrite doesn't interfere
+	require.NoError(t, store.CheckWritability(ctx))
+	require.Error(t, store.VerifyStorageDir(ctx, ident0.ID))
+
 	require.NoError(t, dir.CreateVerificationFile(ctx, ident0.ID))
 
 	// test correct ID returns no error


### PR DESCRIPTION
What: Add test steps to make sure VerifyDirWriteable doesn't create the file for VerifyDirReadable. Even if the write test gets executed first the read test should still throw an error.

Why: There was a question in the community. What happens if the storage node drive gets unmounted and the storage node continues with an empty directory instead. Wouldn't the VerifyDirWriteable check create the file and the VerifyDirReadable pass after that? The answer is no. They use different files. This unit test will double-check that.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
