### PR TITLE
satellite/console: reduce activation token timeout from 30 to 10 minutes

### DIFF
--- a/satellite/console/consoleauth/service.go
+++ b/satellite/console/consoleauth/service.go
@@ -18,7 +18,7 @@ var mon = monkit.Package()
 
 // Config contains configuration parameters for console auth.
 type Config struct {
-	TokenExpirationTime time.Duration `help:"expiration time for account recovery and activation tokens" default:"30m"`
+	TokenExpirationTime time.Duration `help:"expiration time for account recovery and activation tokens" default:"10m"`
 }
 
 // Service handles creating, signing, and checking the expiration of auth tokens.

--- a/satellite/satellite-config.yaml.lock
+++ b/satellite/satellite-config.yaml.lock
@@ -200,7 +200,7 @@ compensation.rates.put-tb: "0"
 compensation.withheld-percents: 75,75,75,50,50,50,25,25,25,0,0,0,0,0,0
 
 # expiration time for account recovery and activation tokens
-# console-auth.token-expiration-time: 30m0s
+# console-auth.token-expiration-time: 10m0s
 
 # interval for 'AS OF SYSTEM TIME' clause (CockroachDB specific) to read from the DB at a specific time in the past
 # console-db-cleanup.as-of-system-time-interval: -5m0s


### PR DESCRIPTION
What: Reduce the activation token timeout from 30 minutes down to 10 minutes.

Why: 30 minutes is on the upper end of the timewindow. 10 minutes sounds more secure while still given the customer enough time to enter it. Closes https://github.com/storj/storj-private/issues/1455

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
