### PR TITLE
Point release v1.138.4

### DIFF
--- a/cmd/satellite/repair_segment.go
+++ b/cmd/satellite/repair_segment.go
@@ -97,7 +97,8 @@ func cmdRepairSegment(cmd *cobra.Command, args []string) (err error) {
 		signing.SigneeFromPeerIdentity(identity.PeerIdentity()),
 		config.Repairer.DialTimeout,
 		config.Repairer.DownloadTimeout,
-		true, true) // force inmemory download and upload of pieces
+		true, true, // force inmemory download and upload of pieces
+		config.Repairer.DownloadLongTail)
 
 	segmentRepairer, err := repairer.NewSegmentRepairer(
 		log.Named("segment-repair"),

--- a/satellite/repair/repair_test.go
+++ b/satellite/repair/repair_test.go
@@ -2500,6 +2500,7 @@ func ecRepairerWithMockConnector(t testing.TB, sat *testplanet.Satellite, mock *
 		sat.Config.Repairer.DownloadTimeout,
 		sat.Config.Repairer.InMemoryRepair,
 		sat.Config.Repairer.InMemoryUpload,
+		sat.Config.Repairer.DownloadLongTail,
 	)
 	return ec
 }

--- a/satellite/repair/repairer/mud.go
+++ b/satellite/repair/repairer/mud.go
@@ -21,8 +21,7 @@ import (
 // Module is a mud module definition.
 func Module(ball *mud.Ball) {
 	mud.Provide[*ECRepairer](ball, func(dialer rpc.Dialer, satelliteSignee signing.Signee, cfg Config) *ECRepairer {
-		return NewECRepairer(dialer, satelliteSignee, cfg.DialTimeout, cfg.DownloadTimeout, cfg.InMemoryRepair, cfg.InMemoryUpload)
-
+		return NewECRepairer(dialer, satelliteSignee, cfg.DialTimeout, cfg.DownloadTimeout, cfg.InMemoryRepair, cfg.InMemoryUpload, cfg.DownloadLongTail)
 	})
 	mud.Provide[*SegmentRepairer](ball, func(log *zap.Logger, metabase *metabase.DB, orders *orders.Service, overlay *overlay.Service, reporter audit.Reporter, ecRepairer *ECRepairer, placements nodeselection.PlacementDefinitions, config Config, checkerConfig checker.Config) (*SegmentRepairer, error) {
 		return NewSegmentRepairer(log, metabase, orders, overlay, reporter, ecRepairer, placements, checkerConfig.RepairThresholdOverrides, checkerConfig.RepairTargetOverrides, config)

--- a/satellite/repair/repairer/repairer.go
+++ b/satellite/repair/repairer/repairer.go
@@ -36,6 +36,7 @@ type Config struct {
 	DialTimeout                   time.Duration `help:"time limit for dialing storage node" default:"5s"`
 	Timeout                       time.Duration `help:"time limit for uploading repaired pieces to new storage nodes" default:"5m0s" testDefault:"1m"`
 	DownloadTimeout               time.Duration `help:"time limit for downloading pieces from a node for repair" default:"5m0s" testDefault:"1m"`
+	DownloadLongTail              int           `help:"number of extra concurrent downloads beyond required count for faster repairs" default:"0" testDefault:"3"`
 	TotalTimeout                  time.Duration `help:"time limit for an entire repair job, from queue pop to upload completion" default:"45m" testDefault:"10m"`
 	MaxExcessRateOptimalThreshold float64       `help:"ratio applied to the optimal threshold to calculate the excess of the maximum number of repaired pieces to upload" default:"0.05"`
 	InMemoryRepair                bool          `help:"whether to download pieces for repair in memory (true) or download to disk (false)" default:"false"`

--- a/satellite/repairer.go
+++ b/satellite/repairer.go
@@ -223,6 +223,7 @@ func NewRepairer(log *zap.Logger, full *identity.FullIdentity,
 			config.Repairer.DownloadTimeout,
 			config.Repairer.InMemoryRepair,
 			config.Repairer.InMemoryUpload,
+			config.Repairer.DownloadLongTail,
 		)
 
 		if len(config.Repairer.RepairExcludedCountryCodes) == 0 {

--- a/satellite/satellite-config.yaml.lock
+++ b/satellite/satellite-config.yaml.lock
@@ -1649,6 +1649,9 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # repair pieces out of segment placement
 # repairer.do-placement-check: true
 
+# number of extra concurrent downloads beyond required count for faster repairs
+# repairer.download-long-tail: 0
+
 # time limit for downloading pieces from a node for repair
 # repairer.download-timeout: 5m0s
 


### PR DESCRIPTION
This change is adding simple long tail cancellation to repair download process. Additional number of pieces above minimum can be specified by new flag.

When number of successful pieces will reach minimum required then all download contexts are cancelled. Method downloadAndVerifyPiece might require more adjustments to support context cancellation better but for now only data copy was changed to use sync2.Copy.

Change-Id: Ice0351d4651db675a4ebff60c1ba67de22e84482


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
