### PR TITLE
satellite/repair: only record audit result if segment can be downloaded

### DIFF
--- a/satellite/repair/repair_test.go
+++ b/satellite/repair/repair_test.go
@@ -569,26 +569,15 @@ func testFailedDataRepair(t *testing.T, inMemoryRepair bool) {
 			nodesReputationAfter[piece.StorageNode] = *info
 		}
 
-		// repair should update audit status
-		for _, piece := range availablePieces[1 : len(availablePieces)-1] {
+		// repair shouldn't update audit status
+		for _, piece := range availablePieces {
 			successfulNodeReputation := nodesReputation[piece.StorageNode]
 			successfulNodeReputationAfter := nodesReputationAfter[piece.StorageNode]
-			require.Equal(t, successfulNodeReputation.TotalAuditCount+1, successfulNodeReputationAfter.TotalAuditCount)
-			require.Equal(t, successfulNodeReputation.AuditSuccessCount+1, successfulNodeReputationAfter.AuditSuccessCount)
-			require.True(t, successfulNodeReputation.AuditReputationAlpha < successfulNodeReputationAfter.AuditReputationAlpha)
-			require.True(t, successfulNodeReputation.AuditReputationBeta >= successfulNodeReputationAfter.AuditReputationBeta)
+			require.Equal(t, successfulNodeReputation.TotalAuditCount, successfulNodeReputationAfter.TotalAuditCount)
+			require.Equal(t, successfulNodeReputation.AuditSuccessCount, successfulNodeReputationAfter.AuditSuccessCount)
+			require.Equal(t, successfulNodeReputation.AuditReputationAlpha, successfulNodeReputationAfter.AuditReputationAlpha)
+			require.Equal(t, successfulNodeReputation.AuditReputationBeta, successfulNodeReputationAfter.AuditReputationBeta)
 		}
-
-		offlineNodeReputation := nodesReputation[offlinePiece.StorageNode]
-		offlineNodeReputationAfter := nodesReputationAfter[offlinePiece.StorageNode]
-		require.Equal(t, offlineNodeReputation.TotalAuditCount+1, offlineNodeReputationAfter.TotalAuditCount)
-		require.Equal(t, int32(0), offlineNodeReputationAfter.AuditHistory.Windows[0].OnlineCount)
-
-		badNodeReputation := nodesReputation[unknownPiece.StorageNode]
-		badNodeReputationAfter := nodesReputationAfter[unknownPiece.StorageNode]
-		require.Equal(t, badNodeReputation.TotalAuditCount+1, badNodeReputationAfter.TotalAuditCount)
-		require.True(t, badNodeReputation.UnknownAuditReputationBeta < badNodeReputationAfter.UnknownAuditReputationBeta)
-		require.True(t, badNodeReputation.UnknownAuditReputationAlpha >= badNodeReputationAfter.UnknownAuditReputationAlpha)
 
 		// repair should fail, so segment should contain all the original nodes
 		segmentAfter, _ := getRemoteSegment(ctx, t, satellite, planet.Uplinks[0].Projects[0].ID, "testbucket")
@@ -1077,21 +1066,15 @@ func testMissingPieceDataRepairFailed(t *testing.T, inMemoryRepair bool) {
 			nodesReputationAfter[piece.StorageNode] = *info
 		}
 
-		// repair should update audit status
+		// repair shouldn't update audit status
 		for _, piece := range successful {
 			successfulNodeReputation := nodesReputation[piece.StorageNode]
 			successfulNodeReputationAfter := nodesReputationAfter[piece.StorageNode]
-			require.Equal(t, successfulNodeReputation.TotalAuditCount+1, successfulNodeReputationAfter.TotalAuditCount)
-			require.Equal(t, successfulNodeReputation.AuditSuccessCount+1, successfulNodeReputationAfter.AuditSuccessCount)
-			require.True(t, successfulNodeReputation.AuditReputationAlpha < successfulNodeReputationAfter.AuditReputationAlpha)
-			require.True(t, successfulNodeReputation.AuditReputationBeta >= successfulNodeReputationAfter.AuditReputationBeta)
+			require.Equal(t, successfulNodeReputation.TotalAuditCount, successfulNodeReputationAfter.TotalAuditCount)
+			require.Equal(t, successfulNodeReputation.AuditSuccessCount, successfulNodeReputationAfter.AuditSuccessCount)
+			require.Equal(t, successfulNodeReputation.AuditReputationAlpha, successfulNodeReputationAfter.AuditReputationAlpha)
+			require.Equal(t, successfulNodeReputation.AuditReputationBeta, successfulNodeReputationAfter.AuditReputationBeta)
 		}
-
-		missingPieceNodeReputation := nodesReputation[missingPiece.StorageNode]
-		missingPieceNodeReputationAfter := nodesReputationAfter[missingPiece.StorageNode]
-		require.Equal(t, missingPieceNodeReputation.TotalAuditCount+1, missingPieceNodeReputationAfter.TotalAuditCount)
-		require.True(t, missingPieceNodeReputation.AuditReputationBeta < missingPieceNodeReputationAfter.AuditReputationBeta)
-		require.True(t, missingPieceNodeReputation.AuditReputationAlpha >= missingPieceNodeReputationAfter.AuditReputationAlpha)
 
 		// repair should fail, so segment should contain all the original nodes
 		segmentAfter, _ := getRemoteSegment(ctx, t, satellite, planet.Uplinks[0].Projects[0].ID, "testbucket")
@@ -1325,21 +1308,15 @@ func testCorruptDataRepairFailed(t *testing.T, inMemoryRepair bool) {
 			nodesReputationAfter[piece.StorageNode] = *info
 		}
 
-		// repair should update audit status
+		// repair shouldn't update audit status
 		for _, piece := range successful {
 			successfulNodeReputation := nodesReputation[piece.StorageNode]
 			successfulNodeReputationAfter := nodesReputationAfter[piece.StorageNode]
-			require.Equal(t, successfulNodeReputation.TotalAuditCount+1, successfulNodeReputationAfter.TotalAuditCount)
-			require.Equal(t, successfulNodeReputation.AuditSuccessCount+1, successfulNodeReputationAfter.AuditSuccessCount)
-			require.True(t, successfulNodeReputation.AuditReputationAlpha < successfulNodeReputationAfter.AuditReputationAlpha)
-			require.True(t, successfulNodeReputation.AuditReputationBeta >= successfulNodeReputationAfter.AuditReputationBeta)
+			require.Equal(t, successfulNodeReputation.TotalAuditCount, successfulNodeReputationAfter.TotalAuditCount)
+			require.Equal(t, successfulNodeReputation.AuditSuccessCount, successfulNodeReputationAfter.AuditSuccessCount)
+			require.Equal(t, successfulNodeReputation.AuditReputationAlpha, successfulNodeReputationAfter.AuditReputationAlpha)
+			require.Equal(t, successfulNodeReputation.AuditReputationBeta, successfulNodeReputationAfter.AuditReputationBeta)
 		}
-
-		corruptedNodeReputation := nodesReputation[corruptedPiece.StorageNode]
-		corruptedNodeReputationAfter := nodesReputationAfter[corruptedPiece.StorageNode]
-		require.Equal(t, corruptedNodeReputation.TotalAuditCount+1, corruptedNodeReputationAfter.TotalAuditCount)
-		require.True(t, corruptedNodeReputation.AuditReputationBeta < corruptedNodeReputationAfter.AuditReputationBeta)
-		require.True(t, corruptedNodeReputation.AuditReputationAlpha >= corruptedNodeReputationAfter.AuditReputationAlpha)
 
 		// repair should fail, so segment should contain all the original nodes
 		segmentAfter, _ := getRemoteSegment(ctx, t, satellite, planet.Uplinks[0].Projects[0].ID, "testbucket")

--- a/satellite/repair/repairer/segments.go
+++ b/satellite/repair/repairer/segments.go
@@ -317,24 +317,6 @@ func (repairer *SegmentRepairer) Repair(ctx context.Context, queueSegment *queue
 	if len(piecesReport.Contained) > 0 {
 		repairer.log.Debug("unexpected contained pieces during repair", zap.Int("count", len(piecesReport.Contained)))
 	}
-	var report audit.Report
-	for _, piece := range piecesReport.Successful {
-		report.Successes = append(report.Successes, piece.StorageNode)
-	}
-	for _, piece := range piecesReport.Failed {
-		report.Fails = append(report.Fails, piece.StorageNode)
-	}
-	for _, piece := range piecesReport.Offline {
-		report.Offlines = append(report.Offlines, piece.StorageNode)
-	}
-	for _, piece := range piecesReport.Unknown {
-		report.Unknown = append(report.Unknown, piece.StorageNode)
-	}
-	_, reportErr := repairer.reporter.RecordAudits(ctx, report)
-	if reportErr != nil {
-		// failed updates should not affect repair, therefore we will not return the error
-		repairer.log.Debug("failed to record audit", zap.Error(reportErr))
-	}
 
 	if err != nil {
 		// If the context was closed during the Get phase, it will appear here as though
@@ -364,6 +346,26 @@ func (repairer *SegmentRepairer) Repair(ctx context.Context, queueSegment *queue
 		return true, repairReconstructError.New("segment could not be reconstructed: %w", err)
 	}
 	defer func() { err = errs.Combine(err, segmentReader.Close()) }()
+
+	// only report audit result when segment can be successfully downloaded
+	var report audit.Report
+	for _, piece := range piecesReport.Successful {
+		report.Successes = append(report.Successes, piece.StorageNode)
+	}
+	for _, piece := range piecesReport.Failed {
+		report.Fails = append(report.Fails, piece.StorageNode)
+	}
+	for _, piece := range piecesReport.Offline {
+		report.Offlines = append(report.Offlines, piece.StorageNode)
+	}
+	for _, piece := range piecesReport.Unknown {
+		report.Unknown = append(report.Unknown, piece.StorageNode)
+	}
+	_, reportErr := repairer.reporter.RecordAudits(ctx, report)
+	if reportErr != nil {
+		// failed updates should not affect repair, therefore we will not return the error
+		repairer.log.Debug("failed to record audit", zap.Error(reportErr))
+	}
 
 	// Upload the repaired pieces
 	successfulNodes, _, err := repairer.ec.Repair(ctx, putLimits, putPrivateKey, redundancy, segmentReader, repairer.timeout, minSuccessfulNeeded)


### PR DESCRIPTION
If satellite can't find enough nodes to successfully download a segment,
it probably is not the fault of storage nodes.

Change-Id: I681f66056df0bb940da9edb3a7dbb3658c0a56cb


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
