### PR TITLE
web/multinode: Fix `My Nodes` sidebar item spelling

### DIFF
--- a/web/multinode/src/app/router/index.ts
+++ b/web/multinode/src/app/router/index.ts
@@ -94,7 +94,7 @@ export class Config {
     public static Welcome: Route = new Route('/welcome', 'Welcome', WelcomeScreen);
     // nodes.
     public static AddFirstNode: Route = new Route('/add-first-node', 'AddFirstNode', AddFirstNode);
-    public static MyNodes: Route = new Route('/my-nodes', 'MyNodes', MyNodes);
+    public static MyNodes: Route = new Route('/my-nodes', 'My Nodes', MyNodes);
     // payouts.
     public static PayoutsSummary: Route = new Route('summary', 'PayoutsSummary', PayoutsPage);
     public static PayoutsByNode: Route = new Route('by-node/:id', 'PayoutsByNode', PayoutsByNode);


### PR DESCRIPTION
What: The `MyNodes` section of the sidebar is not correct

Why: It is currently spelled as `MyNodes` when it should be `My Nodes` to match the rest of entries in the menu.

Please describe the tests:
There are no tests for this, as it is a change in a string literal of the UI and there were no previous tests regarding this.
 
Please describe the performance impact:
It has no performing impact, as it is an UI change.

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
