### PR TITLE
cherry-pick v1.140.7

### DIFF
--- a/satellite/console/service.go
+++ b/satellite/console/service.go
@@ -5361,17 +5361,16 @@ func (s *Service) getPlacementDetails(ctx context.Context, project *Project) ([]
 		}
 	}
 
-	if len(placements) == 1 && placements[0] == project.DefaultPlacement {
-		// if the only placement available is the default placement,
-		// don't return any placement details.
-		return []PlacementDetail{}, nil
-	}
-
 	details := make([]PlacementDetail, 0)
 	for _, placement := range placements {
 		if detail, ok := s.config.Placement.SelfServeDetails.Get(placement); ok {
 			details = append(details, detail)
 		}
+	}
+	if len(details) == 1 && details[0].ID == int(project.DefaultPlacement) {
+		// if the only placement available is the default placement,
+		// don't return any placement details.
+		return []PlacementDetail{}, nil
 	}
 	return details, nil
 }

--- a/web/satellite/src/components/dialogs/CreateBucketDialog.vue
+++ b/web/satellite/src/components/dialogs/CreateBucketDialog.vue
@@ -623,8 +623,8 @@ const showNewPricingTiers = computed<boolean>(() => configStore.state.config.sho
 const selfPlacementEnabled = computed<boolean>(() => {
     if (!configStore.state.config.selfServePlacementSelectEnabled) return false;
 
-    return (configStore.state.config.entitlementsEnabled && !!projectConfig.value.availablePlacements.length) ||
-        !project.value.placement;
+    return (configStore.state.config.entitlementsEnabled || !project.value.placement) &&
+        !!projectConfig.value.availablePlacements.length;
 });
 
 const selectedPlacement = computed<PlacementDetails | null>(() => {


### PR DESCRIPTION
This change makes it so that if a project can only access a placement detail that is the same as it's default placement, no available placement details will be returned to the UI.
Also, the placement selection step will be skipped in the bucket creation dialog if there are no available placement details to choose from.

Change-Id: Ie895575ce9a92ed94010f864a1da3413d3dbf689


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
