### PR TITLE
satellite/console: Enable gallery view and limits area by default

### DIFF
--- a/satellite/console/consoleweb/server.go
+++ b/satellite/console/consoleweb/server.go
@@ -100,14 +100,14 @@ type Config struct {
 	PublicLinksharingURL            string     `help:"url link for linksharing requests for external sharing" default:"https://link.storjshare.io" devDefault:"http://localhost:8001"`
 	PathwayOverviewEnabled          bool       `help:"indicates if the overview onboarding step should render with pathways" default:"true"`
 	AllProjectsDashboard            bool       `help:"indicates if all projects dashboard should be used" default:"true"`
-	LimitsAreaEnabled               bool       `help:"indicates whether limit card section of the UI is enabled" default:"false"`
+	LimitsAreaEnabled               bool       `help:"indicates whether limit card section of the UI is enabled" default:"true"`
 	GeneratedAPIEnabled             bool       `help:"indicates if generated console api should be used" default:"false"`
 	OptionalSignupSuccessURL        string     `help:"optional url to external registration success page" default:""`
 	HomepageURL                     string     `help:"url link to storj.io homepage" default:"https://www.storj.io"`
 	NativeTokenPaymentsEnabled      bool       `help:"indicates if storj native token payments system is enabled" default:"false"`
 	PricingPackagesEnabled          bool       `help:"whether to allow purchasing pricing packages" default:"false" devDefault:"true"`
 	NewUploadModalEnabled           bool       `help:"whether to show new upload modal" default:"false"`
-	GalleryViewEnabled              bool       `help:"whether to show new gallery view" default:"false"`
+	GalleryViewEnabled              bool       `help:"whether to show new gallery view" default:"true"`
 	UseVuetifyProject               bool       `help:"whether to use vuetify POC project" default:"false"`
 
 	OauthCodeExpiry         time.Duration `help:"how long oauth authorization codes are issued for" default:"10m"`

--- a/scripts/testdata/satellite-config.yaml.lock
+++ b/scripts/testdata/satellite-config.yaml.lock
@@ -272,7 +272,7 @@ compensation.withheld-percents: 75,75,75,50,50,50,25,25,25,0,0,0,0,0,0
 # console.frontend-enable: true
 
 # whether to show new gallery view
-# console.gallery-view-enabled: false
+# console.gallery-view-enabled: true
 
 # url link for gateway credentials requests
 # console.gateway-credentials-request-url: https://auth.storjsatelliteshare.io
@@ -293,7 +293,7 @@ compensation.withheld-percents: 75,75,75,50,50,50,25,25,25,0,0,0,0,0,0
 # console.let-us-know-url: https://storjlabs.atlassian.net/servicedesk/customer/portals
 
 # indicates whether limit card section of the UI is enabled
-# console.limits-area-enabled: false
+# console.limits-area-enabled: true
 
 # url link for linksharing requests within the application
 # console.linksharing-url: https://link.storjsatelliteshare.io


### PR DESCRIPTION
What: Enable gallery view and limits area in production by default

Why: It looks good on the QA satellite. Enabling it by default will simplify the UI tests.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
