### PR TITLE
satellite/console: disable account activation reminder email

### DIFF
--- a/satellite/console/emailreminders/chore.go
+++ b/satellite/console/emailreminders/chore.go
@@ -27,7 +27,7 @@ type Config struct {
 	FirstVerificationReminder  time.Duration `help:"amount of time before sending first reminder to users who need to verify their email" default:"24h"`
 	SecondVerificationReminder time.Duration `help:"amount of time before sending second reminder to users who need to verify their email" default:"120h"`
 	ChoreInterval              time.Duration `help:"how often to send reminders to users who need to verify their email" default:"24h"`
-	Enable                     bool          `help:"enable sending emails reminding users to verify their email" default:"false"`
+	Enable                     bool          `help:"enable sending emails reminding users to verify their email" releaseDefault:"false" devDefault:"true"`
 }
 
 // Chore checks whether any emails need to be re-sent.

--- a/satellite/console/emailreminders/chore.go
+++ b/satellite/console/emailreminders/chore.go
@@ -27,7 +27,7 @@ type Config struct {
 	FirstVerificationReminder  time.Duration `help:"amount of time before sending first reminder to users who need to verify their email" default:"24h"`
 	SecondVerificationReminder time.Duration `help:"amount of time before sending second reminder to users who need to verify their email" default:"120h"`
 	ChoreInterval              time.Duration `help:"how often to send reminders to users who need to verify their email" default:"24h"`
-	Enable                     bool          `help:"enable sending emails reminding users to verify their email" default:"true"`
+	Enable                     bool          `help:"enable sending emails reminding users to verify their email" default:"false"`
 }
 
 // Chore checks whether any emails need to be re-sent.

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -332,7 +332,7 @@ contact.external-address: ""
 # email-reminders.chore-interval: 24h0m0s
 
 # enable sending emails reminding users to verify their email
-# email-reminders.enable: true
+# email-reminders.enable: false
 
 # amount of time before sending first reminder to users who need to verify their email
 # email-reminders.first-verification-reminder: 24h0m0s


### PR DESCRIPTION
What: Disable account activation reminder email.

Why: In the early days customers had to create multiple accounts (fill out signup form) with the same email address in order to resend the activation email. At the end the customer activated one account. The other accounts are still in the satellite DB and would now trigger an account activation reminder email. We have to disable the reminder email for the moment and cleanup the satellite DB first.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
