### PR TITLE
Jenkinsfile.public: fix backwards compatibility tests

### DIFF
--- a/Jenkinsfile.public
+++ b/Jenkinsfile.public
@@ -269,6 +269,7 @@ pipeline {
 
                         STORJ_SIM_POSTGRES = 'postgres://postgres@localhost/teststorj3?sslmode=disable'
                         STORJ_MIGRATION_DB = 'postgres://postgres@localhost/teststorj3?sslmode=disable&options=--search_path=satellite/0/meta'
+                        STORJ_CONSOLE_SIGNUP_ACTIVATION_CODE_ENABLED = 'false'
                     }
 
                     steps {
@@ -284,6 +285,7 @@ pipeline {
 
                         STORJ_SIM_POSTGRES = 'cockroach://root@localhost:26257/testcockroach5?sslmode=disable'
                         STORJ_MIGRATION_DB = 'postgres://root@localhost:26257/testcockroach5/satellite/0/meta?sslmode=disable'
+                        STORJ_CONSOLE_SIGNUP_ACTIVATION_CODE_ENABLED = 'false'
                     }
 
                     steps {


### PR DESCRIPTION
These env vars were originally added to Jenkinsfile.premerge, (3bd94df9c7762f000408) but they need to be in Jenkinsfile.public to fix Github builds.
