### PR TITLE
Revert "storagenode: display quic status on SNO dashboard"

### DIFF
--- a/private/server/server.go
+++ b/private/server/server.go
@@ -118,9 +118,6 @@ func (p *Server) DRPC() *drpcmux.Mux { return p.public.mux }
 // PrivateDRPC returns the server's dRPC mux for registration purposes.
 func (p *Server) PrivateDRPC() *drpcmux.Mux { return p.private.mux }
 
-// IsQUICEnabled checks if QUIC is enabled.
-func (p *Server) IsQUICEnabled() bool { return !p.public.disableQUIC && p.public.quicListener != nil }
-
 // Close shuts down the server.
 func (p *Server) Close() error {
 	p.mu.Lock()

--- a/storagenode/console/service.go
+++ b/storagenode/console/service.go
@@ -61,17 +61,13 @@ type Service struct {
 	walletFeatures operator.WalletFeatures
 	startedAt      time.Time
 	versionInfo    version.Info
-
-	quicEnabled    bool
-	configuredPort string
 }
 
 // NewService returns new instance of Service.
 func NewService(log *zap.Logger, bandwidth bandwidth.DB, pieceStore *pieces.Store, version *checker.Service,
 	allocatedDiskSpace memory.Size, walletAddress string, versionInfo version.Info, trust *trust.Pool,
 	reputationDB reputation.DB, storageUsageDB storageusage.DB, pricingDB pricing.DB, satelliteDB satellites.DB,
-	pingStats *contact.PingStats, contact *contact.Service, estimation *estimatedpayouts.Service, usageCache *pieces.BlobsUsageCache,
-	walletFeatures operator.WalletFeatures, port string, quicEnabled bool) (*Service, error) {
+	pingStats *contact.PingStats, contact *contact.Service, estimation *estimatedpayouts.Service, usageCache *pieces.BlobsUsageCache, walletFeatures operator.WalletFeatures) (*Service, error) {
 	if log == nil {
 		return nil, errs.New("log can't be nil")
 	}
@@ -123,8 +119,6 @@ func NewService(log *zap.Logger, bandwidth bandwidth.DB, pieceStore *pieces.Stor
 		startedAt:          time.Now(),
 		versionInfo:        versionInfo,
 		walletFeatures:     walletFeatures,
-		quicEnabled:        quicEnabled,
-		configuredPort:     port,
 	}, nil
 }
 
@@ -155,9 +149,6 @@ type Dashboard struct {
 	UpToDate       bool           `json:"upToDate"`
 
 	StartedAt time.Time `json:"startedAt"`
-
-	ConfiguredPort string `json:"configuredPort"`
-	QUICEnabled    bool   `json:"quicEnabled"`
 }
 
 // GetDashboardData returns stale dashboard data.
@@ -173,9 +164,6 @@ func (s *Service) GetDashboardData(ctx context.Context) (_ *Dashboard, err error
 
 	data.LastPinged = s.pingStats.WhenLastPinged()
 	data.AllowedVersion, data.UpToDate = s.version.IsAllowed(ctx)
-
-	data.QUICEnabled = s.quicEnabled
-	data.ConfiguredPort = s.configuredPort
 
 	stats, err := s.reputationDB.All(ctx)
 	if err != nil {

--- a/storagenode/peer.go
+++ b/storagenode/peer.go
@@ -635,7 +635,6 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 	}
 
 	{ // setup storage node operator dashboard
-		_, port, _ := net.SplitHostPort(peer.Addr())
 		peer.Console.Service, err = console.NewService(
 			peer.Log.Named("console:service"),
 			peer.DB.Bandwidth(),
@@ -654,8 +653,6 @@ func New(log *zap.Logger, full *identity.FullIdentity, db DB, revocationDB exten
 			peer.Estimation.Service,
 			peer.Storage2.BlobsCache,
 			config.Operator.WalletFeatures,
-			port,
-			peer.Server.IsQUICEnabled(),
 		)
 		if err != nil {
 			return nil, errs.Combine(err, peer.Close())

--- a/web/storagenode/src/app/components/SNOContentTitle.vue
+++ b/web/storagenode/src/app/components/SNOContentTitle.vue
@@ -18,28 +18,6 @@
                 <p v-else class="title-area__info-container__info-item__content offline-status">Offline</p>
             </div>
             <div class="title-area-divider" />
-
-            <VInfo
-                v-if="info.quicEnabled"
-                :text="'QUIC is configured to use UDP port ' + info.configuredPort"
-            >
-                <div class="title-area__info-container__info-item">
-                    <p class="title-area__info-container__info-item__title">QUIC</p>
-                    <p class="title-area__info-container__info-item__content online-status">OK</p>
-                </div>
-            </VInfo>
-            <VInfo
-                v-if="!info.quicEnabled"
-                :text="'QUIC is misconfigured. You must forward port ' + info.configuredPort + ' for both TCP and UDP to enable QUIC.'"
-                bold-text="See https://docs.storj.io/node/dependencies/port-forwarding on how to do this."
-            >
-                <div class="title-area__info-container__info-item">
-                    <p class="title-area__info-container__info-item__title">QUIC</p>
-                    <p class="title-area__info-container__info-item__content offline-status">Misconfigured</p>
-                </div>
-            </VInfo>
-
-            <div class="title-area-divider" />
             <div class="title-area__info-container__info-item">
                 <p class="title-area__info-container__info-item__title">UPTIME</p>
                 <p class="title-area__info-container__info-item__content">{{ uptime }}</p>
@@ -99,18 +77,14 @@ class NodeInfo {
     public allowedVersion: string;
     public wallet: string;
     public isLastVersion: boolean;
-    public quicEnabled: boolean
-    public configuredPort: string
 
-    public constructor(id: string, status: string, version: string, allowedVersion: string, wallet: string, isLastVersion: boolean, quicEnabled: boolean, port: string) {
+    public constructor(id: string, status: string, version: string, allowedVersion: string, wallet: string, isLastVersion: boolean) {
         this.id = id;
         this.status = status;
         this.version = this.toVersionString(version);
         this.allowedVersion = this.toVersionString(allowedVersion);
         this.wallet = wallet;
         this.isLastVersion = isLastVersion;
-        this.quicEnabled = quicEnabled
-        this.configuredPort = port
     }
 
     private toVersionString(version: string): string {
@@ -142,7 +116,7 @@ export default class SNOContentTitle extends Vue {
         const nodeInfo = this.$store.state.node.info;
 
         return new NodeInfo(nodeInfo.id, nodeInfo.status, nodeInfo.version, nodeInfo.allowedVersion, nodeInfo.wallet,
-            nodeInfo.isLastVersion, nodeInfo.quicEnabled, nodeInfo.configuredPort);
+            nodeInfo.isLastVersion);
     }
 
     public get online(): boolean {

--- a/web/storagenode/src/app/store/modules/node.ts
+++ b/web/storagenode/src/app/store/modules/node.ts
@@ -61,8 +61,6 @@ export function newNodeModule(service: StorageNodeService): StoreModule<StorageN
                     nodeInfo.wallet,
                     nodeInfo.walletFeatures,
                     nodeInfo.isUpToDate,
-                    nodeInfo.quicEnabled,
-                    nodeInfo.configuredPort
                 );
 
                 state.utilization = new Utilization(

--- a/web/storagenode/src/storagenode/api/storagenode.ts
+++ b/web/storagenode/src/storagenode/api/storagenode.ts
@@ -45,7 +45,7 @@ export class StorageNodeApi {
         const bandwidth: Traffic = new Traffic(data.bandwidth.used);
 
         return new Dashboard(data.nodeID, data.wallet, data.walletFeatures || [], satellites, diskSpace, bandwidth,
-            new Date(data.lastPinged), new Date(data.startedAt), data.version, data.allowedVersion, data.upToDate, data.quicEnabled, data.configuredPort);
+            new Date(data.lastPinged), new Date(data.startedAt), data.version, data.allowedVersion, data.upToDate);
     }
 
     /**

--- a/web/storagenode/src/storagenode/sno/sno.ts
+++ b/web/storagenode/src/storagenode/sno/sno.ts
@@ -17,8 +17,6 @@ export class Node {
         public wallet: string = '',
         public walletFeatures: string[] = [],
         public isLastVersion: boolean = false,
-        public quicEnabled: boolean = false,
-        public configuredPort: string = '',
     ) {}
 }
 
@@ -75,8 +73,6 @@ export class Dashboard {
         public version: string,
         public allowedVersion: string,
         public isUpToDate: boolean,
-        public quicEnabled: boolean,
-        public configuredPort: string,
     ) { }
 }
 

--- a/web/storagenode/tests/unit/components/DiskStatChart.spec.ts
+++ b/web/storagenode/tests/unit/components/DiskStatChart.spec.ts
@@ -58,8 +58,6 @@ describe('DiskStatChart', (): void => {
                     '0.1.1',
                     '0.2.2',
                     false,
-                    true,
-                    '13000',
                 ),
             ),
         );

--- a/web/storagenode/tests/unit/components/payments/EstimationPeriodDropdown.spec.ts
+++ b/web/storagenode/tests/unit/components/payments/EstimationPeriodDropdown.spec.ts
@@ -73,8 +73,6 @@ describe('EstimationPeriodDropdown', (): void => {
             '0.1.1',
             '0.2.2',
             false,
-            true,
-            '13000',
         );
 
         store.commit(NODE_MUTATIONS.POPULATE_STORE, dashboardInfo);

--- a/web/storagenode/tests/unit/store/node.spec.ts
+++ b/web/storagenode/tests/unit/store/node.spec.ts
@@ -53,8 +53,6 @@ describe('mutations', () => {
             '0.1.1',
             '0.2.2',
             false,
-            true,
-            '13000',
         );
 
         store.commit(NODE_MUTATIONS.POPULATE_STORE, dashboardInfo);
@@ -193,8 +191,6 @@ describe('actions', () => {
                     '0.1.1',
                     '0.2.2',
                     false,
-                    true,
-                    '13000',
                 ),
             ),
         );
@@ -339,8 +335,6 @@ describe('getters', () => {
             '0.1.1',
             '0.2.2',
             false,
-            true,
-            '13000',
         );
 
         store.commit(NODE_MUTATIONS.POPULATE_STORE, dashboardInfo);


### PR DESCRIPTION
This reverts commit 589c82f23e5630ccb7f26f36eb00511b2ba417d8.


What: 

Why: On storagenode dashboard user sees Misconfigured QUIC status which might confuse them

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
