### PR TITLE
cmd/storagenode-updater/: allow updater to update when storagenode is down

### DIFF
--- a/cmd/storagenode-updater/restart_linux.go
+++ b/cmd/storagenode-updater/restart_linux.go
@@ -46,6 +46,10 @@ func stopProcess(service string) (err error) {
 	if err != nil {
 		return err
 	}
+	// if process shutdown, return
+	if pid == 0 {
+		return nil
+	}
 	p, err := os.FindProcess(pid)
 	if err != nil {
 		return err


### PR DESCRIPTION
Resolves https://github.com/storj/storj/issues/6986


What: Allows updater to update the binaries, even if the main storagenode process is down.

Why: Otherwise its deadlocked and cannot update itself anymore.

Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
