### PR TITLE
storagenode/storagenodedb: do not register db stat for migration

### DIFF
--- a/storagenode/storagenodedb/database.go
+++ b/storagenode/storagenodedb/database.go
@@ -712,7 +712,7 @@ func (db *DB) Migration(ctx context.Context) *migrate.Migration {
 				Description: "Initial setup",
 				Version:     0,
 				CreateDB: func(ctx context.Context, log *zap.Logger) error {
-					if err := db.openDatabase(ctx, DeprecatedInfoDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, DeprecatedInfoDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
 
@@ -1132,31 +1132,31 @@ func (db *DB) Migration(ctx context.Context) *migrate.Migration {
 				Description: "Split into multiple sqlite databases",
 				Version:     23,
 				CreateDB: func(ctx context.Context, log *zap.Logger) error {
-					if err := db.openDatabase(ctx, BandwidthDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, BandwidthDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
-					if err := db.openDatabase(ctx, OrdersDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, OrdersDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
-					if err := db.openDatabase(ctx, PieceExpirationDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, PieceExpirationDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
-					if err := db.openDatabase(ctx, PieceInfoDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, PieceInfoDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
-					if err := db.openDatabase(ctx, PieceSpaceUsedDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, PieceSpaceUsedDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
-					if err := db.openDatabase(ctx, ReputationDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, ReputationDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
-					if err := db.openDatabase(ctx, StorageUsageDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, StorageUsageDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
-					if err := db.openDatabase(ctx, UsedSerialsDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, UsedSerialsDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
-					if err := db.openDatabase(ctx, SatellitesDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, SatellitesDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
 
@@ -1256,7 +1256,7 @@ func (db *DB) Migration(ctx context.Context) *migrate.Migration {
 				Description: "Create notifications table",
 				Version:     28,
 				CreateDB: func(ctx context.Context, log *zap.Logger) error {
-					if err := db.openDatabase(ctx, NotificationsDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, NotificationsDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
 
@@ -1317,7 +1317,7 @@ func (db *DB) Migration(ctx context.Context) *migrate.Migration {
 				Description: "Create paystubs table and payments table",
 				Version:     32,
 				CreateDB: func(ctx context.Context, log *zap.Logger) error {
-					if err := db.openDatabase(ctx, HeldAmountDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, HeldAmountDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
 
@@ -1416,7 +1416,7 @@ func (db *DB) Migration(ctx context.Context) *migrate.Migration {
 				Description: "Create pricing table",
 				Version:     35,
 				CreateDB: func(ctx context.Context, log *zap.Logger) error {
-					if err := db.openDatabase(ctx, PricingDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, PricingDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
 
@@ -1877,7 +1877,7 @@ func (db *DB) Migration(ctx context.Context) *migrate.Migration {
 				Description: "Create secret table",
 				Version:     46,
 				CreateDB: func(ctx context.Context, log *zap.Logger) error {
-					if err := db.openDatabase(ctx, APIKeysDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, APIKeysDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
 
@@ -2088,7 +2088,7 @@ func (db *DB) Migration(ctx context.Context) *migrate.Migration {
 				Description: "Create gc_filewalker_progress db",
 				Version:     55,
 				CreateDB: func(ctx context.Context, log *zap.Logger) error {
-					if err := db.openDatabase(ctx, GCFilewalkerProgressDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, GCFilewalkerProgressDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
 
@@ -2108,7 +2108,7 @@ func (db *DB) Migration(ctx context.Context) *migrate.Migration {
 				Description: "Create used_space_per_prefix db",
 				Version:     56,
 				CreateDB: func(ctx context.Context, log *zap.Logger) error {
-					if err := db.openDatabase(ctx, UsedSpacePerPrefixDBName); err != nil {
+					if err := db.openDatabaseWithStat(ctx, UsedSpacePerPrefixDBName, false); err != nil {
 						return ErrDatabase.Wrap(err)
 					}
 


### PR DESCRIPTION
What: storagenode/storagenodedb: do not register db stat for migration

Why: They generate duplicated Prometheus entries, which are forbidden.

Please describe the tests:
Tested manually with storj-up.

Fixes #7114

Satellite also has this problem when five disk gauge metrics below are repeated 4 times:

```
# TYPE disk gauge
disk{device="_dev_mapper_vgubuntu_root",scope="github_com_jtolds_monkit_hw_v2",field="Total"} 9.81132795904e+11
disk{device="_dev_mapper_vgubuntu_root",scope="github_com_jtolds_monkit_hw_v2",field="Used"} 4.29911502848e+11
disk{device="_dev_mapper_vgubuntu_root",scope="github_com_jtolds_monkit_hw_v2",field="Free"} 5.51221293056e+11
disk{scope="github_com_jtolds_monkit_hw_v2",device="_dev_mapper_vgubuntu_root",field="Avail"} 5.01306978304e+11
disk{scope="github_com_jtolds_monkit_hw_v2",device="_dev_mapper_vgubuntu_root",field="Files"} 6.0915712e+07
```

This happens because monkit-hw uses [device names](https://github.com/jtolio/monkit-hw/blob/master/disk.go#L30) for labels and they are not unique. Listing mounted fs from inside the container:

```sh
$ docker exec -ti storj-storagenode1-1 /bin/bash
storj@5516bcd0b262:~$ cat /etc/mtab
...
/dev/mapper/vgubuntu-root /etc/resolv.conf ext4 rw,relatime,errors=remount-ro 0 0
/dev/mapper/vgubuntu-root /etc/hostname ext4 rw,relatime,errors=remount-ro 0 0
/dev/mapper/vgubuntu-root /etc/hosts ext4 rw,relatime,errors=remount-ro 0 0
/dev/mapper/vgubuntu-root /var/lib/storj/go/bin/storagenode ext4 rw,relatime,errors=remount-ro 0 0
```

One solution is to update the monkit-hw to use dir name instead, so metric labels are `dir="_etc_resolv.conf" ...` instead. Another is to use storagenode approach and [filter out hw.Disk()](https://github.com/storj/storj/blob/main/storagenode/diskmon.go#L29)

 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
