### PR TITLE
point release with fix folder upload

### DIFF
--- a/web/satellite/src/components/browser/FileBrowser.vue
+++ b/web/satellite/src/components/browser/FileBrowser.vue
@@ -38,6 +38,16 @@
                                     multiple
                                     @change="upload"
                                 >
+                                <input
+                                    ref="folderInput"
+                                    type="file"
+                                    aria-roledescription="folder-upload"
+                                    hidden
+                                    multiple
+                                    webkitdirectory
+                                    mozdirectory
+                                    @change="upload"
+                                >
                                 <div v-if="isUploadDropDownShown" class="dropdown">
                                     <div class="dropdown__item">
                                         <div
@@ -51,16 +61,6 @@
                                         </div>
                                     </div>
                                     <div class="dropdown__item">
-                                        <input
-                                            ref="folderInput"
-                                            type="file"
-                                            aria-roledescription="folder-upload"
-                                            hidden
-                                            webkitdirectory
-                                            mozdirectory
-                                            multiple
-                                            @change="upload"
-                                        >
                                         <div
                                             class="upload-option"
                                             @click="buttonFolderUpload"


### PR DESCRIPTION
Fixed folder upload for object browser.
Seems like the issue appeared because user has to cofirm folder upload in browser alert message now. So the problem is that folder upload input is getting unloaded before user approves folder upload.

Change-Id: I5d8377106e5aed74d7c38b2dc88f75370c828d62


What: 
fix for folder upload
Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
