### PR TITLE
cmd/storagenode: use the right subcommand for restarting windows services

### DIFF
--- a/cmd/storagenode/main.go
+++ b/cmd/storagenode/main.go
@@ -15,12 +15,12 @@ import (
 func main() {
 	process.SetHardcodedApplicationName("storagenode")
 
-	if startAsService() {
-		return
-	}
-
 	allowDefaults := !isFilewalkerCommand()
 	rootCmd, _ := newRootCmd(allowDefaults)
+
+	if startAsService(rootCmd) {
+		return
+	}
 
 	loggerFunc := func(logger *zap.Logger) *zap.Logger {
 		return logger.With(zap.String("Process", rootCmd.Use))

--- a/cmd/storagenode/service_nonwindows.go
+++ b/cmd/storagenode/service_nonwindows.go
@@ -6,6 +6,8 @@
 
 package main
 
-func startAsService() bool {
+import "github.com/spf13/cobra"
+
+func startAsService(*cobra.Command) bool {
 	return false
 }


### PR DESCRIPTION
I am proposing to create a v1.78.3 which includes an important fix for windows based Storagnodes.

This commit changes only the Storagenodes binary, and I tested the new binary in a windows environment.