### PR TITLE
point release v1.102.4

### DIFF
--- a/satellite/gc/piecetracker/observer_test.go
+++ b/satellite/gc/piecetracker/observer_test.go
@@ -22,7 +22,7 @@ func TestObserverPieceTracker(t *testing.T) {
 		SatelliteCount: 1, StorageNodeCount: 4, UplinkCount: 1,
 		Reconfigure: testplanet.Reconfigure{
 			Satellite: func(log *zap.Logger, index int, config *satellite.Config) {
-				config.PieceTracker.UseRangedLoop = true
+				config.PieceTracker.UpdateBatchSize = 3
 				config.RangedLoop.Parallelism = 4
 				config.RangedLoop.BatchSize = 4
 

--- a/satellite/gc/piecetracker/piecetracker.go
+++ b/satellite/gc/piecetracker/piecetracker.go
@@ -5,5 +5,6 @@ package piecetracker
 
 // Config is the configuration for the piecetracker.
 type Config struct {
-	UseRangedLoop bool `help:"whether to enable piece tracker observer with ranged loop" default:"true"`
+	UseRangedLoop   bool `help:"whether to enable piece tracker observer with ranged loop" default:"true"`
+	UpdateBatchSize int  `help:"batch size for updating nodes with number of pieces" default:"1000"`
 }

--- a/satellite/satellite-config.yaml.lock
+++ b/satellite/satellite-config.yaml.lock
@@ -1099,6 +1099,9 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # price user should pay for storage per month in dollars/TB
 # payments.usage-price.storage-tb: "4"
 
+# batch size for updating nodes with number of pieces
+# piece-tracker.update-batch-size: 1000
+
 # whether to enable piece tracker observer with ranged loop
 # piece-tracker.use-ranged-loop: true
 


### PR DESCRIPTION
Single SQL query to update all nodes pieces found by piece tracker is an exhausting operation. It become problematic after updating CRDB version to 23.4.  This change puts all update operation into batches.
https://github.com/storj/storj/issues/6922
What: 
fix emergency 2024-04-17
Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
