### PR TITLE
scripts/draft-release: add sleep to avoid race condition on uploading the binaries

### DIFF
--- a/scripts/draft-release.sh
+++ b/scripts/draft-release.sh
@@ -17,6 +17,9 @@ FOLDER="${2-}"
 echo "Drafting release"
 github-release release --user storj --repo storj --tag "$TAG" --draft
 
+echo "Sleep 10 seconds in order to wait for release propagation"
+sleep 10
+
 echo "Uploading binaries to release draft"
 for app in $apps;
 do


### PR DESCRIPTION
It seems that the github API is a little slow/laggy with regards to propagation of whether a release tag has been made or not.
This sleep should fix it and avoid having to retrigger builds.

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
