### PR TITLE
Add upload and download rate metrics

### DIFF
--- a/storagenode/piecestore/endpoint.go
+++ b/storagenode/piecestore/endpoint.go
@@ -265,6 +265,8 @@ func (endpoint *Endpoint) Upload(stream pb.DRPCPiecestore_UploadStream) (err err
 		uploadRate := float64(0)
 		if dt.Seconds() > 0 {
 			uploadRate = float64(uploadSize) / dt.Seconds()
+			mon.FloatVal("upload_rate_bytes_per_sec_meter").Observe(uploadRate)
+
 		}
 		uploadDuration := dt.Nanoseconds()
 
@@ -513,6 +515,7 @@ func (endpoint *Endpoint) Download(stream pb.DRPCPiecestore_DownloadStream) (err
 		downloadRate := float64(0)
 		if dt.Seconds() > 0 {
 			downloadRate = float64(downloadSize) / dt.Seconds()
+			mon.FloatVal("download_rate_bytes_per_sec_meter", actionSeriesTag).Observe(downloadRate)
 		}
 		downloadDuration := dt.Nanoseconds()
 		if errs2.IsCanceled(err) || drpc.ClosedError.Has(err) {


### PR DESCRIPTION

#### What: 
- Send a metric named `upload_rate_bytes_per_sec_meter`  for upload rate and a metric named `download_rate_bytes_per_sec_meter` for download rate using [monkit](https://github.com/spacemonkeygo/monkit)

#### Why:

- Fix https://github.com/storj/storj/issues/3918

_Tests_: 

Currently monkit metrics are not tested unfortunately
 
_Performance impact:_
- `upload_rate_bytes_per_sec_meter` and `download_rate_bytes_per_sec_meter` are added to metrics, serving as metrics to monitor global download/upload speed of the node.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
