### PR TITLE
v1.80.7

### DIFF
--- a/satellite/metabase/list_segments.go
+++ b/satellite/metabase/list_segments.go
@@ -61,7 +61,7 @@ func (db *DB) ListSegments(ctx context.Context, opts ListSegments) (result ListS
 				position, created_at, expires_at, root_piece_id,
 				encrypted_key_nonce, encrypted_key, encrypted_size,
 				plain_offset, plain_size, encrypted_etag, redundancy,
-				inline_data, remote_alias_pieces
+				inline_data, remote_alias_pieces, placement
 			FROM segments
 			WHERE
 				stream_id = $1 AND
@@ -75,7 +75,7 @@ func (db *DB) ListSegments(ctx context.Context, opts ListSegments) (result ListS
 				position, created_at, expires_at, root_piece_id,
 				encrypted_key_nonce, encrypted_key, encrypted_size,
 				plain_offset, plain_size, encrypted_etag, redundancy,
-				inline_data, remote_alias_pieces
+				inline_data, remote_alias_pieces, placement
 			FROM segments
 			WHERE
 				stream_id = $1 AND
@@ -98,6 +98,7 @@ func (db *DB) ListSegments(ctx context.Context, opts ListSegments) (result ListS
 				&segment.EncryptedETag,
 				redundancyScheme{&segment.Redundancy},
 				&segment.InlineData, &aliasPieces,
+				&segment.Placement,
 			)
 			if err != nil {
 				return Error.New("failed to scan segments: %w", err)

--- a/satellite/orders/service.go
+++ b/satellite/orders/service.go
@@ -144,6 +144,14 @@ func (service *Service) CreateGetOrderLimits(ctx context.Context, bucket metabas
 		return nil, storj.PiecePrivateKey{}, Error.Wrap(err)
 	}
 
+	if segment.Placement != storj.EveryCountry {
+		for id, node := range nodes {
+			if !segment.Placement.AllowedCountry(node.CountryCode) {
+				delete(nodes, id)
+			}
+		}
+	}
+
 	signer, err := NewSignerGet(service, segment.RootPieceID, time.Now(), orderLimit, bucket)
 	if err != nil {
 		return nil, storj.PiecePrivateKey{}, Error.Wrap(err)
@@ -152,8 +160,8 @@ func (service *Service) CreateGetOrderLimits(ctx context.Context, bucket metabas
 	neededLimits := segment.Redundancy.DownloadNodes()
 	if desiredNodes > neededLimits {
 		neededLimits = desiredNodes
-
 	}
+
 	pieces := segment.Pieces
 	for _, pieceIndex := range service.perm(len(pieces)) {
 		piece := pieces[pieceIndex]


### PR DESCRIPTION
this change adds code to CreateGetOrderLimits to filter out any nodes that are not in the placement specified by the segment. notably, it does not change the audit or repair order limits. the list segments code had to be changed to include getting the placement field from the database.

Change-Id: Ice3e42a327811bb20928c619a72ed94e0c1464ac


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
