### PR TITLE
satellite/metabase/rangedloop: cancellation

### DIFF
--- a/satellite/metabase/rangedloop/observerstats.go
+++ b/satellite/metabase/rangedloop/observerstats.go
@@ -16,7 +16,7 @@ func sendObserverDurations(observerDurations []ObserverDuration) {
 }
 
 // completedObserverStatsInstance is initialized once
-// so that hopefully there is never more than once objec instance per satellite process
+// so that hopefully there is never more than once object instance per satellite process
 // and statistics of different object instances don't clobber each other.
 var completedObserverStatsInstance *completedObserverStats
 

--- a/satellite/metabase/rangedloop/rangedlooptest/callbackobserver.go
+++ b/satellite/metabase/rangedloop/rangedlooptest/callbackobserver.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2022 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package rangedlooptest
+
+import (
+	"context"
+	"time"
+
+	"storj.io/storj/satellite/metabase/rangedloop"
+	"storj.io/storj/satellite/metabase/segmentloop"
+)
+
+var _ rangedloop.Observer = (*CallbackObserver)(nil)
+var _ rangedloop.Partial = (*CallbackObserver)(nil)
+
+// CallbackObserver can be used to easily attach logic to the ranged segment loop during tests.
+type CallbackObserver struct {
+	OnProcess func(context.Context, []segmentloop.Segment) error
+	OnStart   func(context.Context, time.Time) error
+	OnFork    func(context.Context) (rangedloop.Partial, error)
+	OnJoin    func(context.Context, rangedloop.Partial) error
+	OnFinish  func(context.Context) error
+}
+
+// Start executes a callback at ranged segment loop start.
+func (c *CallbackObserver) Start(ctx context.Context, time time.Time) error {
+	if c.OnStart == nil {
+		return nil
+	}
+
+	return c.OnStart(ctx, time)
+}
+
+// Fork executes a callback for every segment range at ranged segment loop fork stage.
+func (c *CallbackObserver) Fork(ctx context.Context) (rangedloop.Partial, error) {
+	if c.OnFork == nil {
+		return c, nil
+	}
+
+	partial, err := c.OnFork(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if partial == nil {
+		return c, nil
+	}
+
+	return partial, nil
+}
+
+// Join executes a callback for every segment range at ranged segment loop join stage.
+func (c *CallbackObserver) Join(ctx context.Context, partial rangedloop.Partial) error {
+	if c.OnJoin == nil {
+		return nil
+	}
+
+	return c.OnJoin(ctx, partial)
+}
+
+// Finish executes a callback at ranged segment loop end.
+func (c *CallbackObserver) Finish(ctx context.Context) error {
+	if c.OnFinish == nil {
+		return nil
+	}
+
+	return c.OnFinish(ctx)
+}
+
+// Process executes a callback for every batch of segment in the ranged segment loop.
+func (c *CallbackObserver) Process(ctx context.Context, segments []segmentloop.Segment) error {
+	if c.OnProcess == nil {
+		return nil
+	}
+
+	return c.OnProcess(ctx, segments)
+}

--- a/satellite/metabase/rangedloop/rangedlooptest/infiniteprovider.go
+++ b/satellite/metabase/rangedloop/rangedlooptest/infiniteprovider.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2022 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package rangedlooptest
+
+import (
+	"context"
+
+	"storj.io/storj/satellite/metabase/rangedloop"
+	"storj.io/storj/satellite/metabase/segmentloop"
+)
+
+var _ rangedloop.RangeSplitter = (*InfiniteSegmentProvider)(nil)
+var _ rangedloop.SegmentProvider = (*InfiniteSegmentProvider)(nil)
+
+// InfiniteSegmentProvider allow to iterate indefinitely to test service cancellation.
+type InfiniteSegmentProvider struct {
+}
+
+// CreateRanges splits the segments into equal ranges.
+func (m *InfiniteSegmentProvider) CreateRanges(nRanges int, batchSize int) (segmentsProviders []rangedloop.SegmentProvider, err error) {
+	for i := 0; i < nRanges; i++ {
+		segmentsProviders = append(segmentsProviders, &InfiniteSegmentProvider{})
+	}
+	return segmentsProviders, nil
+}
+
+// Iterate allows to loop over the segments stored in the provider.
+func (m *InfiniteSegmentProvider) Iterate(ctx context.Context, fn func([]segmentloop.Segment) error) error {
+	for {
+		err := fn(make([]segmentloop.Segment, 3))
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/satellite/metabase/rangedloop/service.go
+++ b/satellite/metabase/rangedloop/service.go
@@ -132,15 +132,13 @@ func createGoroutineClosure(ctx context.Context, rangeProvider SegmentProvider, 
 		defer mon.Task()(&ctx)(&err)
 
 		return rangeProvider.Iterate(ctx, func(segments []segmentloop.Segment) error {
-			for _, state := range states {
-				start := time.Now()
-				err := state.rangeObserver.Process(ctx, segments)
-				if err != nil {
-					return err
-				}
-				state.duration += time.Since(start)
+			// check for cancellation every segment batch
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				return processBatch(ctx, states, segments)
 			}
-			return nil
 		})
 	}
 }
@@ -199,4 +197,16 @@ func finishObserver(ctx context.Context, state observerState) (ObserverDuration,
 		Duration: duration,
 		Observer: state.observer,
 	}, state.observer.Finish(ctx)
+}
+
+func processBatch(ctx context.Context, states []*rangeObserverState, segments []segmentloop.Segment) (err error) {
+	for _, state := range states {
+		start := time.Now()
+		err := state.rangeObserver.Process(ctx, segments)
+		if err != nil {
+			return err
+		}
+		state.duration += time.Since(start)
+	}
+	return nil
 }


### PR DESCRIPTION
Only review the last commit, preceeding commits have their own PR's. First review https://github.com/storj/storj/pull/5350

Support interruption of the ranged segment loop through context.

Part of https://github.com/storj/storj/issues/5223

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
