### PR TITLE
satellite/metabase/rangedloop: minimal loop

### DIFF
--- a/satellite/metabase/rangedloop/provider.go
+++ b/satellite/metabase/rangedloop/provider.go
@@ -1,0 +1,22 @@
+// Copyright (C) 2022 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package rangedloop
+
+import (
+	"context"
+
+	"storj.io/storj/satellite/metabase/segmentloop"
+)
+
+// RangeSplitter gives a way to get non-overlapping ranges of segments concurrently.
+// It usually abstracts over a database.
+// It is a subcomponent of the ranged segment loop.
+type RangeSplitter interface {
+	CreateRanges(nRanges int, batchSize int) ([]SegmentProvider, error)
+}
+
+// SegmentProvider iterates through a range of segments.
+type SegmentProvider interface {
+	Iterate(ctx context.Context, fn func([]segmentloop.Segment) error) error
+}

--- a/satellite/metabase/rangedloop/rangedlooptest/countobserver.go
+++ b/satellite/metabase/rangedloop/rangedlooptest/countobserver.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2022 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package rangedlooptest
+
+import (
+	"context"
+	"time"
+
+	"storj.io/storj/satellite/metabase/rangedloop"
+	"storj.io/storj/satellite/metabase/segmentloop"
+)
+
+var _ rangedloop.Observer = (*CountObserver)(nil)
+var _ rangedloop.Partial = (*CountObserver)(nil)
+
+// CountObserver is a subscriber to the ranged segment  loop which counts the number of segments.
+type CountObserver struct {
+	NumSegments int
+}
+
+// Start is the callback for segment loop start.
+func (c *CountObserver) Start(ctx context.Context, time time.Time) error {
+	c.NumSegments = 0
+	return nil
+}
+
+// Fork splits the observer to count ranges of segments.
+func (c *CountObserver) Fork(ctx context.Context) (rangedloop.Partial, error) {
+	// return new instance for threadsafety
+	return &CountObserver{}, nil
+}
+
+// Join adds the count of all the ranges together.
+func (c *CountObserver) Join(ctx context.Context, partial rangedloop.Partial) error {
+	countPartial := partial.(*CountObserver)
+	c.NumSegments += countPartial.NumSegments
+	// Range done
+	return nil
+}
+
+// Finish is the callback for ranged segment loop end.
+func (c *CountObserver) Finish(ctx context.Context) error {
+	return nil
+}
+
+// Process counts the size of a batch of segments.
+func (c *CountObserver) Process(ctx context.Context, segments []segmentloop.Segment) error {
+	c.NumSegments += len(segments)
+	return nil
+}

--- a/satellite/metabase/rangedloop/rangedlooptest/providermock.go
+++ b/satellite/metabase/rangedloop/rangedlooptest/providermock.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2022 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package rangedlooptest
+
+import (
+	"context"
+	"math"
+
+	"storj.io/storj/satellite/metabase/rangedloop"
+	"storj.io/storj/satellite/metabase/segmentloop"
+)
+
+var _ rangedloop.RangeSplitter = (*RangeSplitterMock)(nil)
+
+// RangeSplitterMock allows to iterate over segments from an in-memory source.
+type RangeSplitterMock struct {
+	Segments []segmentloop.Segment
+}
+
+var _ rangedloop.SegmentProvider = (*SegmentProviderMock)(nil)
+
+// SegmentProviderMock allows to iterate over segments from an in-memory source.
+type SegmentProviderMock struct {
+	Segments []segmentloop.Segment
+
+	batchSize int
+}
+
+// CreateRanges splits the segments into equal ranges.
+func (m *RangeSplitterMock) CreateRanges(nRanges int, batchSize int) ([]rangedloop.SegmentProvider, error) {
+	rangeSize := int(math.Ceil(float64(len(m.Segments)) / float64(nRanges)))
+
+	rangeProviders := []rangedloop.SegmentProvider{}
+	for i := 0; i < nRanges; i++ {
+		offset := min(i*rangeSize, len(m.Segments))
+		end := min(offset+rangeSize, len(m.Segments))
+
+		segments := m.Segments[offset:end]
+
+		rangeProviders = append(rangeProviders, &SegmentProviderMock{
+			Segments:  segments,
+			batchSize: batchSize,
+		})
+	}
+
+	return rangeProviders, nil
+}
+
+// Iterate allows to loop over the segments stored in the provider.
+func (m *SegmentProviderMock) Iterate(ctx context.Context, fn func([]segmentloop.Segment) error) error {
+	for offset := 0; offset < len(m.Segments); offset += m.batchSize {
+		end := min(offset+m.batchSize, len(m.Segments))
+		err := fn(m.Segments[offset:end])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}

--- a/satellite/metabase/rangedloop/service.go
+++ b/satellite/metabase/rangedloop/service.go
@@ -5,6 +5,7 @@ package rangedloop
 
 import (
 	"context"
+	"time"
 
 	"github.com/spacemonkeygo/monkit/v3"
 	"github.com/zeebo/errs"
@@ -19,26 +20,37 @@ var (
 )
 
 // Config contains configurable values for the shared loop.
-type Config struct{}
+type Config struct {
+	Parallelism        int           `help:"how many chunks of segments to process in parallel" default:"2"`
+	BatchSize          int           `help:"how many items to query in a batch" default:"2500"`
+	AsOfSystemInterval time.Duration `help:"as of system interval" releaseDefault:"-5m" devDefault:"-1us" testDefault:"-1us"`
+}
 
 // Service iterates through all segments and calls the attached observers for every segment
 //
 // architecture: Service
 type Service struct {
-	log        *zap.Logger
-	config     Config
-	metabaseDB segmentloop.MetabaseDB
-	observers  []Observer
+	log       *zap.Logger
+	config    Config
+	provider  RangeSplitter
+	observers []Observer
 }
 
 // NewService creates a new instance of the ranged loop service.
-func NewService(log *zap.Logger, config Config, metabaseDB segmentloop.MetabaseDB, observers []Observer) *Service {
+func NewService(log *zap.Logger, config Config, provider RangeSplitter, observers []Observer) *Service {
 	return &Service{
-		log:        log,
-		config:     config,
-		metabaseDB: metabaseDB,
-		observers:  observers,
+		log:       log,
+		config:    config,
+		provider:  provider,
+		observers: observers,
 	}
+}
+
+// observerState contains information to manage an observer during a loop iteration.
+// Improvement: track duration.
+type observerState struct {
+	observer       Observer
+	rangeObservers []Partial
 }
 
 // Run starts the looping service.
@@ -65,7 +77,78 @@ func (service *Service) Run(ctx context.Context) (err error) {
 func (service *Service) RunOnce(ctx context.Context) (err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	// TODO
+	startTime := time.Now()
+	observerStates := []observerState{}
+
+	for _, obs := range service.observers {
+		err := obs.Start(ctx, startTime)
+		if err != nil {
+			return err
+		}
+
+		observerStates = append(observerStates, observerState{
+			observer: obs,
+		})
+	}
+
+	rangeProviders, err := service.provider.CreateRanges(service.config.Parallelism, service.config.BatchSize)
+	if err != nil {
+		return err
+	}
+
+	group := errs2.Group{}
+	for rangeIndex, rangeProvider := range rangeProviders {
+		rangeObservers := []Partial{}
+		for i, observerState := range observerStates {
+			rangeObserver, err := observerState.observer.Fork(ctx)
+			if err != nil {
+				return err
+			}
+			rangeObservers = append(rangeObservers, rangeObserver)
+			observerStates[i].rangeObservers = append(observerStates[i].rangeObservers, rangeObserver)
+		}
+
+		// Create closure to capture loop variables.
+		createClosure := func(ctx context.Context, rangeIndex int, rangeProvider SegmentProvider, rangeObservers []Partial) func() error {
+			return func() (err error) {
+				defer mon.Task()(&ctx)(&err)
+
+				return rangeProvider.Iterate(ctx, func(segments []segmentloop.Segment) error {
+					for _, rangeObserver := range rangeObservers {
+						err := rangeObserver.Process(ctx, segments)
+						if err != nil {
+							return err
+						}
+					}
+					return nil
+				})
+			}
+		}
+
+		group.Go(createClosure(ctx, rangeIndex, rangeProvider, rangeObservers))
+	}
+
+	// Improvement: stop all ranges when one has an error.
+	errList := group.Wait()
+	if errList != nil {
+		return errs.Combine(errList...)
+	}
+
+	// Segment loop has ended.
+	// This is the reduce step.
+	for _, state := range observerStates {
+		for _, rangeObserver := range state.rangeObservers {
+			err := state.observer.Join(ctx, rangeObserver)
+			if err != nil {
+				return err
+			}
+		}
+
+		err := state.observer.Finish(ctx)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/satellite/metabase/rangedloop/service_test.go
+++ b/satellite/metabase/rangedloop/service_test.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2022 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package rangedloop_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"storj.io/storj/satellite/metabase/rangedloop"
+	"storj.io/storj/satellite/metabase/rangedloop/rangedlooptest"
+	"storj.io/storj/satellite/metabase/segmentloop"
+)
+
+func TestLoop(t *testing.T) {
+	for _, parallelism := range []int{1, 2, 3} {
+		for _, nSegments := range []int{0, 1, 2, 11} {
+			for _, nObservers := range []int{0, 1, 2} {
+				t.Run(
+					fmt.Sprintf("par%d_seg%d_obs%d", parallelism, nSegments, nObservers),
+					func(t *testing.T) {
+						RunTest(t, parallelism, nSegments, nObservers)
+					},
+				)
+			}
+		}
+	}
+}
+
+func RunTest(t *testing.T, parallelism int, nSegments int, nObservers int) {
+	batchSize := 2
+	ctx := context.Background()
+
+	observers := []rangedloop.Observer{}
+	for i := 0; i < nObservers; i++ {
+		observers = append(observers, &rangedlooptest.CountObserver{})
+	}
+
+	loopService := rangedloop.NewService(
+		zaptest.NewLogger(t),
+		rangedloop.Config{
+			BatchSize:          batchSize,
+			Parallelism:        parallelism,
+			AsOfSystemInterval: 0,
+		},
+		&rangedlooptest.RangeSplitterMock{
+			Segments: make([]segmentloop.Segment, nSegments),
+		},
+		observers,
+	)
+
+	err := loopService.RunOnce(ctx)
+	require.NoError(t, err)
+
+	for _, observer := range observers {
+		countObserver := observer.(*rangedlooptest.CountObserver)
+		require.Equal(t, nSegments, countObserver.NumSegments)
+	}
+}

--- a/satellite/rangedloop.go
+++ b/satellite/rangedloop.go
@@ -20,6 +20,7 @@ import (
 	"storj.io/storj/private/lifecycle"
 	"storj.io/storj/satellite/metabase"
 	"storj.io/storj/satellite/metabase/rangedloop"
+	"storj.io/storj/satellite/metabase/rangedloop/rangedlooptest"
 )
 
 // RangedLoop is the satellite ranged loop process.
@@ -74,7 +75,9 @@ func NewRangedLoop(log *zap.Logger, full *identity.FullIdentity, db DB, metabase
 	}
 
 	{ // setup ranged loop
-		peer.RangedLoop.Service = rangedloop.NewService(log.Named("rangedloop"), config.RangedLoop, metabaseDB, nil)
+		// TODO: replace with real segment provider
+		segments := &rangedlooptest.RangeSplitterMock{}
+		peer.RangedLoop.Service = rangedloop.NewService(log.Named("rangedloop"), config.RangedLoop, segments, nil)
 
 		peer.Services.Add(lifecycle.Item{
 			Name: "rangeloop",

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -856,6 +856,15 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # how long to cache the project limits.
 # project-limit.cache-expiration: 10m0s
 
+# as of system interval
+# ranged-loop.as-of-system-interval: -5m0s
+
+# how many items to query in a batch
+# ranged-loop.batch-size: 2500
+
+# how many chunks of segments to process in parallel
+# ranged-loop.parallelism: 2
+
 # time limit for downloading pieces from a node for repair
 # repairer.download-timeout: 5m0s
 


### PR DESCRIPTION
Minimal implementation of the ranged (=parallel) segment loop
service, to improve performance over the exiting loop.

Has tests with a an inmemory segment database
and example observer.

Does not have yet: database link, observer duration tracking,
suspicious processed ratio guard, rate limiting, minimum execution
interval per observer, etc.

Part of https://github.com/storj/storj/issues/5223



## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
