### PR TITLE
cherry pick v1.98.2

### DIFF
--- a/satellite/metainfo/endpoint_bucket_test.go
+++ b/satellite/metainfo/endpoint_bucket_test.go
@@ -308,8 +308,7 @@ func TestGetBucketLocation(t *testing.T) {
 		Reconfigure: testplanet.Reconfigure{
 			Satellite: func(log *zap.Logger, index int, config *satellite.Config) {
 				config.Placement = nodeselection.ConfigurablePlacementRule{
-					PlacementRules: fmt.Sprintf(`40:annotated(annotated(country("PL"),annotation("%s","Poland")),annotation("%s","%s"))`,
-						nodeselection.Location, nodeselection.AutoExcludeSubnet, nodeselection.AutoExcludeSubnetOFF),
+					PlacementRules: "endpoint_bucket_test_placement.yaml",
 				}
 			},
 		},
@@ -355,7 +354,7 @@ func TestGetBucketLocation(t *testing.T) {
 			Name: []byte("test-bucket"),
 		})
 		require.NoError(t, err)
-		require.Equal(t, []byte("Poland"), response.Location)
+		require.Equal(t, "Poland", string(response.Location))
 	})
 }
 

--- a/satellite/metainfo/endpoint_bucket_test_placement.yaml
+++ b/satellite/metainfo/endpoint_bucket_test_placement.yaml
@@ -1,0 +1,3 @@
+placements:
+  - id: 40
+    name: Poland

--- a/satellite/overlay/service.go
+++ b/satellite/overlay/service.go
@@ -305,7 +305,7 @@ type Service struct {
 	UploadSelectionCache   *UploadSelectionCache
 	DownloadSelectionCache *DownloadSelectionCache
 	LastNetFunc            LastNetFunc
-	placementRules         nodeselection.PlacementRules
+	placementDefinitions   nodeselection.PlacementDefinitions
 }
 
 // LastNetFunc is the type of a function that will be used to derive a network from an ip and port.
@@ -373,7 +373,7 @@ func NewService(log *zap.Logger, db DB, nodeEvents nodeevents.DB, placements nod
 		DownloadSelectionCache: downloadSelectionCache,
 		LastNetFunc:            MaskOffLastNet,
 
-		placementRules: placements.CreateFilters,
+		placementDefinitions: placements,
 	}, nil
 }
 
@@ -734,10 +734,10 @@ func (service *Service) GetNodeTags(ctx context.Context, id storj.NodeID) (nodes
 	return service.db.GetNodeTags(ctx, id)
 }
 
-// GetLocationFromPlacement returns the value for `nodeselection.Location` that
-// placement is currently annotated with.
+// GetLocationFromPlacement returns the location identifier of the bucket.
+// It comes from the name of the placement (or `nodeselection.Location` in case of legacy config).
 func (service *Service) GetLocationFromPlacement(placement storj.PlacementConstraint) string {
-	return nodeselection.GetAnnotation(service.placementRules(placement), nodeselection.Location)
+	return service.placementDefinitions[placement].Name
 }
 
 // ResolveIPAndNetwork resolves the target address and determines its IP and appropriate last_net, as indicated.


### PR DESCRIPTION
…cements

we tried to be backward compatible, and placement.GetAnnotation("location") can return with the name from the YAML based , but code was not prepared for placement.NodeFilter.GetAnnotation("location")

Easy fix is using the new placement struct instead.

Change-Id: I10f814b46a3564207d01628796d205f676847dbe


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
