### PR TITLE
Fix link underline continuing onto the next space

### DIFF
--- a/web/storagenode/src/app/components/SNOContentFilling.vue
+++ b/web/storagenode/src/app/components/SNOContentFilling.vue
@@ -16,9 +16,7 @@
                     href="https://www.storj.io/s/storage-node-pricing-update-2023"
                     rel="noopener noreferrer"
                     target="_blank"
-                >
-                    forum
-                </a> regarding the Storage Node payout changes.
+                >forum</a> regarding the Storage Node payout changes.
             </p>
         </div>
         <div v-if="isDisqualifiedInfoShown" class="info-area__disqualified-info">
@@ -33,9 +31,7 @@
                     href="https://forum.storj.io/c/sno-category"
                     rel="noopener noreferrer"
                     target="_blank"
-                >
-                    thread
-                </a> on Storj forum.
+                >thread</a> on Storj forum.
             </p>
         </div>
         <div v-else-if="doDisqualifiedSatellitesExist" class="info-area__disqualified-info">
@@ -50,9 +46,7 @@
                     href="https://forum.storj.io/c/sno-category"
                     rel="noopener noreferrer"
                     target="_blank"
-                >
-                    thread
-                </a> on Storj forum.
+                >thread</a> on Storj forum.
             </p>
         </div>
         <div v-if="isSuspendedInfoShown" class="info-area__suspended-info">
@@ -67,9 +61,7 @@
                     href="https://forum.storj.io/c/sno-category"
                     rel="noopener noreferrer"
                     target="_blank"
-                >
-                    thread
-                </a> on Storj forum.
+                >thread</a> on Storj forum.
             </p>
         </div>
         <div v-else-if="doSuspendedSatellitesExist" class="info-area__suspended-info">
@@ -84,9 +76,7 @@
                     href="https://forum.storj.io/c/sno-category"
                     rel="noopener noreferrer"
                     target="_blank"
-                >
-                    thread
-                </a> on Storj forum.
+                >thread</a> on Storj forum.
             </p>
         </div>
         <p class="info-area__title">Bandwidth Utilization </p>


### PR DESCRIPTION
What: This change fixes an underline under links that continues onto the space after the word.

There are likely many, many more instances of this.

Why: Because this is the way it should be, and it bothered me before.

Here's what it looked like rendered before the change:
![image](https://github.com/storj/storj/assets/11021263/ee7535b1-6165-4141-83cf-3be3b092cf72)

Please describe the performance impact: None.

## Code Review Checklist (to be filled out by reviewer)
 - [x ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ x] Does the PR describe what changes are being made?
 - [ x] Does the PR describe why the changes are being made?
 - [ x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ x] Does any documentation need updating?
 - [ x] Do the database access patterns make sense?
 
