### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/shared/mud/component.go
+++ b/shared/mud/component.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -120,10 +121,8 @@ func stageStr(stage *Stage, s string) string {
 
 // AddRequirement marks the argument type as dependency of this component.
 func (c *Component) AddRequirement(in reflect.Type) {
-	for _, req := range c.requirements {
-		if req == in {
-			return
-		}
+	if slices.Contains(c.requirements, in) {
+		return
 	}
 	c.requirements = append(c.requirements, in)
 }

--- a/shared/mud/implementation.go
+++ b/shared/mud/implementation.go
@@ -5,6 +5,7 @@ package mud
 
 import (
 	"context"
+	"slices"
 )
 
 // RegisterImplementation registers the implementation interface, without adding concrete implementation.
@@ -37,11 +38,6 @@ func Implementation[L ~[]T, Instance any, T any](ball *Ball) {
 func ImplementationOf[L ~[]T, T any](ball *Ball) ComponentSelector {
 	component := MustLookupComponent[L](ball)
 	return func(c *Component) bool {
-		for _, dep := range component.requirements {
-			if dep == c.target {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(component.requirements, c.target)
 	}
 }


### PR DESCRIPTION
What: 

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
