### PR TITLE
cmd/multinode: Add further documentation

### DIFF
--- a/cmd/multinode/README.md
+++ b/cmd/multinode/README.md
@@ -4,12 +4,22 @@
 
 [Tech Preview Forum Post](https://forum.storj.io/t/tech-preview-multinode-dashboard-binaries/14572)
 
-## Running in Docker
+## Generate identity files
 
-In order to run this docker image, you need to generate an identity like this:
+In order to run this Docker image, you need to create an identity for the Multinode Dashboard.
+For this you need the binaries of the Identity Tool, which you can find in the latest version here:
+
+[https://github.com/storj/storj/releases/latest](https://github.com/storj/storj/releases/latest)
+
+In this example under Windows, we use the file `identity_windows_amd64.zip`, download it and unzip it.
+Then we open a PowerShell window in the folder where the `identity.exe` was unzipped and run the following command:
 ```
-identity create multinode --difficulty 10
+./identity.exe create multinode --difficulty 10
 ```
+
+If we run this command on Windows, the identity files will be created in the folder `%appdata%\Storj\Identity\multinode`.
+
+## Running the Multinode Dashboard in Docker
 
 Then start the image like this, while replacing the directories marked by the `< >` with your parameters below:
 
@@ -17,7 +27,7 @@ Then start the image like this, while replacing the directories marked by the `<
 docker run -d --restart unless-stopped \
     --user $(id -u):$(id -g) \
     -p 127.0.0.1:15002:15002/tcp \
-    --mount type=bind,source="<identity-dir>",destination=/app/identity \
-    --mount type=bind,source="<storage-dir>",destination=/app/config \
+    --mount type=bind,source="<multinode-identity-dir>",destination=/app/identity \
+    --mount type=bind,source="<multinode-config-dir>",destination=/app/config \
     --name multinode storjlabs/multinode:latest
 ```


### PR DESCRIPTION
The text has been expanded a bit to clarify that it is necessary to create identity files with an example before using the Docker image.
Changed the <identity-dir> placeholder to <multinode-identity-dir> so no one confuses them with the storagenode identity files.
Changed the <storage-dir> placeholder to <multinode-config-dir> so no one confuses them with the storagenode 'config' folder.

fixed #4547

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
