### PR TITLE
fix test-sim-rolling-upgrade.sh

### DIFF
--- a/satellite/overlay/service.go
+++ b/satellite/overlay/service.go
@@ -129,6 +129,9 @@ type DB interface {
 	TestNodeCountryCode(ctx context.Context, nodeID storj.NodeID, countryCode string) (err error)
 	// TestUpdateCheckInDirectUpdate tries to update a node info directly. Returns true if it succeeded, false if there were no node with the provided (used for testing).
 	TestUpdateCheckInDirectUpdate(ctx context.Context, node NodeCheckInInfo, timestamp time.Time, semVer version.SemVer, walletFeatures string) (updated bool, err error)
+	// OneTimeFixLastNets updates the last_net values for all node records to be equal to their
+	// last_ip_port values.
+	OneTimeFixLastNets(ctx context.Context) error
 
 	// IterateAllContactedNodes will call cb on all known nodes (used in restore trash contexts).
 	IterateAllContactedNodes(context.Context, func(context.Context, *SelectedNode) error) error

--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -1681,3 +1681,15 @@ func (n *noiseScanner) Convert() *pb.NoiseInfo {
 		PublicKey: n.PublicKey,
 	}
 }
+
+// OneTimeFixLastNets updates the last_net values for all node records to be equal to their
+// last_ip_port values.
+//
+// This is only appropriate to do when the satellite has DistinctIP=false and has been upgraded from
+// before changeset I0e7e92498c3da768df5b4d5fb213dcd2d4862924. It is only necessary to run this
+// once, after all satellite peers are upgraded (otherwise some nodes may be inserted with truncated
+// last_net values, and those nodes could be unfairly disadvantaged in node selection).
+func (cache *overlaycache) OneTimeFixLastNets(ctx context.Context) error {
+	_, err := cache.db.ExecContext(ctx, "UPDATE nodes SET last_net = last_ip_port")
+	return err
+}


### PR DESCRIPTION
This test involves a satellite with dev defaults (DistinctIP=no) being upgraded past commit 2522ff09b64b98c5a852c7ba3620bc998b8e8c54, which means we need to run the dev-defaults-satellite-upgrade migration SQL to avoid getting DistinctIP=yes behavior:

    UPDATE nodes SET last_net = last_ip_port

Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
