### PR TITLE
point release v1.81.1-rc

### DIFF
--- a/web/satellite/src/components/browser/FileEntry.vue
+++ b/web/satellite/src/components/browser/FileEntry.vue
@@ -440,9 +440,9 @@ function openDropdown(): void {
 /**
  * Download the current file.
  */
-function download(): void {
+async function download(): Promise<void> {
     try {
-        obStore.download(props.file);
+        await obStore.download(props.file);
         notify.warning('Do not share download link with other people. If you want to share this data better use "Share" option.');
     } catch (error) {
         notify.error('Can not download your file', AnalyticsErrorEventSource.FILE_BROWSER_ENTRY);

--- a/web/satellite/src/components/browser/galleryView/GalleryView.vue
+++ b/web/satellite/src/components/browser/galleryView/GalleryView.vue
@@ -279,9 +279,9 @@ async function onDelete(): Promise<void> {
 /**
  * Download the current opened file.
  */
-function download(): void {
+async function download(): Promise<void> {
     try {
-        obStore.download(file.value);
+        await obStore.download(file.value);
         notify.warning('Do not share download link with other people. If you want to share this data better use "Share" option.');
     } catch (error) {
         notify.error('Can not download your file', AnalyticsErrorEventSource.OBJECT_DETAILS_MODAL);

--- a/web/satellite/src/components/modals/ObjectDetailsModal.vue
+++ b/web/satellite/src/components/modals/ObjectDetailsModal.vue
@@ -261,9 +261,9 @@ async function fetchPreviewAndMapUrl(): Promise<void> {
 /**
  * Download the current opened file.
  */
-function download(): void {
+async function download(): Promise<void> {
     try {
-        obStore.download(file.value);
+        await obStore.download(file.value);
         notify.warning('Do not share download link with other people. If you want to share this data better use "Share" option.');
     } catch (error) {
         notify.error('Can not download your file', AnalyticsErrorEventSource.OBJECT_DETAILS_MODAL);

--- a/web/satellite/src/store/modules/objectBrowserStore.ts
+++ b/web/satellite/src/store/modules/objectBrowserStore.ts
@@ -689,14 +689,14 @@ export const useObjectBrowserStore = defineStore('objectBrowser', () => {
         clearAllSelectedFiles();
     }
 
-    function download(file): void {
+    async function download(file): Promise<void> {
         assertIsInitialized(state);
 
-        const url = getSignedUrl(state.s3, new GetObjectCommand({
+        const url = await getSignedUrl(state.s3, new GetObjectCommand({
             Bucket: state.bucket,
             Key: state.path + file.Key,
         }));
-        const downloadURL = function(data, fileName) {
+        const downloadURL = function(data: string, fileName: string) {
             const a = document.createElement('a');
             a.href = data;
             a.download = fileName;


### PR DESCRIPTION
Fixed download objects in object browser.

Context:
aws-sdk v3 getSignedURL method now returns a Promise<string> instead of regular string. So we have to await for promise to resolve

Issue:
https://github.com/storj/storj/issues/5956

Change-Id: I2431095e7e8cd1bbc4e866c6958a2c03898c4b4d


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
