### PR TITLE
point release 1.66.4 - do not reference nil invoice

### DIFF
--- a/satellite/payments/stripecoinpayments/service.go
+++ b/satellite/payments/stripecoinpayments/service.go
@@ -875,9 +875,11 @@ func (service *Service) CreateInvoices(ctx context.Context, period time.Time) (e
 				return Error.Wrap(err)
 			}
 
-			if stripeInvoice.AutoAdvance {
+			switch {
+			case stripeInvoice == nil:
+			case stripeInvoice.AutoAdvance:
 				scheduled++
-			} else {
+			default:
 				draft++
 			}
 		}
@@ -892,8 +894,8 @@ func (service *Service) CreateInvoices(ctx context.Context, period time.Time) (e
 	return nil
 }
 
-// createInvoice creates invoice for stripe customer. Returns nil error if there are no
-// pending invoice line items for customer.
+// createInvoice creates invoice for stripe customer. Returns nil error and nil invoice
+// if there are no pending invoice line items for customer.
 func (service *Service) createInvoice(ctx context.Context, cusID string, period time.Time) (stripeInvoice *stripe.Invoice, err error) {
 	defer mon.Task()(&ctx)(&err)
 


### PR DESCRIPTION
When a customer has no pending line items, an invoice will not be generated for them and the Stripe client method responsible for creating new invoices returns nil. This change adds a nil check to account for this possibility to ensure that no panics are caused by attempted processing of the invoice.

Change-Id: Id184d027d7447f0ef876db58601ab6cf63927fc5


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
