### PR TITLE
storagenode/payouts: Fix monthly earning estimation

### DIFF
--- a/private/date/utils.go
+++ b/private/date/utils.go
@@ -58,3 +58,10 @@ func UTCEndOfMonth(now time.Time) time.Time {
 	y, m, _ := now.Date()
 	return time.Date(y, m+1, 1, 0, 0, 0, 0, &time.Location{}).Add(-time.Nanosecond)
 }
+
+// UTCBeginOfMonth returns utc begin of month (f.e. to get first day in month at 00h00m).
+func UTCBeginOfMonth(now time.Time) time.Time {
+	now = now.UTC()
+	y, m, _ := now.Date()
+	return time.Date(y, m, 1, 0, 0, 0, 0, &time.Location{})
+}

--- a/storagenode/payouts/estimatedpayouts/estimatedpayouts_test.go
+++ b/storagenode/payouts/estimatedpayouts/estimatedpayouts_test.go
@@ -24,7 +24,7 @@ func TestCurrentMonthExpectations(t *testing.T) {
 	}
 	tests := []test{
 		// 28 days in month
-		{time.Date(2021, 2, 1, 16, 0, 0, 0, time.UTC), 2800.00, time.Date(2021, 1, 1, 12, 0, 0, 0, time.UTC),
+		{time.Date(2021, 2, 1, 16, 0, 0, 0, time.UTC), 4199.00, time.Date(2021, 1, 1, 12, 0, 0, 0, time.UTC),
 			estimatedpayouts.EstimatedPayout{},
 			estimatedpayouts.PayoutMonthly{
 				EgressBandwidth:         123,
@@ -48,7 +48,7 @@ func TestCurrentMonthExpectations(t *testing.T) {
 				Payout:                  payout,
 				Held:                    901,
 			}},
-		{time.Date(2021, 2, 28, 10, 0, 0, 0, time.UTC), 103, time.Date(2021, 1, 26, 10, 0, 0, 0, time.UTC),
+		{time.Date(2021, 2, 28, 10, 0, 0, 0, time.UTC), 102, time.Date(2021, 1, 26, 10, 0, 0, 0, time.UTC),
 			estimatedpayouts.EstimatedPayout{},
 			estimatedpayouts.PayoutMonthly{
 				EgressBandwidth:         123,
@@ -72,7 +72,7 @@ func TestCurrentMonthExpectations(t *testing.T) {
 				Payout:                  payout,
 				Held:                    901,
 			}},
-		{time.Date(2021, 2, 28, 10, 0, 0, 0, time.UTC), 215, time.Date(2021, 2, 15, 10, 0, 0, 0, time.UTC),
+		{time.Date(2021, 2, 28, 10, 0, 0, 0, time.UTC), 104, time.Date(2021, 2, 15, 10, 0, 0, 0, time.UTC),
 			estimatedpayouts.EstimatedPayout{},
 			estimatedpayouts.PayoutMonthly{
 				EgressBandwidth:         123,
@@ -97,7 +97,7 @@ func TestCurrentMonthExpectations(t *testing.T) {
 				Held:                    901,
 			}},
 		// 31 days in month
-		{time.Date(2021, 3, 1, 19, 0, 0, 0, time.UTC), 3100.0, time.Date(2021, 1, 1, 19, 0, 0, 0, time.UTC),
+		{time.Date(2021, 3, 1, 19, 0, 0, 0, time.UTC), 3915.0, time.Date(2021, 1, 1, 19, 0, 0, 0, time.UTC),
 			estimatedpayouts.EstimatedPayout{},
 			estimatedpayouts.PayoutMonthly{
 				EgressBandwidth:         123,
@@ -121,7 +121,7 @@ func TestCurrentMonthExpectations(t *testing.T) {
 				Payout:                  payout,
 				Held:                    901,
 			}},
-		{time.Date(2021, 3, 31, 21, 0, 0, 0, time.UTC), 103, time.Date(2021, 1, 31, 21, 0, 0, 0, time.UTC),
+		{time.Date(2021, 3, 31, 21, 0, 0, 0, time.UTC), 100, time.Date(2021, 1, 31, 21, 0, 0, 0, time.UTC),
 			estimatedpayouts.EstimatedPayout{},
 			estimatedpayouts.PayoutMonthly{
 				EgressBandwidth:         123,
@@ -145,7 +145,7 @@ func TestCurrentMonthExpectations(t *testing.T) {
 				Payout:                  payout,
 				Held:                    901,
 			}},
-		{time.Date(2021, 3, 31, 21, 0, 0, 0, time.UTC), 193, time.Date(2021, 3, 15, 21, 0, 0, 0, time.UTC),
+		{time.Date(2021, 3, 31, 21, 0, 0, 0, time.UTC), 100, time.Date(2021, 3, 15, 21, 0, 0, 0, time.UTC),
 			estimatedpayouts.EstimatedPayout{},
 			estimatedpayouts.PayoutMonthly{
 				EgressBandwidth:         123,


### PR DESCRIPTION
## What: 
- Use minutes instead of days in earning estimation monthly
## Why:
To fix https://github.com/storj/storj/issues/4056

### The problem:
- Currently, the interpolation unit is day. This is largely inaccurate, as described in issue https://github.com/storj/storj/issues/4056
- Moreover, the estimation monthly is using full months. For example, if a node joined on 15th of March, it is still estimated to earn from 1st of March to the end of March, while actually it should be estimated only from 15th of March to the end of March.

### Please describe the tests:

`TestCurrentMonthExpectations` is already doing the job well. We need however to change the expected value to reflect better estimation accuracy
 
### Please describe the performance impact:

It should only impact the visualization of the earning estimation. 

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
