### PR TITLE
chore: remove unused min/max func

### DIFF
--- a/cmd/storj-sim/prefix.go
+++ b/cmd/storj-sim/prefix.go
@@ -28,13 +28,6 @@ const (
 	emptyTimeField = "            "
 )
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // NewPrefixWriter creates a writer than can prefix all lines written to it.
 func NewPrefixWriter(defaultPrefix string, maxLineLen int, dst io.Writer) *PrefixWriter {
 	writer := &PrefixWriter{

--- a/satellite/metabase/rangedloop/rangedlooptest/provider.go
+++ b/satellite/metabase/rangedloop/rangedlooptest/provider.go
@@ -67,13 +67,6 @@ func (m *SegmentProvider) Iterate(ctx context.Context, fn func([]rangedloop.Segm
 	return nil
 }
 
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 func streamsFromSegments(segments []rangedloop.Segment) [][]rangedloop.Segment {
 	// Duplicate and sort the segments by stream ID
 	segments = append([]rangedloop.Segment(nil), segments...)

--- a/satellite/metainfo/bloomrate/rate.go
+++ b/satellite/metainfo/bloomrate/rate.go
@@ -75,10 +75,3 @@ func (r *Rate) Allow(now time.Time, limit rate.Limit, burst int) bool {
 	(*atomic.Uint64)(r).Store(uint64(tokens-2) | ((uint64(expiry.UnixNano()) << 1) & timeMask))
 	return true
 }
-
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}

--- a/storagenode/piecestore/endpoint.go
+++ b/storagenode/piecestore/endpoint.go
@@ -1045,13 +1045,6 @@ func (endpoint *Endpoint) TestLiveRequestCount() int32 {
 	return atomic.LoadInt32(&endpoint.liveRequests)
 }
 
-// min finds the min of two values.
-func min(a, b int64) int64 {
-	if a < b {
-		return a
-	}
-	return b
-}
 
 // speedEstimation monitors state of incoming traffic. It would signal slow-speed
 // client in non-congested traffic condition.


### PR DESCRIPTION
What: 

Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
