### PR TITLE
cherry pick v1.116.5

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,5 +2,29 @@
 set -eu
 set -o pipefail
 
+echo -n "Build timestamp: "
+TIMESTAMP=$(date +%s)
+echo $TIMESTAMP
+
+echo -n "Git commit: "
+if [[ "$(git diff --stat)" != '' ]] || [[ -n "$(git status -s)" ]]; then
+  COMMIT=$(git rev-parse HEAD)-dirty
+else
+  COMMIT=$(git rev-parse HEAD)
+fi
+echo $COMMIT
+
+echo -n "Tagged version: "
+if git describe --tags --exact-match --match "v[0-9]*.[0-9]*.[0-9]*"; then
+  VERSION=$(git describe --tags --exact-match --match "v[0-9]*.[0-9]*.[0-9]*")
+else
+  VERSION=$(git show -s --date='format:%Y.%m' --format='v%cd.%ct-%h' HEAD)
+fi
+echo $VERSION
+
 echo Running "go $@"
-exec go "$1" "${@:2}"
+exec go "$1" -ldflags \
+  "-X storj.io/common/version.buildTimestamp=$TIMESTAMP
+   -X storj.io/common/version.buildCommitHash=$COMMIT
+   -X storj.io/common/version.buildVersion=$VERSION
+   -X storj.io/common/version.buildRelease=true" "${@:2}"


### PR DESCRIPTION
it has come to my attention that we do release.sh
for binaries other than storagenode and they may
not have been built on a tag with tag-release.sh
so they may not be set as release builds.

this changes release.sh to just always do a release build because it's release.sh.

Change-Id: Ia3bad5d5fc4e6e079820f8b91774f07609701f53


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
