### PR TITLE
satellite/metabase: set ExcludeTxnFromChangeStreams to more places

### DIFF
--- a/satellite/metabase/adapter_spanner.go
+++ b/satellite/metabase/adapter_spanner.go
@@ -73,15 +73,6 @@ func NewSpannerAdapter(ctx context.Context, cfg SpannerConfig, log *zap.Logger, 
 			Compression:          cfg.Compression,
 			DisableRouteToLeader: false,
 			UserAgent:            cfg.ApplicationName,
-
-			// disable everything except transactions
-			QueryOptions: spanner.QueryOptions{
-				ExcludeTxnFromChangeStreams: true,
-			},
-			BatchWriteOptions: spanner.BatchWriteOptions{
-				ExcludeTxnFromChangeStreams: true,
-			},
-			ApplyOptions: []spanner.ApplyOption{spanner.ExcludeTxnFromChangeStreams()},
 		}, opts...)
 	if err != nil {
 		return nil, errs.Wrap(err)

--- a/satellite/metabase/commit.go
+++ b/satellite/metabase/commit.go
@@ -1093,7 +1093,8 @@ func (s *SpannerAdapter) WithTx(ctx context.Context, opts TransactionOptions, f 
 		CommitOptions: spanner.CommitOptions{
 			MaxCommitDelay: opts.MaxCommitDelay,
 		},
-		TransactionTag: transactionTag,
+		TransactionTag:              transactionTag,
+		ExcludeTxnFromChangeStreams: !opts.TransmitEvent,
 	})
 	return err
 }

--- a/satellite/metabase/commit_object.go
+++ b/satellite/metabase/commit_object.go
@@ -44,6 +44,9 @@ type CommitObjectWithSegments struct {
 
 	// Versioned indicates whether an object is allowed to have multiple versions.
 	Versioned bool
+
+	// supported only by Spanner.
+	TransmitEvent bool
 }
 
 // CommitObjectWithSegments commits pending object to the database.
@@ -69,6 +72,7 @@ func (db *DB) CommitObjectWithSegments(ctx context.Context, opts CommitObjectWit
 	var precommit PrecommitConstraintResult
 	err = db.ChooseAdapter(opts.ProjectID).WithTx(ctx, TransactionOptions{
 		TransactionTag: "commit-object-with-segments",
+		TransmitEvent:  opts.TransmitEvent,
 	}, func(ctx context.Context, adapter TransactionAdapter) error {
 		// TODO: should we prevent this from executing when the object has been committed
 		// currently this requires quite a lot of database communication, so invalid handling can be expensive.

--- a/satellite/metabase/copy_object.go
+++ b/satellite/metabase/copy_object.go
@@ -87,6 +87,9 @@ type FinishCopyObject struct {
 
 	// IfNoneMatch is an optional field for conditional writes.
 	IfNoneMatch IfNoneMatch
+
+	// supported only by Spanner.
+	TransmitEvent bool
 }
 
 // NewLocation returns the new object location.
@@ -256,6 +259,7 @@ func (db *DB) FinishCopyObject(ctx context.Context, opts FinishCopyObject) (obje
 	var precommit PrecommitConstraintResult
 	err = db.ChooseAdapter(opts.ProjectID).WithTx(ctx, TransactionOptions{
 		TransactionTag: "finish-copy-object",
+		TransmitEvent:  opts.TransmitEvent,
 	}, func(ctx context.Context, txadapter TransactionAdapter) error {
 		precommit, err = db.PrecommitConstraint(ctx, PrecommitConstraint{
 			Location:       opts.NewLocation(),

--- a/satellite/metabase/delete.go
+++ b/satellite/metabase/delete.go
@@ -900,8 +900,9 @@ func (s *SpannerAdapter) deleteObjectLastCommittedPlain(ctx context.Context, opt
 			},
 		},
 	}, spanner.BatchWriteOptions{
-		Priority:       spannerpb.RequestOptions_PRIORITY_MEDIUM,
-		TransactionTag: "delete-object-last-committed-plain",
+		Priority:                    spannerpb.RequestOptions_PRIORITY_MEDIUM,
+		TransactionTag:              "delete-object-last-committed-plain",
+		ExcludeTxnFromChangeStreams: !opts.TransmitEvent,
 	})
 	err = iterator.Do(func(r *spannerpb.BatchWriteResponse) error {
 		if err = status.ErrorProto(r.GetStatus()); err != nil {
@@ -1101,6 +1102,7 @@ func (s *SpannerAdapter) DeleteObjectLastCommittedSuspended(ctx context.Context,
 
 	err = s.WithTx(ctx, TransactionOptions{
 		TransactionTag: "delete-object-last-committed-suspended",
+		TransmitEvent:  opts.TransmitEvent,
 	}, func(ctx context.Context, atx TransactionAdapter) error {
 		result = DeleteObjectResult{}
 		stx := atx.(*spannerTransactionAdapter)

--- a/satellite/metabase/delete_objects.go
+++ b/satellite/metabase/delete_objects.go
@@ -26,6 +26,9 @@ type DeleteObjects struct {
 	Suspended bool
 
 	ObjectLock ObjectLockDeleteOptions
+
+	// supported only by Spanner.
+	TransmitEvent bool
 }
 
 // DeleteObjectsItem describes the location of an object in a bucket to be deleted.
@@ -117,7 +120,8 @@ func (db *DB) DeleteObjects(ctx context.Context, opts DeleteObjects) (result Del
 				BucketName: opts.BucketName,
 				ObjectKey:  resultItem.ObjectKey,
 			},
-			ObjectLock: opts.ObjectLock,
+			ObjectLock:    opts.ObjectLock,
+			TransmitEvent: opts.TransmitEvent,
 		}
 
 		var deleteObjectResult DeleteObjectResult
@@ -220,6 +224,7 @@ func (db *DB) DeleteObjects(ctx context.Context, opts DeleteObjects) (result Del
 			Version:        resultItem.RequestedStreamVersionID.Version(),
 			StreamIDSuffix: resultItem.RequestedStreamVersionID.StreamIDSuffix(),
 			ObjectLock:     opts.ObjectLock,
+			TransmitEvent:  opts.TransmitEvent,
 		})
 
 		result.DeletedSegmentCount += int64(deleteObjectResult.DeletedSegmentCount)

--- a/satellite/metabase/move_object.go
+++ b/satellite/metabase/move_object.go
@@ -202,6 +202,9 @@ type FinishMoveObject struct {
 	// LegalHold indicates legal hold settings of the moved object
 	// version.
 	LegalHold bool
+
+	// supported only by Spanner.
+	TransmitEvent bool
 }
 
 // NewLocation returns the new object location.
@@ -244,6 +247,7 @@ func (db *DB) FinishMoveObject(ctx context.Context, opts FinishMoveObject) (err 
 	var precommit PrecommitConstraintResult
 	err = db.ChooseAdapter(opts.ProjectID).WithTx(ctx, TransactionOptions{
 		TransactionTag: "finish-move-object",
+		TransmitEvent:  opts.TransmitEvent,
 	}, func(ctx context.Context, adapter TransactionAdapter) error {
 		precommit, err = db.PrecommitConstraint(ctx, PrecommitConstraint{
 			Location:       opts.NewLocation(),

--- a/satellite/metabase/raw.go
+++ b/satellite/metabase/raw.go
@@ -816,7 +816,8 @@ func (s *SpannerAdapter) TestingSetObjectVersion(ctx context.Context, object Obj
 
 		return nil
 	}, spanner.TransactionOptions{
-		TransactionTag: "testing-set-object-version",
+		TransactionTag:              "testing-set-object-version",
+		ExcludeTxnFromChangeStreams: true,
 	})
 	return rowsAffected, Error.Wrap(err)
 }
@@ -847,7 +848,8 @@ func (s *SpannerAdapter) TestingSetPlacementAllSegments(ctx context.Context, pla
 		}, spanner.QueryOptions{RequestTag: "testing-set-placement-all-segments"})
 		return err
 	}, spanner.TransactionOptions{
-		TransactionTag: "testing-set-placement-all-segments",
+		TransactionTag:              "testing-set-placement-all-segments",
+		ExcludeTxnFromChangeStreams: true,
 	})
 	return Error.Wrap(err)
 }

--- a/satellite/metainfo/endpoint_object.go
+++ b/satellite/metainfo/endpoint_object.go
@@ -2808,6 +2808,9 @@ func (endpoint *Endpoint) FinishMoveObject(ctx context.Context, req *pb.ObjectFi
 
 		Retention: retention,
 		LegalHold: req.LegalHold,
+
+		TransmitEvent: endpoint.bucketEventing.Enabled(keyInfo.ProjectID, string(streamID.Bucket)) ||
+			endpoint.bucketEventing.Enabled(keyInfo.ProjectID, string(req.NewBucket)),
 	})
 	if err != nil {
 		return nil, endpoint.ConvertMetabaseErr(err)
@@ -3103,6 +3106,8 @@ func (endpoint *Endpoint) FinishCopyObject(ctx context.Context, req *pb.ObjectFi
 		},
 
 		IfNoneMatch: req.IfNoneMatch,
+
+		TransmitEvent: endpoint.bucketEventing.Enabled(keyInfo.ProjectID, string(req.NewBucket)),
 	})
 	if err != nil {
 		return nil, endpoint.ConvertMetabaseErr(err)

--- a/satellite/metainfo/endpoint_object_delete.go
+++ b/satellite/metainfo/endpoint_object_delete.go
@@ -398,6 +398,8 @@ func (endpoint *Endpoint) DeleteObjects(ctx context.Context, req *pb.DeleteObjec
 			},
 
 			Items: make([]metabase.DeleteObjectsItem, 0, numAllowedObjectKeys),
+
+			TransmitEvent: endpoint.bucketEventing.Enabled(keyInfo.ProjectID, string(req.Bucket)),
 		}
 
 		for _, item := range req.Items {


### PR DESCRIPTION
What: set ExcludeTxnFromChangeStreams to more places

https://review.dev.storj.tools/c/storj/storj/+/19001

Why: This addresses leaking or missing records in the change stream.

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
