### PR TITLE
satellite/metabase: fix ListSegments argument

### DIFF
--- a/satellite/metabase/list_segments.go
+++ b/satellite/metabase/list_segments.go
@@ -196,7 +196,7 @@ func (s *SpannerAdapter) ListSegments(ctx context.Context, opts ListSegments, al
 				&segment.EncryptedETag,
 				redundancyScheme{&segment.Redundancy},
 				&segment.InlineData, &aliasPieces,
-				spannerutil.Int(&segment.Placement),
+				&segment.Placement,
 			)
 			if err != nil {
 				return Error.New("failed to read segments: %w", err)


### PR DESCRIPTION
PlacementConstraint implements spanner decode already and spannerutil.Int doesn't work for nullable columns.

Change-Id: Ia8465241893b1f7e9602a7e3fb0d7e6a7d51ddba