### PR TITLE
satellite/metabase/rangedloop: monkit durations

### DIFF
--- a/satellite/metabase/rangedloop/observerstats.go
+++ b/satellite/metabase/rangedloop/observerstats.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2022 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package rangedloop
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/spacemonkeygo/monkit/v3"
+)
+
+func sendObserverDurations(observerDurations []ObserverDuration) {
+	initCompletedObserverStats()
+	completedObserverStatsInstance.setObserverDurations(observerDurations)
+}
+
+// completedObserverStatsInstance is initialized once
+// so that hopefully there is never more than once objec instance per satellite process
+// and statistics of different object instances don't clobber each other.
+var completedObserverStatsInstance *completedObserverStats
+
+// Implements monkit.StatSource.
+// Reports the duration per observer from the last completed run of the ranged segment loop.
+type completedObserverStats struct {
+	mu                sync.Mutex
+	observerDurations []ObserverDuration
+}
+
+func initCompletedObserverStats() {
+	if completedObserverStatsInstance != nil {
+		return
+	}
+
+	completedObserverStatsInstance = &completedObserverStats{
+		observerDurations: []ObserverDuration{},
+	}
+
+	// wire statistics up with monkit
+	mon.Chain(completedObserverStatsInstance)
+}
+
+// Stats implements monkit.StatSource to send the observer durations every time monkit is polled externally.
+func (o *completedObserverStats) Stats(cb func(key monkit.SeriesKey, field string, val float64)) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	// if there are no completed observers yet, no statistics will be sent
+	for _, observerDuration := range o.observerDurations {
+		key := monkit.NewSeriesKey("completed-observer-duration")
+		key = key.WithTag("observer", fmt.Sprintf("%T", observerDuration.Observer))
+
+		cb(key, "duration", observerDuration.Duration.Seconds())
+	}
+}
+
+// setObserverDurations sets the observer durations to report at ranged segment loop completion.
+func (o *completedObserverStats) setObserverDurations(observerDurations []ObserverDuration) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.observerDurations = observerDurations
+}

--- a/satellite/metabase/rangedloop/service.go
+++ b/satellite/metabase/rangedloop/service.go
@@ -178,6 +178,8 @@ func finishObservers(ctx context.Context, observerStates []observerState) (obser
 		observerDurations = append(observerDurations, observerDuration)
 	}
 
+	sendObserverDurations(observerDurations)
+
 	return observerDurations, nil
 }
 


### PR DESCRIPTION
Only review last commit, the preceeding commits have their own PR's


Wire up duration measurement of observers with monkit.
    
Tested by attaching a SleepObserver, starting the rangedloop in storj-up
and navigating to http://<container>:11111/mon/stats. It reports the
following statistic:
    
completed-observer-duration,observer=*rangedlooptest.SleepObserver,scope=storj.io/storj/satellite/metabase/rangedloop duration=10.000117


## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
