### PR TITLE
Update Learn more link with billing page from docs

### DIFF
--- a/web/satellite/src/components/modals/AddTokenFundsModal.vue
+++ b/web/satellite/src/components/modals/AddTokenFundsModal.vue
@@ -25,7 +25,7 @@
                                 This is a Storj deposit address generated just for you.
                                 <a
                                     class="modal__label__info__msg__link"
-                                    href=""
+                                    href="https://docs.storj.io/dcs/billing"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                 >


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/15882196/234261577-020ff5d1-4cd5-4926-aace-596e8c94bf79.png)


What: Currently `Learn more` links to same page. 

Why: It should link to `Storj token` section of billing page from docs. Since the inner link (https://docs.storj.io/dcs/billing#syi5o) might change in future linking to the entire billing page (https://docs.storj.io/dcs/billing) makes sense.
