### PR TITLE
v1.123.3-rc

### DIFF
--- a/cmd/satellite/delete_data.go
+++ b/cmd/satellite/delete_data.go
@@ -8,9 +8,11 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/zeebo/errs"
@@ -22,6 +24,8 @@ import (
 	"storj.io/storj/satellite/buckets"
 	"storj.io/storj/satellite/console"
 	"storj.io/storj/satellite/metabase"
+	"storj.io/storj/satellite/payments"
+	"storj.io/storj/satellite/payments/stripe"
 	"storj.io/storj/satellite/satellitedb"
 )
 
@@ -35,7 +39,7 @@ func cmdDeleteObjects(cmd *cobra.Command, args []string) error {
 		RevocationLRUOptions: runCfg.RevocationLRUOptions(),
 	})
 	if err != nil {
-		return errs.New("Error connecting to satellite database: %+v", err)
+		return errs.New("error connecting to satellite database: %+v", err)
 	}
 	defer func() {
 		err = errs.Combine(err, satDB.Close())
@@ -43,7 +47,7 @@ func cmdDeleteObjects(cmd *cobra.Command, args []string) error {
 
 	metabaseDB, err := metabase.Open(ctx, log.Named("metabase"), runCfg.Metainfo.DatabaseURL, runCfg.Metainfo.Metabase("satellite-rangedloop"))
 	if err != nil {
-		return errs.New("Error creating metabase connection: %+v", err)
+		return errs.New("error creating metabase connection: %+v", err)
 	}
 	defer func() {
 		err = errs.Combine(err, metabaseDB.Close())
@@ -60,9 +64,38 @@ func cmdDeleteObjects(cmd *cobra.Command, args []string) error {
 	return deleteObjects(ctx, log, satDB, metabaseDB, csvFile)
 }
 
-func cmdDeleteAccounts(_ *cobra.Command, _ []string) error {
-	// TODO: implement it
-	panic("not implemented")
+func cmdDeleteAccounts(cmd *cobra.Command, args []string) error {
+	ctx, _ := process.Ctx(cmd)
+	log := zap.L()
+
+	satDB, err := satellitedb.Open(ctx, log.Named("db"), runCfg.Database, satellitedb.Options{
+		ApplicationName:      "satellite-delete-data",
+		APIKeysLRUOptions:    runCfg.APIKeysLRUOptions(),
+		RevocationLRUOptions: runCfg.RevocationLRUOptions(),
+	})
+	if err != nil {
+		return errs.New("error connecting to satellite database: %+v", err)
+	}
+	defer func() {
+		err = errs.Combine(err, satDB.Close())
+	}()
+
+	csvFile, err := os.Open(args[0])
+	if err != nil {
+		return errs.New("error opening CSV file: %+v", err)
+	}
+	defer func() {
+		err = errs.Combine(err, csvFile.Close())
+	}()
+
+	stripeService, err := setupPayments(log, satDB)
+	if err != nil {
+		return errs.New("error setting up Stripe service: %+v", err)
+	}
+
+	return deleteAccounts(
+		ctx, log, satDB, stripeService.Accounts().Invoices(), csvFile,
+	)
 }
 
 // deleteObjects for each user's account with the email in csvData, delete all the objects and
@@ -128,6 +161,178 @@ func deleteObjects(
 
 				blopts = blopts.NextPage(bcks)
 			}
+		}
+
+		return nil
+	})
+}
+
+// deleteAccounts for each user's account with the email in csvData, redacts the user's personal
+// information and mark the account as deleted, marks their associated projects as disabled, and
+// delete their API keys.
+//
+// The user's accounts that they fulfill the following requirements are skipped and logged with an
+// error message:
+//
+// - The account must be in "pending deletion" status.
+//
+// - If the account is in the paid tier:
+//
+//   - All the invoices must not be in "open" or "draft" status.
+//
+//   - There are no pending invoice items.
+//
+//   - All the projects must not have any usage in the current month.
+//
+//   - All the projects must not have any usage in the last month without a created invoice.
+//
+// - Its projects must not have any buckets.
+//
+// It returns an error when a system error is found or when the CSV file has an error.
+func deleteAccounts(
+	ctx context.Context, log *zap.Logger, satDB satellite.DB, invoices payments.Invoices,
+	csvData io.Reader,
+) error {
+	var (
+		projectAccounting = satDB.ProjectAccounting()
+		projectRecords    = satDB.StripeCoinPayments().ProjectRecords()
+	)
+
+	rows := CSVEmails{
+		Data:       csvData,
+		UserStatus: console.PendingDeletion,
+		Log:        log,
+		DB:         satDB.Console(),
+	}
+
+	return rows.ForEach(ctx, func(user *console.User, projects []console.Project) error {
+		if user.PaidTier {
+			{ // Check if the user has pending invoices.
+				list, err := invoices.List(ctx, user.ID)
+				if err != nil {
+					return errs.New(
+						"error listing invoices for user %q: %+v", user.Email, err,
+					)
+				}
+
+				for _, inv := range list {
+					if inv.Status == payments.InvoiceStatusOpen || inv.Status == payments.InvoiceStatusDraft {
+						log.Error(
+							"cannot mark as deleted the account because it has pending invoices ('open' or 'draft')",
+							zap.String("user_email", user.Email),
+						)
+						return nil
+					}
+				}
+			}
+
+			// Check if the user has pending invoice items.
+			hasPendingItems, err := invoices.CheckPendingItems(ctx, user.ID)
+			if err != nil {
+				return errs.New(
+					"error checking pending invoice items for user %q: %+v", user.Email, err,
+				)
+			}
+			if hasPendingItems {
+				log.Error(
+					"cannot mark as deleted the account because it has pending invoice items",
+					zap.String("user_email", user.Email),
+				)
+				return nil
+			}
+
+			now := time.Now().UTC()
+			year, month, _ := now.Date()
+			firstOfMonth := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+			for _, p := range projects {
+				// Check if there is usage this month.
+				usage, err := projectAccounting.GetProjectTotal(ctx, p.ID, firstOfMonth, now)
+				if err != nil {
+					return errs.New(
+						"error getting usage for project %q (user: %q): %+v", p.ID, user.Email, err,
+					)
+				}
+
+				if usage.Storage > 0 || usage.Egress > 0 || usage.SegmentCount > 0 {
+					log.Error(
+						"cannot mark as deleted the account because the project has usage",
+						zap.String("user_email", user.Email),
+						zap.String("project_id", p.ID.String()),
+					)
+					return nil
+				}
+
+				// Check usage for last month, if exists, ensure we have an invoice item created.
+				usage, err = projectAccounting.GetProjectTotal(
+					ctx, p.ID, firstOfMonth.AddDate(0, -1, 0), firstOfMonth.AddDate(0, 0, -1),
+				)
+				if err != nil {
+					return errs.New("error getting usage for project %q (user: %q): %+v", p.ID, user.Email, err)
+				}
+
+				if usage.Storage > 0 || usage.Egress > 0 || usage.SegmentCount > 0 {
+					err = projectRecords.Check(ctx, p.ID, firstOfMonth.AddDate(0, -1, 0), firstOfMonth)
+					if !errors.Is(err, stripe.ErrProjectRecordExists) {
+						log.Error(
+							"cannot mark as deleted the account because the project has usage last month and not invoiced yet",
+							zap.String("user_email", user.Email),
+							zap.String("project_id", p.ID.String()),
+						)
+						return nil
+					}
+				}
+			}
+		}
+
+		for _, p := range projects {
+			bcks, err := satDB.Buckets().ListBuckets(ctx,
+				p.ID, buckets.ListOptions{
+					Direction: buckets.DirectionForward,
+					Limit:     1,
+				}, macaroon.AllowedBuckets{All: true})
+			if err != nil {
+				return errs.New(
+					"error listing buckets for project %q (user: %q): %+v", p.ID, user.Email, err,
+				)
+			}
+			if len(bcks.Items) > 0 {
+				log.Error(
+					"cannot mark as deleted the account because the project has buckets",
+					zap.String("email", user.Email),
+					zap.String("project", p.ID.String()),
+				)
+				return nil
+			}
+
+			if err := satDB.Console().APIKeys().DeleteAllByProjectID(ctx, p.ID); err != nil {
+				return errs.New(
+					"error deleting API keys for project %q (user: %q): %+v", p.ID, user.Email, err,
+				)
+			}
+
+			if err := satDB.Console().Projects().UpdateStatus(ctx, p.ID, console.ProjectDisabled); err != nil {
+				return errs.New(
+					"error updating project status %q (user: %q) to 'disabled': %+v", p.ID, user.Email, err,
+				)
+			}
+		}
+
+		emptyName := ""
+		emptyNamePtr := &emptyName
+		deactivatedEmail := fmt.Sprintf("deactivated+%s@storj.io", user.ID.String())
+		status := console.Deleted
+
+		err := satDB.Console().Users().Update(ctx, user.ID, console.UpdateUserRequest{
+			FullName:  &emptyName,
+			ShortName: &emptyNamePtr,
+			Email:     &deactivatedEmail,
+			Status:    &status,
+		})
+		if err != nil {
+			return errs.New(
+				"error updating user %q to redact its personal data and set it to 'deleted' status: %+v",
+				user.Email, err,
+			)
 		}
 
 		return nil

--- a/cmd/satellite/delete_data.go
+++ b/cmd/satellite/delete_data.go
@@ -273,6 +273,12 @@ func deleteAccounts(
 				if usage.Storage > 0 || usage.Egress > 0 || usage.SegmentCount > 0 {
 					err = projectRecords.Check(ctx, p.ID, firstOfMonth.AddDate(0, -1, 0), firstOfMonth)
 					if !errors.Is(err, stripe.ErrProjectRecordExists) {
+						if err != nil {
+							return errs.New(
+								"error checking project record for project %q (user: %q): %+v", p.ID, user.Email, err,
+							)
+						}
+
 						log.Error(
 							"cannot mark as deleted the account because the project has usage last month and not invoiced yet",
 							zap.String("user_email", user.Email),

--- a/cmd/satellite/delete_data_test.go
+++ b/cmd/satellite/delete_data_test.go
@@ -7,10 +7,13 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"github.com/stripe/stripe-go/v75"
+	"go.uber.org/zap/zaptest"
 
 	"storj.io/common/macaroon"
 	"storj.io/common/memory"
@@ -18,6 +21,8 @@ import (
 	"storj.io/common/testrand"
 	"storj.io/storj/private/testplanet"
 	"storj.io/storj/satellite/console"
+	"storj.io/storj/satellite/payments"
+	storjstripe "storj.io/storj/satellite/payments/stripe"
 	"storj.io/uplink"
 )
 
@@ -129,7 +134,7 @@ func TestDeleteObjects(t *testing.T) {
 		}
 
 		// Delete all the data of the accounts.
-		require.NoError(t, deleteObjects(ctx, zap.NewNop(), sat.DB, sat.Metabase.DB, csvData))
+		require.NoError(t, deleteObjects(ctx, zaptest.NewLogger(t), sat.DB, sat.Metabase.DB, csvData))
 
 		// Check that all the data was deleted.
 		objects, err = sat.Metabase.DB.TestingAllObjects(ctx)
@@ -155,5 +160,376 @@ func TestDeleteObjects(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, objects, 1)
 		}
+	})
+}
+
+func TestDeleteAccounts(t *testing.T) {
+	// The test is based on 16 uplinks because it offers having several users with projects.
+	// The test uses them to create the following scenario following the order of the uplinks. If
+	// not specified, the user is as provided by testplanet with no extra API keys, isn't member of
+	// any project, no data, no usage, no invoices, no pending invoice items.
+	// - 1) user with status "pending deletion".
+	// - 2) user with status "pending deletion", 5 API keys on its project, and paid tier.
+	// - 3) user with status "pending deletion", and member of the project of the 4th uplink.
+	// - 4) user with status "pending deletion", member of the project of the 3th uplink, and paid tier.
+	// - 5) user with status "pending deletion", and member of the project of the 4rd and 6th uplink.
+	// - 6) user with status "pending deletion" and 1 additional project.
+	// - 7) user with status "pending deletion" and a bucket and object.
+	// - 8) user with status "pending deletion", usage, and paid tier.
+	// - 9) user with status "pending deletion" , invoice in "draft" status, and paid tier.
+	// - 10) user with status "pending deletion", invoice in "open" status, and paid tier.
+	// - 11) user with status "pending deletion", invoice in "paid" status, and paid tier.
+	// - 12) user with status "pending deletion", invoice in "void" status, and paid tier.
+	// - 13) user with status "pending deletion", invoice in "uncollectible" status, and paid tier.
+	// - 14) user with status "pending deletion", pending invoice items, and paid tier.
+	// - 15) user status "active".
+	// - 16) user status "legal hold". NOTE: We don't check all the statuses, but we consider that
+	//       the "active" status is an usual one, so we check the "legal hold" as a differentiation.
+	const UplinkCount = 16
+
+	testplanet.Run(t, testplanet.Config{
+		Reconfigure: testplanet.Reconfigure{
+			Satellite: testplanet.Combine(
+				testplanet.ReconfigureRS(2, 2, 4, 4),
+				testplanet.MaxSegmentSize(13*memory.KiB),
+			),
+		},
+		UplinkCount: UplinkCount, SatelliteCount: 1, StorageNodeCount: 4,
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		sat := planet.Satellites[0]
+		uplinks := planet.Uplinks
+		require.Len(t, uplinks, UplinkCount)
+
+		{ // Add 4 API keys more to the 2nd uplink project.
+			userCtx, err := sat.UserContext(ctx, uplinks[1].Projects[0].Owner.ID)
+			require.NoError(t, err)
+			for i := 1; i <= 3; i++ {
+				_, _, err := sat.API.Console.Service.CreateAPIKey(
+					userCtx, uplinks[1].Projects[0].ID, strconv.Itoa(i), macaroon.APIKeyVersionLatest,
+				)
+				require.NoError(t, err)
+			}
+		}
+
+		{ // Add the 3rd uplink user to the 4th uplink project.
+			userCtx, err := sat.UserContext(ctx, uplinks[3].Projects[0].Owner.ID)
+			require.NoError(t, err)
+			_, err = sat.API.Console.Service.AddProjectMembers(userCtx,
+				uplinks[3].Projects[0].ID, []string{uplinks[2].User[sat.ID()].Email},
+			)
+			require.NoError(t, err)
+		}
+
+		{ // Add the 4th uplink user to the 3rd uplink project.
+			userCtx, err := sat.UserContext(ctx, uplinks[2].Projects[0].Owner.ID)
+			require.NoError(t, err)
+			_, err = sat.API.Console.Service.AddProjectMembers(userCtx,
+				uplinks[2].Projects[0].ID, []string{uplinks[3].User[sat.ID()].Email},
+			)
+			require.NoError(t, err)
+		}
+
+		{ // Add the 5th uplink user to the 4th and 6th uplink projects.
+			userCtx, err := sat.UserContext(ctx, uplinks[3].Projects[0].Owner.ID)
+			require.NoError(t, err)
+			_, err = sat.API.Console.Service.AddProjectMembers(userCtx,
+				uplinks[3].Projects[0].ID, []string{uplinks[4].User[sat.ID()].Email},
+			)
+			require.NoError(t, err)
+			userCtx, err = sat.UserContext(ctx, uplinks[5].Projects[0].Owner.ID)
+			require.NoError(t, err)
+			_, err = sat.API.Console.Service.AddProjectMembers(userCtx,
+				uplinks[5].Projects[0].ID, []string{uplinks[4].User[sat.ID()].Email},
+			)
+			require.NoError(t, err)
+		}
+
+		// Add a second project to the 6th Uplink user.
+		var extraProj *console.Project
+		{ // Create a new project associated with the 5th Uplink user and upload some objects.
+			require.Len(t, uplinks[5].Projects, 1)
+
+			var err error
+			owner := uplinks[4].Projects[0].Owner
+			extraProj, err = sat.AddProject(ctx, owner.ID, "a second project")
+			require.NoError(t, err)
+
+			// Create 3 API keys for the project.
+			userCtx, err := sat.UserContext(ctx, owner.ID)
+			require.NoError(t, err)
+			for i := 1; i <= 3; i++ {
+				_, _, err := sat.API.Console.Service.CreateAPIKey(
+					userCtx, extraProj.ID, strconv.Itoa(i), macaroon.APIKeyVersionLatest,
+				)
+				require.NoError(t, err)
+			}
+		}
+
+		// Upload an object to the 7th Uplink's project.
+		require.NoError(t, uplinks[6].Upload(
+			ctx, sat, "my-bucket", "my-object", testrand.Bytes(10*memory.KiB)),
+		)
+
+		{ // Create usage for the project of the 8th Uplink.
+			since := time.Now()
+			sat.Accounting.Tally.Loop.Pause()
+
+			require.NoError(t, uplinks[7].Upload(
+				ctx, sat, "my-bucket", "my-object", testrand.Bytes(10*memory.KiB),
+			))
+
+			_, err := uplinks[7].Download(ctx, sat, "my-bucket", "my-object")
+			require.NoError(t, err)
+
+			// sat.Accounting.Tally.Loop.TriggerWait()
+			require.NoError(t, uplinks[7].DeleteObject(ctx, sat, "my-bucket", "my-object"))
+			require.NoError(t, uplinks[7].DeleteBucket(ctx, sat, "my-bucket"))
+
+			// Wait for the SNs endpoints to finish their work
+			require.NoError(t, planet.WaitForStorageNodeEndpoints(ctx))
+
+			// Ensure all nodes have sent up any orders for the time period we're calculating
+			for _, sn := range planet.StorageNodes {
+				sn.Storage2.Orders.SendOrders(ctx, since.Add(24*time.Hour))
+			}
+
+			sat.Accounting.Tally.Loop.TriggerWait()
+			// flush rollups write cache
+			sat.Orders.Chore.Loop.TriggerWait()
+		}
+
+		{ // Create a draft invoice for the 9th Uplink.
+			user := uplinks[8].Projects[0].Owner
+			inv, err := sat.API.Payments.StripeService.Accounts().Invoices().Create(
+				ctx, user.ID, 1000, "test invoice",
+			)
+			require.NoError(t, err)
+			require.Equal(t, payments.InvoiceStatusDraft, inv.Status)
+		}
+
+		{ // Create an open invoice for the 10th Uplink.
+			user := uplinks[9].Projects[0].Owner
+			inv, err := sat.API.Payments.StripeService.Accounts().Invoices().Create(
+				ctx, user.ID, 1000, "test invoice",
+			)
+			require.NoError(t, err)
+
+			// attempting to pay a draft invoice changes it to open if payment fails
+			_, err = sat.API.Payments.StripeService.Accounts().Invoices().Pay(
+				ctx, inv.ID, storjstripe.MockInvoicesPayFailure,
+			)
+			require.Error(t, err)
+
+			inv, err = sat.API.Payments.StripeService.Accounts().Invoices().Get(ctx, inv.ID)
+			require.NoError(t, err)
+			require.Equal(t, payments.InvoiceStatusOpen, inv.Status)
+		}
+
+		{ // Create a paid invoice for the 11th Uplink.
+			user := uplinks[10].Projects[0].Owner
+			inv, err := sat.API.Payments.StripeService.Accounts().Invoices().Create(
+				ctx, user.ID, 1000, "test invoice",
+			)
+			require.NoError(t, err)
+
+			_, err = sat.API.Payments.StripeService.Accounts().Invoices().Pay(
+				ctx, inv.ID, storjstripe.MockInvoicesPaySuccess,
+			)
+			require.NoError(t, err)
+
+			inv, err = sat.API.Payments.StripeService.Accounts().Invoices().Get(ctx, inv.ID)
+			require.NoError(t, err)
+			require.Equal(t, payments.InvoiceStatusPaid, inv.Status)
+		}
+
+		{ // Create a void invoice for the 12th Uplink.
+			user := uplinks[11].Projects[0].Owner
+			inv, err := sat.API.Payments.StripeService.Accounts().Invoices().Create(
+				ctx, user.ID, 1000, "test invoice",
+			)
+			require.NoError(t, err)
+
+			_, err = sat.Config.Payments.MockProvider.Invoices().VoidInvoice(inv.ID, nil)
+			require.NoError(t, err)
+
+			inv, err = sat.API.Payments.StripeService.Accounts().Invoices().Get(ctx, inv.ID)
+			require.NoError(t, err)
+			require.Equal(t, payments.InvoiceStatusVoid, inv.Status)
+		}
+
+		{ // Create a uncollectible invoice for the 13th Uplink.
+			user := uplinks[12].Projects[0].Owner
+			inv, err := sat.API.Payments.StripeService.Accounts().Invoices().Create(
+				ctx, user.ID, 1000, "test invoice",
+			)
+			require.NoError(t, err)
+
+			// attempting to pay a draft invoice changes it to open if payment fails
+			_, err = sat.Config.Payments.MockProvider.Invoices().MarkUncollectible(inv.ID, nil)
+			require.NoError(t, err)
+
+			inv, err = sat.API.Payments.StripeService.Accounts().Invoices().Get(ctx, inv.ID)
+			require.NoError(t, err)
+			require.Equal(t, payments.InvoiceStatusUncollectible, inv.Status)
+		}
+
+		{ // Create pending invoice items for the 14th Uplink.
+			userID := uplinks[13].Projects[0].Owner.ID
+			cusID, err := sat.DB.StripeCoinPayments().Customers().GetCustomerID(ctx, userID)
+			require.NoError(t, err)
+
+			amount := int64(1000)
+			_, err = sat.Config.Payments.MockProvider.InvoiceItems().New(&stripe.InvoiceItemParams{
+				Customer: &cusID,
+				Amount:   &amount,
+			})
+			require.NoError(t, err)
+
+			hasPending, err := sat.API.Payments.StripeService.Accounts().Invoices().CheckPendingItems(ctx, userID)
+			require.NoError(t, err)
+			require.True(t, hasPending)
+		}
+
+		// Set the accounts in "pending deletion" status, except the 15th and 16th Uplink.
+		for i := 0; i < len(uplinks)-2; i++ {
+			pendingStatus := console.PendingDeletion
+			require.NoError(t,
+				sat.DB.Console().Users().Update(ctx, uplinks[i].Projects[0].Owner.ID,
+					console.UpdateUserRequest{
+						Status: &pendingStatus,
+					},
+				),
+			)
+		}
+
+		// Change some users to be in the paid tier.
+		for _, i := range []int{1, 3, 7, 8, 9, 10, 11, 12, 13} {
+			paidTier := true
+			require.NoError(t,
+				sat.DB.Console().Users().Update(ctx, uplinks[i].Projects[0].Owner.ID,
+					console.UpdateUserRequest{
+						PaidTier: &paidTier,
+					},
+				),
+			)
+		}
+
+		{ // Set the 16th Uplink user in "legal hold" status.}
+			pendingStatus := console.LegalHold
+			require.NoError(t,
+				sat.DB.Console().Users().Update(ctx, uplinks[15].Projects[0].Owner.ID,
+					console.UpdateUserRequest{
+						Status: &pendingStatus,
+					},
+				),
+			)
+		}
+
+		// Create a CSV with the users' emails to delete.
+		var csvData io.Reader
+		{
+			emails := "email"
+			for _, uplnk := range uplinks {
+				emails += fmt.Sprintf("\n%s", uplnk.User[sat.ID()].Email)
+			}
+
+			csvData = bytes.NewBufferString(emails)
+		}
+
+		// Delete accounts and their associated projects.
+		require.NoError(t, deleteAccounts(
+			ctx, zaptest.NewLogger(t), sat.DB, sat.API.Payments.Accounts.Invoices(), csvData,
+		))
+
+		deleteVerification := func(uplinkIdx int) {
+			pID := uplinks[uplinkIdx].Projects[0].ID
+			keys, err := sat.DB.Console().APIKeys().GetAllNamesByProjectID(ctx, pID)
+			require.NoError(t, err)
+			require.Empty(t, keys)
+
+			proj, err := sat.DB.Console().Projects().Get(ctx, pID)
+			require.NoError(t, err)
+			require.NotNil(t, proj.Status)
+			require.Equal(t, console.ProjectDisabled, *proj.Status)
+
+			userID := uplinks[uplinkIdx].Projects[0].Owner.ID
+			user, err := sat.DB.Console().Users().Get(ctx, userID)
+			require.NoError(t, err)
+			require.Equal(t, console.Deleted, user.Status)
+			require.Empty(t, user.FullName)
+			require.Empty(t, user.ShortName)
+			require.Equal(t, user.Email, fmt.Sprintf("deactivated+%s@storj.io", user.ID))
+		}
+
+		// Verify extra project API keys are deleted.
+		keys, err := sat.DB.Console().APIKeys().GetAllNamesByProjectID(ctx, extraProj.ID)
+		require.NoError(t, err)
+		require.Empty(t, keys)
+
+		// Verify users and projects associated with the uplinks 1st to 6th are marked as deleted.
+		for i := 0; i < 6; i++ {
+			deleteVerification(i)
+		}
+
+		// Verify users and projects associated with the uplinks 11th to 13th are marked as deleted.
+		for i := 10; i < 13; i++ {
+			deleteVerification(i)
+		}
+
+		{ // Verify that the 6th uplink additional project is marked as deleted and their API keys
+			// are deleted.
+			keys, err := sat.DB.Console().APIKeys().GetAllNamesByProjectID(ctx, extraProj.ID)
+			require.NoError(t, err)
+			require.Empty(t, keys)
+
+			proj, err := sat.DB.Console().Projects().Get(ctx, extraProj.ID)
+			require.NoError(t, err)
+			require.NotNil(t, proj.Status)
+			require.Equal(t, console.ProjectDisabled, *proj.Status)
+		}
+
+		noDeleteVerification := func(uplinkIdx int, expectedStatus console.UserStatus) {
+			pID := uplinks[uplinkIdx].Projects[0].ID
+			keys, err := sat.DB.Console().APIKeys().GetAllNamesByProjectID(ctx, pID)
+			require.NoError(t, err, uplinkIdx)
+			require.NotEmpty(t, keys, uplinkIdx)
+
+			proj, err := sat.DB.Console().Projects().Get(ctx, pID)
+			require.NoError(t, err, uplinkIdx)
+			require.NotNil(t, proj.Status, uplinkIdx)
+			require.Equal(t, console.ProjectActive, *proj.Status, uplinkIdx)
+
+			userID := uplinks[uplinkIdx].Projects[0].Owner.ID
+			user, err := sat.DB.Console().Users().Get(ctx, userID)
+			require.NoError(t, err, uplinkIdx)
+			require.Equal(t, expectedStatus, user.Status, uplinkIdx)
+			require.NotEmpty(t, user.FullName, uplinkIdx)
+			require.NotEqual(t, user.Email, fmt.Sprintf("deactivated+%s@storj.io", userID), uplinkIdx)
+		}
+
+		// Verify that users and projects of the uplinks 7th to 10th are not marked as deleted.
+		for i := 6; i < 10; i++ {
+			noDeleteVerification(i, console.PendingDeletion)
+		}
+
+		{ // Verify that the 7th uplink has its data.
+			buckets, err := uplinks[6].ListBuckets(ctx, sat)
+			require.NoError(t, err)
+			require.Len(t, buckets, 1)
+
+			objects, err := uplinks[6].ListObjects(ctx, sat, buckets[0].Name)
+			require.NoError(t, err)
+			require.Len(t, objects, 1)
+		}
+
+		// Verify that users and projects of the uplinks 14th to 14th are not marked as deleted.
+		for i := 13; i < 14; i++ {
+			noDeleteVerification(i, console.PendingDeletion)
+		}
+
+		// Verify that users and projects of the uplinks 15th to 16th are not marked as deleted because
+		// of the users statuses.
+		noDeleteVerification(14, console.Active)
+		noDeleteVerification(15, console.LegalHold)
 	})
 }

--- a/cmd/satellite/main.go
+++ b/cmd/satellite/main.go
@@ -386,11 +386,12 @@ var (
 		Short: "Delete accounts and their associated entities",
 		Long: "From the list of users accounts it redacts the users' personal information and marks " +
 			"their accounts as deleted, deactivate their projects, and delete their API keys.\n The " +
-			"accounts must be on 'pending deletion' status and to not have any bucket, otherwise, they " +
-			"are logged with an info message and skipped. Unexisting accounts are logged with a debug  " +
-			"message and skipped.\nSystem errors exit the process with an error message.\nThe accounts " +
-			"are read from a CSV file with a single column that contains the email of the user's " +
-			"account; the first row is considered as header if it doesn't contain '@'",
+			"accounts must be on 'pending deletion' status, otherwise they are logged with an info " +
+			"message and skipped. The accounts must not have data, othersise they are logged as an " +
+			"error message and skipped. Unexisting accounts are logged with a debug  message and " +
+			"skipped.\nSystem errors exit the process with an error message.\nThe accounts are read " +
+			"from a CSV file with a single column that contains the email of the user's account; the " +
+			"first row is considered as header if it doesn't contain '@'",
 		Args: cobra.ExactArgs(1),
 		RunE: cmdDeleteAccounts,
 	}

--- a/satellite/gc-bf.go
+++ b/satellite/gc-bf.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net"
 	"runtime/pprof"
+	"time"
 
 	"github.com/spacemonkeygo/monkit/v3"
 	"github.com/zeebo/errs"
@@ -103,11 +104,22 @@ func NewGarbageCollectionBF(log *zap.Logger, db DB, metabaseDB *metabase.DB, rev
 			)
 		}
 
-		provider := rangedloop.NewMetabaseRangeSplitter(log.Named("rangedloop-metabase-range-splitter"), metabaseDB, config.RangedLoop)
-		peer.RangedLoop.Service = rangedloop.NewService(log.Named("rangedloop"), config.RangedLoop, provider, []rangedloop.Observer{
+		observers := []rangedloop.Observer{
 			rangedloop.NewLiveCountObserver(metabaseDB, config.RangedLoop.SuspiciousProcessedRatio, config.RangedLoop.AsOfSystemInterval),
 			observer,
-		})
+		}
+
+		spannerReadTimestamp := time.Time{}
+		// this observer will work correctly only when GC is executed in RunOnce mode.
+		if peer.GarbageCollection.Config.RunOnce && config.RangedLoop.SpannerStaleInterval > 0 {
+			spannerReadTimestamp = time.Now().Add(-config.RangedLoop.SpannerStaleInterval)
+
+			observers = append(observers, rangedloop.NewSegmentsCountValidation(log.Named("rangedloop"), metabaseDB, spannerReadTimestamp))
+		}
+
+		provider := rangedloop.NewMetabaseRangeSplitterWithReadTimestamp(log.Named("rangedloop-metabase-range-splitter"),
+			metabaseDB, config.RangedLoop, spannerReadTimestamp)
+		peer.RangedLoop.Service = rangedloop.NewService(log.Named("rangedloop"), config.RangedLoop, provider, observers)
 
 		if !peer.GarbageCollection.Config.RunOnce {
 			peer.Services.Add(lifecycle.Item{

--- a/satellite/metabase/adapter.go
+++ b/satellite/metabase/adapter.go
@@ -45,6 +45,7 @@ type Adapter interface {
 	SetObjectLastCommittedLegalHold(ctx context.Context, opts SetObjectLastCommittedLegalHold) error
 
 	GetTableStats(ctx context.Context, opts GetTableStats) (result TableStats, err error)
+	CountSegments(ctx context.Context, checkTimestamp time.Time) (result int64, err error)
 	UpdateTableStats(ctx context.Context) error
 	BucketEmpty(ctx context.Context, opts BucketEmpty) (empty bool, err error)
 

--- a/satellite/metabase/stats_test.go
+++ b/satellite/metabase/stats_test.go
@@ -115,3 +115,18 @@ func TestGetTableStats(t *testing.T) {
 		}
 	})
 }
+
+func TestCountSegments(t *testing.T) {
+	metabasetest.Run(t, func(ctx *testcontext.Context, t *testing.T, db *metabase.DB) {
+		if db.Implementation() != dbutil.Spanner {
+			t.Skip("implemented only for spanner")
+		}
+
+		metabasetest.CreateTestObject{}.Run(ctx, t, db, metabasetest.RandObjectStream(), 4)
+
+		result, err := db.CountSegments(ctx, time.Now())
+		require.NoError(t, err)
+		require.EqualValues(t, 4, result.SegmentCount)
+		require.EqualValues(t, []int64{4}, result.PerAdapterSegmentCount)
+	})
+}


### PR DESCRIPTION
The main goal for this change is to compare number of segments processed by loop and number of segments in DB before and after loop. This comparison make sense only if all parts are using the same stale read timestamp. This should give us the answer if the loop is skipping segments or not.

Implementation is similar to `LiveCountObserver` but for now I wanted to keep this only for GC bloom filter generation process.

This change has only basic tests, as it would require more work and I'm not sure if this code will live long.

Change-Id: Ic4d6cfc123adb1dc0141410dd6151ee7690702d8


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
