### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/cmd/tools/migrate-encryption-master-key/main.go
+++ b/cmd/tools/migrate-encryption-master-key/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	goFlag "flag"
+	"maps"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/spacemonkeygo/monkit/v3"
@@ -74,12 +75,8 @@ func (config *Config) OldKeyID() int {
 // AllKeyInfos returns all key infos.
 func (config *Config) AllKeyInfos() kms.KeyInfos {
 	infos := make(map[int]kms.KeyInfo)
-	for i, info := range config.OldKeyInfo.Values {
-		infos[i] = info
-	}
-	for i, info := range config.NewKeyInfo.Values {
-		infos[i] = info
-	}
+	maps.Copy(infos, config.OldKeyInfo.Values)
+	maps.Copy(infos, config.NewKeyInfo.Values)
 
 	return kms.KeyInfos{Values: infos}
 }

--- a/cmd/uplink/external_access.go
+++ b/cmd/uplink/external_access.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -116,9 +117,7 @@ func (ex *external) GetAccessInfo(required bool) (string, map[string]string, err
 
 	// return a copy to avoid mutations messing things up
 	accesses := make(map[string]string)
-	for name, accessData := range ex.access.accesses {
-		accesses[name] = accessData
-	}
+	maps.Copy(accesses, ex.access.accesses)
 
 	return ex.access.defaultName, accesses, nil
 }

--- a/storagenode/pieces/cache.go
+++ b/storagenode/pieces/cache.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync"
@@ -529,9 +530,7 @@ func (blobs *BlobsUsageCache) copyCacheTotals() BlobsUsageCache {
 	blobs.mu.Lock()
 	defer blobs.mu.Unlock()
 	var copyMap = map[storj.NodeID]SatelliteUsage{}
-	for k, v := range blobs.spaceUsedBySatellite {
-		copyMap[k] = v
-	}
+	maps.Copy(copyMap, blobs.spaceUsedBySatellite)
 	return BlobsUsageCache{
 		piecesTotal:          blobs.piecesTotal,
 		piecesContentSize:    blobs.piecesContentSize,

--- a/storagenode/piecestore/migrate_backend.go
+++ b/storagenode/piecestore/migrate_backend.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"io/fs"
+	"maps"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -137,9 +138,7 @@ func (m *MigratingBackend) UpdateState(ctx context.Context, satellite storj.Node
 
 	// make a copy of the current state map into a new one and update the value for the satellite.
 	next := make(map[storj.NodeID]MigrationState, len(states))
-	for k, v := range states {
-		next[k] = v
-	}
+	maps.Copy(next, states)
 	next[satellite] = state
 
 	// publish the new immutable state map.

--- a/storagenode/storagenodedb/storagenodedbtest/snapshot_test.go
+++ b/storagenode/storagenodedb/storagenodedbtest/snapshot_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"testing"
 
@@ -77,9 +78,7 @@ func getSerializedScheme(t *testing.T, ctx *testcontext.Context, db *storagenode
 		s := dbScheme{}
 		sqliteScheme, err := readSqliteScheme(ctx, db.GetDB())
 		require.Nil(t, err)
-		for k, v := range sqliteScheme {
-			s[k] = v
-		}
+		maps.Copy(s, sqliteScheme)
 
 		dbs[dbName] = s
 	}


### PR DESCRIPTION
What: 

There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.


Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
