### PR TITLE
web/satellite: update preview types and icons

### DIFF
--- a/web/satellite/src/types/browser.ts
+++ b/web/satellite/src/types/browser.ts
@@ -101,11 +101,11 @@ export enum PreviewType {
 }
 
 export const EXTENSION_PREVIEW_TYPES = new Map<string[], PreviewType>([
-    [['txt'], PreviewType.Text],
+    [['txt', 'md', 'json', 'xml'], PreviewType.Text],
     [['csv'], PreviewType.CSV],
-    [['bmp', 'svg', 'jpg', 'jpeg', 'png', 'ico', 'gif'], PreviewType.Image],
-    [['m4v', 'mp4', 'webm', 'mov', 'mkv'], PreviewType.Video],
-    [['m4a', 'mp3', 'wav', 'ogg'], PreviewType.Audio],
+    [['bmp', 'svg', 'jpg', 'jpeg', 'png', 'ico', 'gif', 'webp'], PreviewType.Image],
+    [['m4v', 'mp4', 'webm', 'mov', 'mkv', 'ogv'], PreviewType.Video],
+    [['m4a', 'mp3', 'wav', 'ogg', 'aac', 'flac'], PreviewType.Audio],
     [['pdf'], PreviewType.PDF],
 ]);
 
@@ -125,9 +125,9 @@ export type BrowserObjectWrapper = {
 };
 
 export const EXTENSION_INFOS: Map<string[], BrowserObjectTypeInfo> = new Map([
-    [['jpg', 'jpeg', 'png', 'gif', 'svg'], { title: 'Image', icon: imageIcon }],
-    [['mp4', 'mkv', 'mov'], { title: 'Video', icon: videoIcon }],
-    [['mp3', 'aac', 'wav', 'm4a'], { title: 'Audio', icon: audioIcon }],
+    [['bmp', 'svg', 'jpg', 'jpeg', 'png', 'ico', 'gif', 'webp'], { title: 'Image', icon: imageIcon }],
+    [['m4v', 'mp4', 'webm', 'mov', 'mkv', 'ogv', 'avi'], { title: 'Video', icon: videoIcon }],
+    [['m4a', 'mp3', 'wav', 'ogg', 'aac', 'flac', 'aiff'], { title: 'Audio', icon: audioIcon }],
     [['txt', 'docx', 'doc', 'pages'], { title: 'Text', icon: textIcon }],
     [['pdf'], { title: 'PDF', icon: pdfIcon }],
     [['zip'], { title: 'ZIP', icon: zipIcon }],


### PR DESCRIPTION
What: 
Add .md .json .xml as text preview types.
Add .webp format for image preview.
Add .ogv format for video preview.
Add .aac .flac for audio preview.
Add all these plus more extensions to show the correct icons in the browser.

Why:
Enabling more file types for preview in the browser.


## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
