### PR TITLE
cherry-pick fix migration v261

### DIFF
--- a/satellite/satellitedb/dbx/billing.dbx
+++ b/satellite/satellitedb/dbx/billing.dbx
@@ -268,7 +268,7 @@ read one (
 
 // storjscan_payment contains information about payments from storjscan.
 model storjscan_payment (
-	key chain_id block_hash log_index
+	key block_hash log_index
 
 	index (fields chain_id block_number log_index)
 

--- a/satellite/satellitedb/dbx/satellitedb.dbx.go
+++ b/satellite/satellitedb/dbx/satellitedb.dbx.go
@@ -718,7 +718,7 @@ CREATE TABLE storjscan_payments (
 	status text NOT NULL,
 	timestamp timestamp with time zone NOT NULL,
 	created_at timestamp with time zone NOT NULL,
-	PRIMARY KEY ( chain_id, block_hash, log_index )
+	PRIMARY KEY ( block_hash, log_index )
 );
 CREATE TABLE storjscan_wallets (
 	user_id bytea NOT NULL,
@@ -1420,7 +1420,7 @@ CREATE TABLE storjscan_payments (
 	status text NOT NULL,
 	timestamp timestamp with time zone NOT NULL,
 	created_at timestamp with time zone NOT NULL,
-	PRIMARY KEY ( chain_id, block_hash, log_index )
+	PRIMARY KEY ( block_hash, log_index )
 );
 CREATE TABLE storjscan_wallets (
 	user_id bytea NOT NULL,

--- a/satellite/satellitedb/dbx/satellitedb.dbx.pgx.sql
+++ b/satellite/satellitedb/dbx/satellitedb.dbx.pgx.sql
@@ -405,7 +405,7 @@ CREATE TABLE storjscan_payments (
 	status text NOT NULL,
 	timestamp timestamp with time zone NOT NULL,
 	created_at timestamp with time zone NOT NULL,
-	PRIMARY KEY ( chain_id, block_hash, log_index )
+	PRIMARY KEY ( block_hash, log_index )
 );
 CREATE TABLE storjscan_wallets (
 	user_id bytea NOT NULL,

--- a/satellite/satellitedb/dbx/satellitedb.dbx.pgxcockroach.sql
+++ b/satellite/satellitedb/dbx/satellitedb.dbx.pgxcockroach.sql
@@ -405,7 +405,7 @@ CREATE TABLE storjscan_payments (
 	status text NOT NULL,
 	timestamp timestamp with time zone NOT NULL,
 	created_at timestamp with time zone NOT NULL,
-	PRIMARY KEY ( chain_id, block_hash, log_index )
+	PRIMARY KEY ( block_hash, log_index )
 );
 CREATE TABLE storjscan_wallets (
 	user_id bytea NOT NULL,

--- a/satellite/satellitedb/migrate.go
+++ b/satellite/satellitedb/migrate.go
@@ -2649,13 +2649,9 @@ func (db *satelliteDB) ProductionMigration() *migrate.Migration {
 			},
 			{
 				DB:          &db.migrationDB,
-				Description: "update storjscan payments table to use chain_id in primary key",
+				Description: "(reverted migration) update storjscan payments table to use chain_id in primary key",
 				Version:     261,
-				Action: migrate.SQL{
-					`ALTER TABLE storjscan_payments DROP CONSTRAINT IF EXISTS "primary";`,
-					`ALTER TABLE storjscan_payments DROP CONSTRAINT IF EXISTS storjscan_payments_pkey;`,
-					`ALTER TABLE storjscan_payments ADD CONSTRAINT storjscan_payments_pkey PRIMARY KEY ( chain_id, block_hash, log_index );`,
-				},
+				Action:      migrate.SQL{},
 			},
 			// NB: after updating testdata in `testdata`, run
 			//     `go generate` to update `migratez.go`.

--- a/satellite/satellitedb/migratez.go
+++ b/satellite/satellitedb/migratez.go
@@ -421,7 +421,7 @@ CREATE TABLE storjscan_payments (
                                     status text NOT NULL,
                                     timestamp timestamp with time zone NOT NULL,
                                     created_at timestamp with time zone NOT NULL,
-                                    PRIMARY KEY ( chain_id, block_hash, log_index )
+                                    PRIMARY KEY ( block_hash, log_index )
 );
 CREATE TABLE storjscan_wallets (
                                    user_id bytea NOT NULL,

--- a/satellite/satellitedb/testdata/postgres.v261.sql
+++ b/satellite/satellitedb/testdata/postgres.v261.sql
@@ -405,7 +405,7 @@ CREATE TABLE storjscan_payments (
                                     status text NOT NULL,
                                     timestamp timestamp with time zone NOT NULL,
                                     created_at timestamp with time zone NOT NULL,
-                                    PRIMARY KEY ( chain_id, block_hash, log_index )
+                                    PRIMARY KEY ( block_hash, log_index )
 );
 CREATE TABLE storjscan_wallets (
                                    user_id bytea NOT NULL,


### PR DESCRIPTION
Due to a mismatch in the primary key name of the storjscan_payments table, the migration of the primary key is being rolled back.
What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
