### PR TITLE
satellite/payments: Fix discount when listing invoices.

### DIFF
--- a/satellite/payments/stripecoinpayments/invoices.go
+++ b/satellite/payments/stripecoinpayments/invoices.go
@@ -32,7 +32,7 @@ func (invoices *invoices) List(ctx context.Context, userID uuid.UUID) (invoicesL
 	params := &stripe.InvoiceListParams{
 		Customer: &customerID,
 	}
-	params.AddExpand("total_discount_amounts.discount")
+	params.AddExpand("data.total_discount_amounts.discount")
 
 	invoicesIterator := invoices.service.stripeClient.Invoices().List(params)
 	for invoicesIterator.Next() {


### PR DESCRIPTION
The error message Stripe's API was sending:
"This property cannot be expanded (total_discount_amounts).
You may want to try expanding 'data.total_discount_amounts' instead."

Change-Id: I9f8cea4107d826d837755be2c3c04675a36f3c37


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
