### PR TITLE
cmd/multinode,Makefile: build docker image for multinode dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ images: multinode-image satellite-image storagenode-image versioncontrol-image #
 	echo Built version: ${TAG}
 
 .PHONY: multinode-image
-satellite-image: multinode_linux_arm multinode_linux_arm64 multinode_linux_amd64 ## Build multinode Docker image
+multinode-image: multinode_linux_arm multinode_linux_arm64 multinode_linux_amd64 ## Build multinode Docker image
 	${DOCKER_BUILD} --pull=true -t storjlabs/multinode:${TAG}${CUSTOMTAG}-amd64 \
 		-f cmd/multinode/Dockerfile .
 	${DOCKER_BUILD} --pull=true -t storjlabs/multinode:${TAG}${CUSTOMTAG}-arm32v6 \

--- a/Makefile
+++ b/Makefile
@@ -198,8 +198,19 @@ satellite-wasm:
 	scripts/build-wasm.sh ;\
 
 .PHONY: images
-images: satellite-image storagenode-image versioncontrol-image ## Build satellite, storagenode, and versioncontrol Docker images
+images: multinode-image satellite-image storagenode-image versioncontrol-image ## Build multinode, satellite, storagenode, and versioncontrol Docker images
 	echo Built version: ${TAG}
+
+.PHONY: multinode-image
+satellite-image: multinode_linux_arm multinode_linux_arm64 multinode_linux_amd64 ## Build multinode Docker image
+	${DOCKER_BUILD} --pull=true -t storjlabs/multinode:${TAG}${CUSTOMTAG}-amd64 \
+		-f cmd/multinode/Dockerfile .
+	${DOCKER_BUILD} --pull=true -t storjlabs/multinode:${TAG}${CUSTOMTAG}-arm32v6 \
+		--build-arg=GOARCH=arm --build-arg=DOCKER_ARCH=arm32v6 \
+		-f cmd/multinode/Dockerfile .
+	${DOCKER_BUILD} --pull=true -t storjlabs/multinode:${TAG}${CUSTOMTAG}-arm64v8 \
+		--build-arg=GOARCH=arm64 --build-arg=DOCKER_ARCH=arm64v8 \
+		-f cmd/multinode/Dockerfile .
 
 .PHONY: satellite-image
 satellite-image: satellite_linux_arm satellite_linux_arm64 satellite_linux_amd64 ## Build satellite Docker image
@@ -291,6 +302,9 @@ identity_%:
 .PHONY: inspector_%
 inspector_%:
 	$(MAKE) binary-check COMPONENT=inspector GOARCH=$(word 3, $(subst _, ,$@)) GOOS=$(word 2, $(subst _, ,$@))
+.PHONE: multinode_%
+multinode_%: multinode-console
+	$(MAKE) binary-check COMPONENT=multinode GOARCH=$(word 3, $(subst _, ,$@)) GOOS=$(word 2, $(subst _, ,$@))
 .PHONY: satellite_%
 satellite_%: satellite-admin-ui
 	$(MAKE) binary-check COMPONENT=satellite GOARCH=$(word 3, $(subst _, ,$@)) GOOS=$(word 2, $(subst _, ,$@))
@@ -311,11 +325,11 @@ multinode_%: multinode-console
 	$(MAKE) binary-check COMPONENT=multinode GOARCH=$(word 3, $(subst _, ,$@)) GOOS=$(word 2, $(subst _, ,$@))
 
 
-COMPONENTLIST := certificates identity inspector satellite storagenode storagenode-updater uplink versioncontrol multinode
+COMPONENTLIST := certificates identity inspector multinode satellite storagenode storagenode-updater uplink versioncontrol
 OSARCHLIST    := linux_amd64 linux_arm linux_arm64 windows_amd64 freebsd_amd64
 BINARIES      := $(foreach C,$(COMPONENTLIST),$(foreach O,$(OSARCHLIST),$C_$O))
 .PHONY: binaries
-binaries: ${BINARIES} ## Build certificates, identity, inspector, satellite, storagenode, uplink, versioncontrol and multinode binaries (jenkins)
+binaries: ${BINARIES} ## Build certificates, identity, inspector, multinode, satellite, storagenode, uplink, versioncontrol and multinode binaries (jenkins)
 
 .PHONY: sign-windows-installer
 sign-windows-installer:
@@ -326,8 +340,7 @@ sign-windows-installer:
 .PHONY: push-images
 push-images: ## Push Docker images to Docker Hub (jenkins)
 	# images have to be pushed before a manifest can be created
-	# satellite
-	for c in satellite storagenode uplink versioncontrol ; do \
+	for c in multinode satellite storagenode uplink versioncontrol ; do \
 		docker push storjlabs/$$c:${TAG}${CUSTOMTAG}-amd64 \
 		&& docker push storjlabs/$$c:${TAG}${CUSTOMTAG}-arm32v6 \
 		&& docker push storjlabs/$$c:${TAG}${CUSTOMTAG}-arm64v8 \
@@ -373,6 +386,7 @@ binaries-clean: ## Remove all local release binaries (jenkins)
 
 .PHONY: clean-images
 clean-images:
+	-docker rmi storjlabs/multinode:${TAG}${CUSTOMTAG}
 	-docker rmi storjlabs/satellite:${TAG}${CUSTOMTAG}
 	-docker rmi storjlabs/storagenode:${TAG}${CUSTOMTAG}
 	-docker rmi storjlabs/versioncontrol:${TAG}${CUSTOMTAG}

--- a/cmd/multinode/Dockerfile
+++ b/cmd/multinode/Dockerfile
@@ -8,10 +8,8 @@ FROM ${DOCKER_ARCH:-amd64}/alpine
 ARG TAG
 ARG GOARCH
 ENV GOARCH ${GOARCH}
-
-ENV CONF_PATH=/root/.local/storj/multinode
+EXPOSE 15002
 WORKDIR /app
-VOLUME /root/.local/storj/multinode
 COPY --from=ca-cert /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY release/${TAG}/multinode_linux_${GOARCH:-amd64} /app/multinode
 COPY cmd/multinode/entrypoint /entrypoint

--- a/cmd/multinode/Dockerfile
+++ b/cmd/multinode/Dockerfile
@@ -1,0 +1,18 @@
+ARG DOCKER_ARCH
+
+# Fetch ca-certificates file for arch independent builds below
+FROM alpine as ca-cert
+RUN apk -U add ca-certificates
+
+FROM ${DOCKER_ARCH:-amd64}/alpine
+ARG TAG
+ARG GOARCH
+ENV GOARCH ${GOARCH}
+
+ENV CONF_PATH=/root/.local/storj/multinode
+WORKDIR /app
+VOLUME /root/.local/storj/multinode
+COPY --from=ca-cert /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY release/${TAG}/multinode_linux_${GOARCH:-amd64} /app/multinode
+COPY cmd/multinode/entrypoint /entrypoint
+ENTRYPOINT ["/entrypoint"]

--- a/cmd/multinode/README.md
+++ b/cmd/multinode/README.md
@@ -1,0 +1,23 @@
+# Multinode Dashboard
+
+## Reference Articles
+
+[Tech Preview Forum Post](https://forum.storj.io/t/tech-preview-multinode-dashboard-binaries/14572)
+
+## Running in Docker
+
+In order to run this docker image, you need to generate an identity like this:
+```
+identity create multinode --difficulty 10
+```
+
+Then start the image like this, while replacing the directories marked by the `< >` with your parameters below:
+
+```
+docker run -d --restart unless-stopped \
+    --user $(id -u):$(id -g) \
+    -p 127.0.0.1:15002:15002/tcp \
+    --mount type=bind,source="<identity-dir>",destination=/app/identity \
+    --mount type=bind,source="<storage-dir>",destination=/app/config \
+    --name multinode storjlabs/multinode:latest
+```

--- a/cmd/multinode/entrypoint
+++ b/cmd/multinode/entrypoint
@@ -1,9 +1,12 @@
 #!/bin/sh
 set -euo pipefail
 
-if [[ ! -f "${CONF_PATH}/config.yaml" ]]; then
-	./multinode setup
+if [[ ! -f "/app/config/config.yaml" ]]; then
+	./multinode setup --config-dir config --identity-dir identity
 fi
 
-RUN_PARAMS="${RUN_PARAMS:-} --config ${CONF_PATH} --console.address=:15002"
+RUN_PARAMS="${RUN_PARAMS:-} --config-dir config"
+RUN_PARAMS="${RUN_PARAMS:-} --identity-dir identity"
+RUN_PARAMS="${RUN_PARAMS:-} --console.address=:15002"
+
 exec ./multinode run $RUN_PARAMS "$@"

--- a/cmd/multinode/entrypoint
+++ b/cmd/multinode/entrypoint
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -euo pipefail
+
+if [[ ! -f "${CONF_PATH}/config.yaml" ]]; then
+	./multinode setup
+fi
+
+RUN_PARAMS="${RUN_PARAMS:-} --config ${CONF_PATH} --console.address=:15002"
+exec ./multinode run $RUN_PARAMS "$@"


### PR DESCRIPTION
Resolves https://github.com/storj/storj/issues/4547

We do not build an docker image for the multinode dashboard,
which makes monitoring for docker-focused environments harder.
This adds the basic image and ties it into CI/CD.

Change-Id: I14c01a7f1f0019f6f5c1b8fd75dc424fc362b18d

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
