### PR TITLE
cherry-pick v1.118.7

### DIFF
--- a/testsuite/rolling-upgrade/start-sim.sh
+++ b/testsuite/rolling-upgrade/start-sim.sh
@@ -56,7 +56,8 @@ git fetch --tags
 # if it's running on a release branch, we will set the stage 1 version to be the latest previous major release
 # if it's running on main, we will set the stage 1 version to be the current release version
 current_commit=$(git rev-parse HEAD)
-stage1_release_version=$(git tag -l --sort -version:refname | grep -v rc | head -1)
+# uses { head -1; cat >/dev/null; } to ensure all output from grep is consumed and pipe won't fail
+stage1_release_version=$(git tag -l --sort -version:refname | grep -v rc | { head -1; cat >/dev/null; } )
 if [[ $BRANCH_NAME = v* ]]; then
     stage1_release_version=$($SCRIPTDIR/../find-previous-release.sh --major)
 fi


### PR DESCRIPTION
When using:

  git tag -l --sort -version:refname | grep -v rc | head -1

The head may stop before grep has processed all the data, hence it will end up writing to a closed pipe. Causing a "exit code 141" failure.

The fix is to consume the full output from grep to avoid the failure.

  { head -1; cat >/dev/null; }

An alternative would be to disable pipefail, but that may hide other errors.

Change-Id: I6918eac14e8df39dc4d702531ed011a9c6354662


What: 

Why:
fix for jenkins pipeline
Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
