### PR TITLE
satellite/metainfo: add UUIDsFlag for uuids list

### DIFF
--- a/satellite/metabase/db.go
+++ b/satellite/metabase/db.go
@@ -51,7 +51,7 @@ type Config struct {
 	TestingUniqueUnversioned   bool
 	TestingCommitSegmentMode   string
 	TestingPrecommitDeleteMode TestingPrecommitDeleteMode
-	TestingSpannerProjects     []uuid.UUID
+	TestingSpannerProjects     map[uuid.UUID]struct{}
 }
 
 const commitSegmentModeTransaction = "transaction"
@@ -151,7 +151,7 @@ func Open(ctx context.Context, log *zap.Logger, connstr string, config Config) (
 				return nil, err
 			}
 			db.adapters[i] = adapter
-			for _, projectID := range config.TestingSpannerProjects {
+			for projectID := range config.TestingSpannerProjects {
 				db.projectsAdapters[projectID] = adapter
 			}
 		default:

--- a/satellite/metabase/db_test.go
+++ b/satellite/metabase/db_test.go
@@ -103,8 +103,14 @@ func TestSpannerProjects(t *testing.T) {
 	require.Len(t, connUrls, 2, "two databases are required for this test")
 	require.True(t, spannerFound, "Spanner must be configured for this test")
 
-	spannerProjects := []uuid.UUID{testrand.UUID(), testrand.UUID()}
-	nonSpannerProject := []uuid.UUID{testrand.UUID(), testrand.UUID()}
+	spannerProjects := map[uuid.UUID]struct{}{
+		testrand.UUID(): {},
+		testrand.UUID(): {},
+	}
+	nonSpannerProject := map[uuid.UUID]struct{}{
+		testrand.UUID(): {},
+		testrand.UUID(): {},
+	}
 
 	log := zaptest.NewLogger(t)
 	db, err := metabase.Open(ctx, log.Named("metabase"), strings.Join(connUrls, ";"), metabase.Config{
@@ -114,13 +120,13 @@ func TestSpannerProjects(t *testing.T) {
 	require.NoError(t, err)
 	defer ctx.Check(db.Close)
 
-	for _, projectID := range spannerProjects {
+	for projectID := range spannerProjects {
 		adapter := db.ChooseAdapter(projectID)
 		_, ok := adapter.(*metabase.SpannerAdapter)
 		require.True(t, ok, "project %v should be a spanner project", projectID)
 	}
 
-	for _, projectID := range nonSpannerProject {
+	for projectID := range nonSpannerProject {
 		adapter := db.ChooseAdapter(projectID)
 		_, ok := adapter.(*metabase.SpannerAdapter)
 		require.False(t, ok, "project %v should NOT be a spanner project", projectID)

--- a/satellite/metainfo/config.go
+++ b/satellite/metainfo/config.go
@@ -199,11 +199,11 @@ type Config struct {
 	UserInfoValidation UserInfoValidationConfig `help:"Config for user info validation"`
 
 	// TODO remove when we benchmarking are done and decision is made.
-	TestListingQuery                bool     `default:"false" help:"test the new query for non-recursive listing"`
-	TestCommitSegmentMode           string   `default:"" help:"which code path use for commit segment step, empty means default. Other options: transaction, no-pending-object-check"`
-	TestOptimizedInlineObjectUpload bool     `default:"false" devDefault:"true" help:"enables optimization for uploading objects with single inline segment"`
-	TestingPrecommitDeleteMode      int      `default:"0" help:"which code path to use for precommit delete step for unversioned objects, 0 is the default (old) code path."`
-	TestingSpannerProjects          []string `default:""  help:"list of project IDs for which Spanner metabase DB is enabled" hidden:"true"`
+	TestListingQuery                bool      `default:"false" help:"test the new query for non-recursive listing"`
+	TestCommitSegmentMode           string    `default:"" help:"which code path use for commit segment step, empty means default. Other options: transaction, no-pending-object-check"`
+	TestOptimizedInlineObjectUpload bool      `default:"false" devDefault:"true" help:"enables optimization for uploading objects with single inline segment"`
+	TestingPrecommitDeleteMode      int       `default:"0" help:"which code path to use for precommit delete step for unversioned objects, 0 is the default (old) code path."`
+	TestingSpannerProjects          UUIDsFlag `default:""  help:"list of project IDs for which Spanner metabase DB is enabled" hidden:"true"`
 }
 
 // Metabase constructs Metabase configuration based on Metainfo configuration with specific application name.
@@ -216,6 +216,7 @@ func (c Config) Metabase(applicationName string) metabase.Config {
 		NodeAliasCacheFullRefresh:  c.NodeAliasCacheFullRefresh,
 		TestingCommitSegmentMode:   c.TestCommitSegmentMode,
 		TestingPrecommitDeleteMode: metabase.TestingPrecommitDeleteMode(c.TestingPrecommitDeleteMode),
+		TestingSpannerProjects:     c.TestingSpannerProjects,
 	}
 }
 
@@ -225,7 +226,6 @@ type ExtendedConfig struct {
 
 	useBucketLevelObjectVersioningProjects map[uuid.UUID]struct{}
 	useBucketLevelObjectLockProjects       map[uuid.UUID]struct{}
-	spannerProjects                        []uuid.UUID
 }
 
 // NewExtendedConfig creates new instance of extended config.
@@ -248,13 +248,6 @@ func NewExtendedConfig(config Config) (_ ExtendedConfig, err error) {
 			return ExtendedConfig{}, err
 		}
 		extendedConfig.useBucketLevelObjectLockProjects[projectID] = struct{}{}
-	}
-	for _, projectIDString := range config.TestingSpannerProjects {
-		projectID, err := uuid.FromString(projectIDString)
-		if err != nil {
-			return ExtendedConfig{}, err
-		}
-		extendedConfig.spannerProjects = append(extendedConfig.spannerProjects, projectID)
 	}
 
 	return extendedConfig, nil
@@ -291,9 +284,46 @@ func (ec ExtendedConfig) ObjectLockEnabled(projectID uuid.UUID) bool {
 	return ok
 }
 
-// Metabase constructs Metabase configuration based on Metainfo configuration with specific application name.
-func (ec ExtendedConfig) Metabase(applicationName string) metabase.Config {
-	config := ec.Config.Metabase(applicationName)
-	config.TestingSpannerProjects = ec.spannerProjects
-	return config
+// UUIDsFlag is a configuration struct that keeps info about project IDs
+//
+// Can be used as a flag.
+type UUIDsFlag map[uuid.UUID]struct{}
+
+// Type is required for pflag.Value.
+func (m UUIDsFlag) Type() string {
+	return "metainfo.UUIDsFlag"
+}
+
+// Set is required for pflag.Value.
+func (m *UUIDsFlag) Set(s string) error {
+	if s == "" {
+		*m = map[uuid.UUID]struct{}{}
+		return nil
+	}
+
+	uuids := strings.Split(s, ",")
+	*m = make(map[uuid.UUID]struct{}, len(uuids))
+	for _, uuidStr := range uuids {
+		id, err := uuid.FromString(uuidStr)
+		if err != nil {
+			return err
+		}
+
+		(*m)[id] = struct{}{}
+	}
+	return nil
+}
+
+// String is required for pflag.Value.
+func (m UUIDsFlag) String() string {
+	var b strings.Builder
+	i := 0
+	for id := range m {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(id.String())
+		i++
+	}
+	return b.String()
 }

--- a/satellite/metainfo/config_test.go
+++ b/satellite/metainfo/config_test.go
@@ -191,3 +191,25 @@ func TestExtendedConfig_ObjectLockSupported(t *testing.T) {
 	require.True(t, config.ObjectLockEnabled(projectID1))
 	require.True(t, config.ObjectLockEnabled(projectID2))
 }
+
+func TestUUIDsFlag(t *testing.T) {
+	var UUIDs metainfo.UUIDsFlag
+	err := UUIDs.Set("")
+	require.NoError(t, err)
+	require.Len(t, UUIDs, 0)
+
+	testIDA := testrand.UUID()
+	err = UUIDs.Set(testIDA.String())
+	require.NoError(t, err)
+	require.Equal(t, metainfo.UUIDsFlag{
+		testIDA: {},
+	}, UUIDs)
+
+	testIDB := testrand.UUID()
+	err = UUIDs.Set(testIDA.String() + "," + testIDB.String())
+	require.NoError(t, err)
+	require.Equal(t, metainfo.UUIDsFlag{
+		testIDA: {},
+		testIDB: {},
+	}, UUIDs)
+}


### PR DESCRIPTION
Using ExtendedConfig its hard to process ids list in every place. It's easy to miss adding extended config in needed place. With custom flag it will be processed always without need for adding it manually everywhere.

We can replace other []string for UUIDs with new type with subsequent changes.