### PR TITLE
satellite/metabase: revert non-recursive listing optimization

### DIFF
--- a/satellite/metabase/iterator.go
+++ b/satellite/metabase/iterator.go
@@ -138,35 +138,19 @@ func (it *objectsIterator) Next(ctx context.Context, item *ObjectEntry) bool {
 	}
 
 	// TODO: implement this on the database side
-
-	// skip prefix to avoid listing all objects from prefixes
-	// inside listed prefix
-	if it.skipPrefix != "" {
-		// drop current results page
-		if rowsErr := it.curRows.Err(); rowsErr != nil {
-			it.failErr = rowsErr
-			return false
-		}
-
-		if closeErr := it.curRows.Close(); closeErr != nil {
-			it.failErr = closeErr
-			return false
-		}
-
-		// set new cursor after prefix we would like to skip
-		it.cursor.Key = it.prefix + prefixLimit(it.skipPrefix)
-		it.cursor.StreamID = uuid.UUID{}
-		it.cursor.Version = 0
-
-		// bump curIndex to not stop iteration because of no more results
-		it.curIndex = it.batchSize
-
-		it.skipPrefix = ""
-	}
-
 	ok := it.next(ctx, item)
 	if !ok {
 		return false
+	}
+
+	// skip until we are past the prefix we returned before.
+	if it.skipPrefix != "" {
+		for strings.HasPrefix(string(item.ObjectKey), string(it.skipPrefix)) {
+			if !it.next(ctx, item) {
+				return false
+			}
+		}
+		it.skipPrefix = ""
 	}
 
 	// should this be treated as a prefix?
@@ -302,7 +286,7 @@ func doNextQueryAllVersionsWithStatus(ctx context.Context, it *objectsIterator) 
 			AND (expires_at IS NULL OR expires_at > now())
 			ORDER BY (project_id, bucket_name, object_key, version) ASC
 		LIMIT $7
-		`, it.projectID, it.bucketName,
+	`, it.projectID, it.bucketName,
 		it.status,
 		[]byte(it.cursor.Key), int(it.cursor.Version),
 		[]byte(it.prefixLimit),


### PR DESCRIPTION
This change reverts satellite/metabase/iterator.go of 7390f389c to the
previous version (without optimization) but leaves added benchmarks in
place.

We noticed that this optimization doesn't work and actually elevates
listing times for most buckets, hence the revert until we come up with a
better idea.

Benchmarks:

name                                                old time/op new time/op delta
NonRecursiveListing/Postgres/listing_no_prefix-8    1.30ms ± 4% 4.52ms ± 4% +246.92% (p=0.008 n=5+5)
NonRecursiveListing/Postgres/listing_with_prefix-8  3.26ms ± 3% 4.44ms ± 2%  +36.19% (p=0.008 n=5+5)
NonRecursiveListing/Cockroach/listing_no_prefix-8    618µs ± 3% 2225µs ± 2% +259.94% (p=0.008 n=5+5)
NonRecursiveListing/Cockroach/listing_with_prefix-8 1.81ms ± 5% 2.60ms ± 5%  +43.96% (p=0.008 n=5+5)

Updates storj/team-metainfo#115

Change-Id: I96e4e7a563b188df478f8489027dc0042469b839


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
