### PR TITLE
web/satellite: add server-side encryption banner to new project dashb…

### DIFF
--- a/web/satellite/src/components/modals/DeleteBucketModal.vue
+++ b/web/satellite/src/components/modals/DeleteBucketModal.vue
@@ -86,7 +86,7 @@ export default class DeleteBucketModal extends Vue {
             }
 
             const now = new Date();
-            const inOneDay = new Date(now.setDate(now.getDate() + 1));
+            const inOneHour = new Date(now.setHours(now.getHours() + 1));
 
             await this.worker.postMessage({
                 'type': 'SetPermission',
@@ -94,8 +94,8 @@ export default class DeleteBucketModal extends Vue {
                 'isUpload': false,
                 'isList': true,
                 'isDelete': true,
-                'notAfter': inOneDay.toISOString(),
-                'buckets': [],
+                'notAfter': inOneHour.toISOString(),
+                'buckets': [this.name],
                 'apiKey': this.apiKey,
             });
 

--- a/web/satellite/src/components/project/newProjectDashboard/NewProjectDashboard.vue
+++ b/web/satellite/src/components/project/newProjectDashboard/NewProjectDashboard.vue
@@ -171,6 +171,7 @@
             <p class="project-dashboard__stats-header__title">Buckets</p>
         </div>
         <BucketsTable :is-loading="areBucketsFetching" />
+        <EncryptionBanner v-if="!isServerSideEncryptionBannerHidden" :hide="hideBanner" />
     </div>
 </template>
 
@@ -187,6 +188,7 @@ import { DataStamp, ProjectLimits } from '@/types/projects';
 import { Dimensions, Size } from '@/utils/bytesSize';
 import { ChartUtils } from '@/utils/chart';
 import { AnalyticsHttpApi } from '@/api/analytics';
+import { LocalData } from '@/utils/localData';
 
 import VLoader from '@/components/common/VLoader.vue';
 import InfoContainer from '@/components/project/newProjectDashboard/InfoContainer.vue';
@@ -196,6 +198,7 @@ import VButton from '@/components/common/VButton.vue';
 import DateRangeSelection from '@/components/project/newProjectDashboard/DateRangeSelection.vue';
 import VInfo from '@/components/common/VInfo.vue';
 import BucketsTable from '@/components/objects/BucketsTable.vue';
+import EncryptionBanner from '@/components/objects/EncryptionBanner.vue';
 
 import NewProjectIcon from '@/../static/images/project/newProject.svg';
 import InfoIcon from '@/../static/images/project/infoIcon.svg';
@@ -213,12 +216,14 @@ import InfoIcon from '@/../static/images/project/infoIcon.svg';
         NewProjectIcon,
         InfoIcon,
         BucketsTable,
+        EncryptionBanner,
     },
 })
 export default class NewProjectDashboard extends Vue {
     public now = new Date().toLocaleDateString('en-US');
     public isDataFetching = true;
     public areBucketsFetching = true;
+    public isServerSideEncryptionBannerHidden = true;
 
     public chartWidth = 0;
 
@@ -233,6 +238,8 @@ export default class NewProjectDashboard extends Vue {
      * Fetches project limits.
      */
     public async mounted(): Promise<void> {
+        this.isServerSideEncryptionBannerHidden = LocalData.getServerSideEncryptionBannerHidden();
+
         if (!this.$store.getters.selectedProject.id) {
             this.analytics.pageVisit(RouteConfig.OnboardingTour.with(RouteConfig.OverviewStep).path);
             await this.$router.push(RouteConfig.OnboardingTour.with(RouteConfig.OverviewStep).path);
@@ -275,6 +282,14 @@ export default class NewProjectDashboard extends Vue {
      */
     public beforeDestroy(): void {
         window.removeEventListener('resize', this.recalculateChartWidth);
+    }
+
+    /**
+     * Hides server-side encryption banner.
+     */
+    public hideBanner(): void {
+        this.isServerSideEncryptionBannerHidden = true;
+        LocalData.setServerSideEncryptionBannerHidden(true);
     }
 
     /**


### PR DESCRIPTION
…oard

Added server-side encryption banner to new project dashboard (same as on buckets view). Reduced notAfter AG caveat to 1 hour for deleting bucket. Added bucket AG caveat for deleting bucket.

Change-Id: I2aba9e5db315123b8d37c24d80789320093db00e


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
