### PR TITLE
web/satellite: sort applications by category or name

### DIFF
--- a/web/satellite/src/views/Applications.vue
+++ b/web/satellite/src/views/Applications.vue
@@ -164,8 +164,18 @@ const filteredApps = computed<Application[]>(() => {
     }
 
     result.sort((a, b) => {
-        const aValue = (a[sortKey.value] || '').toLowerCase();
-        const bValue = (b[sortKey.value] || '').toLowerCase();
+        let aValue, bValue;
+        
+        if (sortKey.value === 'category') {
+            // Sort by the first category
+            aValue = (a.categories[0] || '').toLowerCase();
+            bValue = (b.categories[0] || '').toLowerCase();
+        } else {
+            // Default to name sorting
+            aValue = (a.name || '').toLowerCase();
+            bValue = (b.name || '').toLowerCase();
+        }
+
         if (aValue < bValue) return sortOrder.value === 'asc' ? -1 : 1;
         if (aValue > bValue) return sortOrder.value === 'asc' ? 1 : -1;
         return 0;


### PR DESCRIPTION
Issue: #7476

Update the sorting logic to sort applications by their first category when the sort key is 'category'; otherwise, sort them by the application name.

Change-Id: I41501d3516614f0e0035ff1351dc0472d470acce

What:
Fix sorting logic to sort applications by their first category when sortKey is 'category'; otherwise, sort by name.

Why:
Fixes broken category sorting on the Applications page (Issue #7476).

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
