### PR TITLE
cherry-pick satellite/entrypoint: ignore unset variable

### DIFF
--- a/cmd/satellite/entrypoint
+++ b/cmd/satellite/entrypoint
@@ -90,10 +90,10 @@ if [ "${STORJUP_ROLE:-""}" ]; then
 fi
 
 # for backward compatibility reason, we use argument as command, only if it's an executable (and use it as satellite flags oterwise)
-set +e
+set +eo nounset
 which "$1" > /dev/null
 VALID_EXECUTABLE=$?
-set -e
+set -eo nounset
 
 if [ $VALID_EXECUTABLE -eq 0 ]; then
   # this is a full command (what storj-up uses)


### PR DESCRIPTION

What: 
satellite/entrypoint: Ignore unset variable errors while checking for VALID_EXECUTABLE
Otherwise core and ranged loop fail at startup with "/entrypoint: line 94: $1: unbound variable"

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
