### PR TITLE
storagenode/storagenodedb: fix query in gcprogress.Store

### DIFF
--- a/storagenode/pieces/filewalker_test.go
+++ b/storagenode/pieces/filewalker_test.go
@@ -54,7 +54,7 @@ func TestFilewalker_Basic(t *testing.T) {
 			}))
 		}
 
-		filter := bloomfilter.NewOptimal(int64(numberOfPieces), 0.1)
+		filter := bloomfilter.NewOptimal(int64(numberOfPieces), 0.000000001)
 
 		// WalkAndComputeSpaceUsedBySatellite
 		total, totalContentSize, err := fw.WalkAndComputeSpaceUsedBySatellite(ctx, satellite)
@@ -64,11 +64,13 @@ func TestFilewalker_Basic(t *testing.T) {
 
 		// WalkSatellitePieces
 		count := 0
+		numOfTrashPieces := 0
 		err = store.WalkSatellitePieces(ctx, satellite, func(pieceAccess pieces.StoredPieceAccess) error {
+			count++
 			if count%2 == 0 {
 				filter.Add(pieceAccess.PieceID())
+				numOfTrashPieces++
 			}
-			count++
 			return nil
 		})
 		require.NoError(t, err)
@@ -82,7 +84,7 @@ func TestFilewalker_Basic(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, int64(numberOfPieces), piecesCount)
-		require.Equal(t, numberOfPieces/2, trashPieceCount)
+		require.Equal(t, numOfTrashPieces, trashPieceCount)
 
 		// check for the logs
 		require.Equal(t, 0, observedLogs.FilterMessage("failed to get progress from database").Len())

--- a/storagenode/pieces/filewalker_test.go
+++ b/storagenode/pieces/filewalker_test.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2024 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package pieces_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"storj.io/common/bloomfilter"
+	"storj.io/common/memory"
+	"storj.io/common/pb"
+	"storj.io/common/storj"
+	"storj.io/common/testcontext"
+	"storj.io/common/testrand"
+	"storj.io/storj/storagenode"
+	"storj.io/storj/storagenode/blobstore/filestore"
+	"storj.io/storj/storagenode/pieces"
+	"storj.io/storj/storagenode/storagenodedb/storagenodedbtest"
+)
+
+func TestFilewalker_Basic(t *testing.T) {
+	storagenodedbtest.Run(t, func(ctx *testcontext.Context, t *testing.T, db storagenode.DB) {
+		observedZapCore, observedLogs := observer.New(zap.DebugLevel)
+		observedLogger := zap.New(observedZapCore).Named("filewalker")
+
+		blobs := db.Pieces()
+		v0PieceInfo := db.V0PieceInfo()
+		fw := pieces.NewFileWalker(observedLogger, blobs, v0PieceInfo, db.GCFilewalkerProgress())
+		store := pieces.NewStore(observedLogger, fw, nil, blobs, v0PieceInfo, db.PieceExpirationDB(), db.PieceSpaceUsedDB(), pieces.DefaultConfig)
+		testStore := pieces.StoreForTest{Store: store}
+
+		numberOfPieces := 100
+
+		const size = 5 * memory.KiB
+
+		satellite := testrand.NodeID()
+
+		for i := 0; i < numberOfPieces; i++ {
+			now := time.Now()
+			pieceID := testrand.PieceID()
+			w, err := testStore.WriterForFormatVersion(ctx, satellite, pieceID, filestore.FormatV1, pb.PieceHashAlgorithm_SHA256)
+			require.NoError(t, err)
+
+			_, err = w.Write(testrand.Bytes(size))
+			require.NoError(t, err)
+
+			require.NoError(t, w.Commit(ctx, &pb.PieceHeader{
+				CreationTime: now,
+			}))
+		}
+
+		filter := bloomfilter.NewOptimal(int64(numberOfPieces), 0.1)
+
+		// WalkAndComputeSpaceUsedBySatellite
+		total, totalContentSize, err := fw.WalkAndComputeSpaceUsedBySatellite(ctx, satellite)
+		require.NoError(t, err)
+		require.Equal(t, int64(numberOfPieces)*size.Int64(), totalContentSize)
+		require.GreaterOrEqual(t, total, int64(numberOfPieces)*size.Int64())
+
+		// WalkSatellitePieces
+		count := 0
+		err = store.WalkSatellitePieces(ctx, satellite, func(pieceAccess pieces.StoredPieceAccess) error {
+			if count%2 == 0 {
+				filter.Add(pieceAccess.PieceID())
+			}
+			count++
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, numberOfPieces, count)
+
+		// WalkSatellitePiecesToTrash
+		trashPieceCount := 0
+		_, piecesCount, _, err := fw.WalkSatellitePiecesToTrash(ctx, satellite, time.Now(), filter, func(pieceID storj.PieceID) error {
+			trashPieceCount++
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(numberOfPieces), piecesCount)
+		require.Equal(t, numberOfPieces/2, trashPieceCount)
+
+		// check for the logs
+		require.Equal(t, 0, observedLogs.FilterMessage("failed to get progress from database").Len())
+		require.Equal(t, 0, observedLogs.FilterMessage("failed to store progress to database").Len())
+		require.Equal(t, 0, observedLogs.FilterMessage("bloomfilter createdBefore time does not match the one used in the last scan").Len())
+		require.Equal(t, 0, observedLogs.FilterMessage("failed to reset progress in database").Len())
+		require.Equal(t, 1, observedLogs.FilterMessage("resetting progress in database").Len())
+		require.Equal(t, 0, observedLogs.FilterMessage("failed to determine mtime of blob").Len())
+	})
+}

--- a/storagenode/storagenodedb/gcprogress.go
+++ b/storagenode/storagenodedb/gcprogress.go
@@ -68,7 +68,7 @@ func (db *gcFilewalkerProgressDB) Store(ctx context.Context, progress pieces.GCF
 	values := strings.TrimRight(strings.Repeat("(?,?,?),", len(args)/3), ",")
 	_, err = db.ExecContext(ctx, `
 		INSERT OR REPLACE INTO progress(satellite_id, bloomfilter_created_before, last_checked_prefix)
-	`+values, args...)
+		VALUES `+values, args...)
 
 	return ErrGCProgress.Wrap(err)
 }


### PR DESCRIPTION
The query was missing the values keyword which results in a syntax error. The basic db test couldn't catch that because it was only hitting the cache.

This patch fixes the query and also adds some basic tests to the filewalker.

Change-Id: Iab108025ca9f38c0074ce0576e09ed76e40a8b45


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
