### PR TITLE
satellite/metabase: fix error message

### DIFF
--- a/satellite/metabase/commit.go
+++ b/satellite/metabase/commit.go
@@ -27,7 +27,7 @@ const defaultZombieDeletionPeriod = 24 * time.Hour
 
 var (
 	// ErrObjectNotFound is used to indicate that the object does not exist.
-	ErrObjectNotFound = errs.Class("metabase: object not found")
+	ErrObjectNotFound = errs.Class("object not found")
 	// ErrInvalidRequest is used to indicate invalid requests.
 	ErrInvalidRequest = errs.Class("metabase: invalid request")
 	// ErrConflict is used to indicate conflict with the request.


### PR DESCRIPTION
Change-Id: I5ce7789cc11742d3435af1ec555bc96927f1bedc


What: 
Changing an internal error message shouldn't break the uplink.
Why:
The "object not found" included an additional prefix "metabase:", which
broke uplink error message detection.
Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
