### PR TITLE
web/satellite: fix new folder button in file browser

### DIFF
--- a/web/satellite/src/components/browser/FileBrowser.vue
+++ b/web/satellite/src/components/browser/FileBrowser.vue
@@ -81,6 +81,7 @@
                                     :is-white="true"
                                     font-size="14px"
                                     width="130px"
+                                    :on-press="toggleFolderCreationModal"
                                 />
                             </div>
                             <bucket-settings-nav class="new-folder-button" :bucket-name="bucket" />


### PR DESCRIPTION
This change opens the "new folder" modal on click of the "new folder" button in the file browser

Change-Id: I063d644c70ad1eff005eb509d97b95cf30aca00a


What: 

Why: fix for open New Folder dialog

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
