### PR TITLE
release v1.91.1: fix with correct path for wasm files

### DIFF
--- a/cmd/satellite/Dockerfile
+++ b/cmd/satellite/Dockerfile
@@ -41,7 +41,7 @@ COPY --from=ui /app/static /app/static
 COPY --from=ui /app/dist /app/dist
 COPY --from=ui /app/dist_vuetify_poc /app/dist_vuetify_poc
 COPY --from=ca-cert /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY release/${TAG}/wasm /app/static/
+COPY release/${TAG}/wasm /app/static/wasm
 COPY release/${TAG}/satellite_linux_${GOARCH:-amd64} /app/satellite
 COPY --from=storjup /go/bin/storj-up /usr/local/bin/storj-up
 COPY --from=dlv /go/bin/dlv /usr/local/bin/dlv


### PR DESCRIPTION
Fixed docker command to copy files to app/static/wasm subfolder instead of app/static itself.

Change-Id: I50e605b9224d2c643cd5f6ae62a3610ed2a06752


What: 
cmd/satellite: copy wasm files into app/static/wasm subfolder
Why:
fix with correct path for wasm files
Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
