### PR TITLE
satellite/nodeselection: new node selection for balancing between small groups

### DIFF
--- a/satellite/nodeselection/config.go
+++ b/satellite/nodeselection/config.go
@@ -190,6 +190,13 @@ func selectorFromString(expr string) (NodeSelectorInit, error) {
 		},
 		"nodelist": AllowedNodesFromFile,
 		"filter":   FilterSelector,
+		"balanced": func(attribute string) (NodeSelectorInit, error) {
+			attr, err := CreateNodeAttribute(attribute)
+			if err != nil {
+				return nil, err
+			}
+			return BalancedGroupBasedSelector(attr), nil
+		},
 	}
 	for k, v := range supportedFilters {
 		env[k] = v


### PR DESCRIPTION
Cherry-pick of #66d6b2e66

```

We have a node selection strategy to choose randomly from different groups (like last_net).

But we have a specific case for Storj Select program (and private installs),
 where we have smaller groups (like different providers), but the number of groups might be limited (let's say a few dozens).

The proposed algorithm is the following.

 * let's iterate over the groups in random order
 * from each group, select one node randomly
 * nodes which are already selected will be ignored
 * at the end of the iteration we will start to check each group again (if not enough groups)

Change-Id: I207ccb6e70122fd4e7b9d9acc0667a809492372e
```
 
