### PR TITLE
satellite/satellitedb: optimize unnest queries

### DIFF
--- a/satellite/satellitedb/invoiceprojectrecords.go
+++ b/satellite/satellitedb/invoiceprojectrecords.go
@@ -159,8 +159,7 @@ func (db *invoiceProjectRecords) GetUnappliedByProjectIDs(ctx context.Context, p
 			FROM
 				stripecoinpayments_invoice_project_records
 			WHERE
-				project_id IN ( SELECT project_id
-			FROM UNNEST(?) AS project_id)
+				project_id IN UNNEST(?)
 				AND period_start = ? AND period_end = ? AND state = ?`
 
 		rows, err = db.db.QueryContext(ctx, query, pids, start, end, int(invoiceProjectRecordStateUnapplied))


### PR DESCRIPTION
Using an extra `v IN (SELECT x FROM UNNEST(?))` makes the query planner perform suboptimally. Using `v IN UNNEST(?)` should be sufficient.

Change-Id: I2e321134a05bab0a7ee73b3b38454c0dc3cc0c95


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
