### PR TITLE
cmd/storagenode: load the identity first during node setup

### DIFF
--- a/cmd/storagenode/main.go
+++ b/cmd/storagenode/main.go
@@ -267,6 +267,11 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("storagenode configuration already exists (%v)", setupDir)
 	}
 
+	identity, err := setupCfg.Identity.Load()
+	if err != nil {
+		return err
+	}
+
 	err = os.MkdirAll(setupDir, 0700)
 	if err != nil {
 		return err
@@ -297,11 +302,6 @@ func cmdSetup(cmd *cobra.Command, args []string) (err error) {
 
 	// create db
 	db, err := storagenodedb.OpenNew(ctx, zap.L().Named("db"), setupCfg.DatabaseConfig())
-	if err != nil {
-		return err
-	}
-
-	identity, err := setupCfg.Identity.Load()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This loads the identity before any changes are written to disk. By loading the identity first, then any errors, such as a non-existent identity file, will be discovered before anything is written to disk.  This fixes #4387.

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
