### PR TITLE
Point release v1.139.7

### DIFF
--- a/satellite/metabase/commit.go
+++ b/satellite/metabase/commit.go
@@ -1164,23 +1164,11 @@ func (db *DB) CommitObject(ctx context.Context, opts CommitObject) (object Objec
 		}
 
 		nextVersion := opts.Version
-
-		// precommit.HighestVersion == 0 means there are no previous object versions (pending and committed)
-		switch {
-		case precommit.HighestVersion < 0:
-			// pending object created with BeginObjectExactVersion and negative version.
-			// There are no other committed objects.
-			nextVersion = 1
-		case precommit.HighestVersion > 0:
-			// pending object created with BeginObjectNextVersion or
-			// there are other committed objects.
-			if nextVersion < precommit.HighestVersion {
-				nextVersion = precommit.HighestVersion + 1
-			}
+		if nextVersion < precommit.HighestVersion {
+			nextVersion = precommit.HighestVersion + 1
 		}
 
-		err = adapter.finalizeObjectCommit(ctx, opts, nextStatus, nextVersion, segments, totalPlainSize, totalEncryptedSize, fixedSegmentSize, &object)
-		if err != nil {
+		if err := adapter.finalizeObjectCommit(ctx, opts, nextStatus, nextVersion, segments, totalPlainSize, totalEncryptedSize, fixedSegmentSize, &object); err != nil {
 			return err
 		}
 

--- a/satellite/metainfo/config.go
+++ b/satellite/metainfo/config.go
@@ -261,7 +261,7 @@ type Config struct {
 	TestingCommitSegmentUseMutations bool          `default:"false"  help:"enable using Spanner mutations while committing segment" hidden:"true"`
 	TestingDeleteBucketBatchSize     int           `default:"15" help:"how many objects to delete in a single batch during a bucket deletion"`
 
-	TestingAlternativeBeginObject         bool      `default:"false" help:"enable alternative (negative version) begin object implementation globally" hidden:"true"`
+	TestingAlternativeBeginObject         bool      `default:"true" help:"enable alternative (negative version) begin object implementation globally" hidden:"true"`
 	TestingAlternativeBeginObjectProjects UUIDsFlag `default:""  help:"list of project IDs for which will use alternative (negative version) begin object implementation" hidden:"true"`
 
 	// TODO we need to split this into separate config with other metabase related flags


### PR DESCRIPTION
With negative version for pending objects it was possible to get HighestVersion from PrecommitConstraint. Not all cases were adjusted to new logic and it was possible to have committed object with negative version.

This change makes sure that PrecommitConstraint never returns negative HighestVersion which makes later easier to determine final version for committed object.

Change also enabled TestingAlternativeBeginObject as it's configuration that is used in production right now.

Change-Id: I195f0229adf9d609a87d286b34e1366efc6cde43


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
