### PR TITLE
Jenkinsfile.public: Fix lint stage

### DIFF
--- a/Jenkinsfile.public
+++ b/Jenkinsfile.public
@@ -110,7 +110,7 @@ pipeline {
                 }
                 stage('Other') {
                     steps {
-                        sh 'golangci-lint --config /go/ci/.golangci.yml -j=2 run'
+                        sh 'golangci-lint --config /go/ci/.golangci.yml -j=2 --timeout=4m run'
                         sh 'protolock status'
                         sh 'go.min vet ./...'
                         dir("testsuite/storjscan") {
@@ -121,7 +121,7 @@ pipeline {
                 stage('licenses check') {
                     steps {
                         // go-licenses by default has AGPL3 in the forbidden list, hence we need to explicitly allow `storj.io/storj`.
-                        sh 'go-licenses check --ignore "storj.io/storj" ./...'
+                        sh 'go-licenses check --ignore "storj.io/storj" --ignore "github.com/json-iterator/go" ./...'
                     }
                 }
             }


### PR DESCRIPTION
Match arguments passed to `golangci-lint` and `go-licenses` from Jenkinsfile.premerge and Jenkinsfile.verify.

These changes were made recently, e.g. by 82b05dc1be58eac, 67e397d68ff265, but not in Jenkinsfile.public.


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
