### PR TITLE
satellite/metabase: fix GetStreamPieceCountByNodeID full table scan

### DIFF
--- a/satellite/metabase/streamstat.go
+++ b/satellite/metabase/streamstat.go
@@ -31,11 +31,7 @@ func (db *DB) GetStreamPieceCountByNodeID(ctx context.Context, opts GetStreamPie
 	err = withRows(db.db.QueryContext(ctx, `
 		SELECT remote_alias_pieces
 		FROM   segments
-		WHERE  stream_id = $1 AND remote_alias_pieces IS NOT null
-		UNION
-		SELECT remote_alias_pieces
-		FROM   segments
-		WHERE  stream_id = (SELECT ancestor_stream_id FROM segment_copies WHERE stream_id = $1) AND remote_alias_pieces IS NOT null
+		WHERE  stream_id IN (SELECT $1 UNION SELECT ancestor_stream_id FROM segment_copies WHERE stream_id = $1) AND remote_alias_pieces IS NOT null
 	`, opts.StreamID))(func(rows tagsql.Rows) error {
 		for rows.Next() {
 			var aliasPieces AliasPieces


### PR DESCRIPTION
Previous version of SQL query was causing full table scan.

Output of EXPLAIN:
---
distribution: local
vectorized: true

• lookup join
│ table: segments@segments_pkey
│ equality: (?column?) = (stream_id)
│ pred: remote_alias_pieces IS NOT NULL
│
└── • union
    │
    ├── • values
    │     size: 1 column, 1 row
    │
    └── • scan
          missing stats
          table: segment_copies@segment_copies_pkey
          spans: [/'\xff135285155378d980b8c49148cef3ca' - /'\xff135285155378d980b8c49148cef3ca']
---