### PR TITLE
point release v1.90.3

### DIFF
--- a/satellite/contact/endpoint.go
+++ b/satellite/contact/endpoint.go
@@ -135,7 +135,7 @@ func (endpoint *Endpoint) CheckIn(ctx context.Context, req *pb.CheckInRequest) (
 		Version:    req.Version,
 	}
 
-	endpoint.emitEvenkitEvent(ctx, req, pingNodeSuccess, pingNodeSuccessQUIC, nodeInfo)
+	emitEventkitEvent(ctx, req, pingNodeSuccess, pingNodeSuccessQUIC, nodeInfo)
 
 	err = endpoint.service.overlay.UpdateCheckIn(ctx, nodeInfo, time.Now().UTC())
 	if err != nil {
@@ -151,7 +151,7 @@ func (endpoint *Endpoint) CheckIn(ctx context.Context, req *pb.CheckInRequest) (
 	}, nil
 }
 
-func (endpoint *Endpoint) emitEvenkitEvent(ctx context.Context, req *pb.CheckInRequest, pingNodeTCPSuccess bool, pingNodeQUICSuccess bool, nodeInfo overlay.NodeCheckInInfo) {
+func emitEventkitEvent(ctx context.Context, req *pb.CheckInRequest, pingNodeTCPSuccess bool, pingNodeQUICSuccess bool, nodeInfo overlay.NodeCheckInInfo) {
 	var sourceAddr string
 	transport, found := drpcctx.Transport(ctx)
 	if found {
@@ -163,18 +163,26 @@ func (endpoint *Endpoint) emitEvenkitEvent(ctx context.Context, req *pb.CheckInR
 		}
 	}
 
-	ek.Event("checkin",
+	tags := []eventkit.Tag{
 		eventkit.String("id", nodeInfo.NodeID.String()),
 		eventkit.String("addr", req.Address),
 		eventkit.String("resolved-addr", nodeInfo.LastIPPort),
 		eventkit.String("source-addr", sourceAddr),
-		eventkit.Timestamp("build-time", nodeInfo.Version.Timestamp),
-		eventkit.String("version", nodeInfo.Version.Version),
 		eventkit.String("country", nodeInfo.CountryCode.String()),
-		eventkit.Int64("free-disk", nodeInfo.Capacity.FreeDisk),
 		eventkit.Bool("ping-tpc-success", pingNodeTCPSuccess),
 		eventkit.Bool("ping-quic-success", pingNodeQUICSuccess),
-	)
+	}
+
+	if nodeInfo.Capacity != nil {
+		eventkit.Int64("free-disk", nodeInfo.Capacity.FreeDisk)
+	}
+
+	if nodeInfo.Version != nil {
+		eventkit.Timestamp("build-time", nodeInfo.Version.Timestamp)
+		eventkit.String("version", nodeInfo.Version.Version)
+	}
+
+	ek.Event("checkin", tags...)
 }
 
 // GetTime returns current timestamp.

--- a/satellite/contact/endpoint_test.go
+++ b/satellite/contact/endpoint_test.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package contact
+
+import (
+	"testing"
+
+	"storj.io/common/pb"
+	"storj.io/common/testcontext"
+	"storj.io/storj/satellite/overlay"
+)
+
+func TestEmitEventkitEvent(t *testing.T) {
+	ctx := testcontext.New(t)
+	emitEventkitEvent(ctx, &pb.CheckInRequest{
+		Address: "127.0.0.1:234",
+	}, false, false, overlay.NodeCheckInInfo{})
+}

--- a/satellite/durability/observer.go
+++ b/satellite/durability/observer.go
@@ -215,6 +215,12 @@ func (c *ObserverFork) Process(ctx context.Context, segments []rangedloop.Segmen
 		s := &segments[i]
 		healthyPieceCount := 0
 		for _, piece := range s.AliasPieces {
+			if len(c.classified) <= int(piece.Alias) {
+				// this is a new node, but we can ignore it.
+				// will be included in the next execution cycle.
+				continue
+			}
+
 			classes := c.classified[piece.Alias]
 
 			// unavailable/offline nodes were not classified

--- a/satellite/satellitedb/overlaycache.go
+++ b/satellite/satellitedb/overlaycache.go
@@ -410,6 +410,8 @@ func (cache *overlaycache) GetNodes(ctx context.Context, nodeIDs storj.NodeIDLis
 		return nil, Error.New("no ids provided")
 	}
 
+	indexesToZero := []int{}
+
 	err = withRows(cache.db.Query(ctx, `
 		SELECT n.id, n.address, n.email, n.wallet, n.last_net, n.last_ip_port, n.country_code,
 			n.last_contact_success > $2 AS online,
@@ -426,7 +428,7 @@ func (cache *overlaycache) GetNodes(ctx context.Context, nodeIDs storj.NodeIDLis
 	`, pgutil.NodeIDArray(nodeIDs), time.Now().Add(-onlineWindow),
 	))(func(rows tagsql.Rows) error {
 		for rows.Next() {
-			node, tag, err := scanSelectedNodeWithTag(rows)
+			node, tag, disqualifiedOrExited, err := scanSelectedNodeWithTag(rows)
 			if err != nil {
 				return err
 			}
@@ -442,11 +444,18 @@ func (cache *overlaycache) GetNodes(ctx context.Context, nodeIDs storj.NodeIDLis
 			}
 
 			records = append(records, node)
+			if disqualifiedOrExited {
+				indexesToZero = append(indexesToZero, len(records)-1)
+			}
 		}
 		return nil
 	})
 	if err != nil {
 		return nil, Error.Wrap(err)
+	}
+
+	for _, i := range indexesToZero {
+		records[i] = nodeselection.SelectedNode{}
 	}
 
 	return records, Error.Wrap(err)
@@ -558,7 +567,7 @@ func scanSelectedNode(rows tagsql.Rows) (nodeselection.SelectedNode, error) {
 	return node, nil
 }
 
-func scanSelectedNodeWithTag(rows tagsql.Rows) (nodeselection.SelectedNode, nodeselection.NodeTag, error) {
+func scanSelectedNodeWithTag(rows tagsql.Rows) (_ nodeselection.SelectedNode, _ nodeselection.NodeTag, disqualifiedOrExited bool, err error) {
 	var node nodeselection.SelectedNode
 	node.Address = &pb.NodeAddress{}
 	var nodeID nullNodeID
@@ -570,22 +579,19 @@ func scanSelectedNodeWithTag(rows tagsql.Rows) (nodeselection.SelectedNode, node
 	signedAt := &time.Time{}
 	signer := nullNodeID{}
 
-	err := rows.Scan(&nodeID, &address, &email, &wallet, &lastNet, &lastIPPort, &countryCode,
+	err = rows.Scan(&nodeID, &address, &email, &wallet, &lastNet, &lastIPPort, &countryCode,
 		&online, &suspended, &disqualified, &exiting, &exited, &name, &tag.Value, &signedAt, &signer)
 	if err != nil {
-		return nodeselection.SelectedNode{}, nodeselection.NodeTag{}, err
+		return nodeselection.SelectedNode{}, nodeselection.NodeTag{}, true, err
 	}
 
 	// If node ID was null, no record was found for the specified ID. For our purposes
 	// here, we will treat that as equivalent to a node being DQ'd or exited.
 	if !nodeID.Valid {
 		// return an empty record
-		return nodeselection.SelectedNode{}, nodeselection.NodeTag{}, nil
+		return nodeselection.SelectedNode{}, nodeselection.NodeTag{}, true, nil
 	}
 	// nodeID was valid, so from here on we assume all the other non-null fields are valid, per database constraints
-	if disqualified.Bool || exited.Bool {
-		return nodeselection.SelectedNode{}, nodeselection.NodeTag{}, nil
-	}
 	node.ID = nodeID.NodeID
 	node.Address.Address = address.String
 	node.Email = email.String
@@ -610,7 +616,7 @@ func scanSelectedNodeWithTag(rows tagsql.Rows) (nodeselection.SelectedNode, node
 		tag.NodeID = node.ID
 	}
 
-	return node, tag, nil
+	return node, tag, disqualified.Bool || exited.Bool, nil
 }
 
 func (cache *overlaycache) addNodeTagsFromFullScan(ctx context.Context, nodes []*nodeselection.SelectedNode) error {


### PR DESCRIPTION
Including: 

* overlaycache: don't return weird responses when certified nodes are disqualified (23 hours ago)
   *  fixing repair process
* satellite/durability: ignore information from new nodes (23 hours ago) 
   * fix the durability rangeloop (important to understand current durability conditions)
* satellite/contact: send evenkit entry only with existing fields (3 minutes ago) 
   *  Better checking validation
