### PR TITLE
Jenkinsfile.public: re-enable satellite UI tests

### DIFF
--- a/Jenkinsfile.public
+++ b/Jenkinsfile.public
@@ -198,6 +198,27 @@ pipeline {
                     }
                 }
 
+                stage('Satellite UI Tests') {
+                    environment {
+                        STORJ_TEST_COCKROACH = 'cockroach://root@localhost:26256/uitestcockroach?sslmode=disable'
+                        STORJ_TEST_COCKROACH_NODROP = 'true'
+                        STORJ_TEST_POSTGRES = 'omit'
+                        STORJ_TEST_LOG_LEVEL = 'debug'
+                    }
+
+                    steps {
+                        sh 'cockroach sql --insecure --host=localhost:26256 -e \'create database uitestcockroach;\''
+                        sh 'make test-satellite-ui'
+                    }
+
+                    post {
+                        failure {
+                            sh script: 'tar -zcvf .build/test-results.tar.gz ./testsuite/playwright-ui/test-results/'
+                            archiveArtifacts artifacts: '.build/test-results.tar.gz'
+                        }
+                    }
+                }
+
                 stage('Check Benchmark') {
                     environment {
                         STORJ_TEST_COCKROACH = 'omit'


### PR DESCRIPTION
These were previously removed due to flakiness/unreliability. The tests are being added back for a few reasons:
* updates have been made to `make test-satellite-ui` to avoid caching, which was causing flakiness
* there is no clear evidence that the Github failures in the past were Github-specific, and UI tests on Gerrit have been passing consistently for several weeks (Jenkinsfile.verify)
* We need to execute satellite UI tests in Jenkinsfile.public to proceed with more ambitious goals in the future, such as continuous deployment of the UI

Change-Id: I71ca6e0bf4c98f7b929e54db405196245324010a


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
