### PR TITLE
satellite/admin/ui/build.sh: create stub go module

### DIFF
--- a/Jenkinsfile.premerge
+++ b/Jenkinsfile.premerge
@@ -41,6 +41,7 @@ pipeline {
                 sh 'echo "module stub" > web/satellite/node_modules/go.mod'
                 sh 'echo "module stub" > web/storagenode/node_modules/go.mod'
                 sh 'echo "module stub" > web/multinode/node_modules/go.mod'
+                sh 'echo "module stub" > satellite/admin/ui/node_modules/go.mod'
             }
         }
         stage('Gerrit status') {

--- a/satellite/admin/ui/build.sh
+++ b/satellite/admin/ui/build.sh
@@ -5,7 +5,7 @@ set -exuo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 npm install --prefer-offline --no-audit --logleve verbose
-touch ./node_modules/go.mod # prevent Go from scanning this dir
+echo "module stub" > ./node_modules/go.mod # prevent Go from scanning this dir
 npm run build
 
 npm audit || true


### PR DESCRIPTION
Without the stub module, the check-downgrade linter fails due to inability to compare the go.mod files.
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
