### PR TITLE
satellite/metainfo: fix listing for VersioningUnsupported buckets

### DIFF
--- a/satellite/buckets/db.go
+++ b/satellite/buckets/db.go
@@ -69,6 +69,11 @@ const (
 	VersioningSuspended Versioning = 3
 )
 
+// IsUnversioned returns true if bucket state represents unversioned bucket.
+func (v Versioning) IsUnversioned() bool {
+	return v == VersioningUnsupported || v == Unversioned
+}
+
 // MinimalBucket contains minimal bucket fields for metainfo protocol.
 type MinimalBucket struct {
 	Name      []byte

--- a/satellite/metainfo/endpoint_object.go
+++ b/satellite/metainfo/endpoint_object.go
@@ -995,8 +995,8 @@ func (endpoint *Endpoint) ListObjects(ctx context.Context, req *pb.ObjectListReq
 			return nil, endpoint.convertMetabaseErr(err)
 		}
 	} else if !req.IncludeAllVersions {
-		// handles regular listing for all type of buckets
-		if bucket.Versioning == buckets.Unversioned {
+		if bucket.Versioning.IsUnversioned() {
+			// handles listing for VersioningUnsupported and Unversioned buckets
 			err = endpoint.metabase.IterateObjectsAllVersionsWithStatusAscending(ctx,
 				metabase.IterateObjectsWithStatus{
 					ProjectID:  keyInfo.ProjectID,


### PR DESCRIPTION
For now we would like to use metabase.ListObjects only for buckets with versioning state Versioned or Suspended. By accident buckets with VersioningUnsupported state were also on that list.

Change-Id: If2068c722d7e775b5f014a87f7afdee4267c7f32


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
