### PR TITLE
satellite/orders: log level warn for remaining "bucketName or projectID not set"

### DIFF
--- a/satellite/orders/endpoint.go
+++ b/satellite/orders/endpoint.go
@@ -323,7 +323,7 @@ func (endpoint *Endpoint) SettlementWithWindowFinal(stream pb.DRPCOrders_Settlem
 		// log error only for orders created by users, for satellite actions order limits are created
 		// without bucket name and project ID because segments loop doesn't have access to it
 		if !satelliteAction && (bucketInfo.BucketName == "" || bucketInfo.ProjectID.IsZero()) {
-			log.Debug("decrypt order: bucketName or projectID not set",
+			log.Warn("decrypt order: bucketName or projectID not set",
 				zap.String("bucketName", bucketInfo.BucketName),
 				zap.String("projectID", bucketInfo.ProjectID.String()),
 			)


### PR DESCRIPTION
What: For customer downloads bucketName and projectID is required otherwise our billing will fail. -> log level warn

Why:  It was reduced to log level debug because besides customer downloads we also had repair and audit traffic printing out many log messages. These orders will not print out this message anymore. The remaining customer downloads should all have bucketName and projectID set.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
