### PR TITLE
cherry pick v1.141.2

### DIFF
--- a/satellite/api.go
+++ b/satellite/api.go
@@ -866,7 +866,12 @@ func NewAPI(log *zap.Logger, full *identity.FullIdentity, db DB,
 
 			consoleConfig.SkuEnabled = config.Payments.StripeCoinPayments.SkuEnabled
 
-			for _, model := range config.Payments.Products {
+			productModels, err := config.Payments.Products.ToModels()
+			if err != nil {
+				return nil, errs.Combine(err, peer.Close())
+			}
+
+			for _, model := range productModels {
 				if model.PriceSummary != "" {
 					consoleConfig.ProductPriceSummaries = append(consoleConfig.ProductPriceSummaries, model.PriceSummary)
 				}
@@ -907,6 +912,8 @@ func NewAPI(log *zap.Logger, full *identity.FullIdentity, db DB,
 				config.Payments.PackagePlans.Packages,
 				config.Entitlements,
 				peer.Entitlements.Service,
+				config.Payments.PlacementPriceOverrides.ToMap(),
+				productModels,
 				consoleConfig.Config,
 			)
 			if err != nil {

--- a/satellite/console-api.go
+++ b/satellite/console-api.go
@@ -580,7 +580,12 @@ func NewConsoleAPI(log *zap.Logger, full *identity.FullIdentity, db DB,
 
 		consoleConfig.SkuEnabled = config.Payments.StripeCoinPayments.SkuEnabled
 
-		for _, model := range config.Payments.Products {
+		productModels, err := config.Payments.Products.ToModels()
+		if err != nil {
+			return nil, errs.Combine(err, peer.Close())
+		}
+
+		for _, model := range productModels {
 			if model.PriceSummary != "" {
 				consoleConfig.ProductPriceSummaries = append(consoleConfig.ProductPriceSummaries, model.PriceSummary)
 			}
@@ -621,6 +626,8 @@ func NewConsoleAPI(log *zap.Logger, full *identity.FullIdentity, db DB,
 			config.Payments.PackagePlans.Packages,
 			config.Entitlements,
 			peer.Entitlements.Service,
+			config.Payments.PlacementPriceOverrides.ToMap(),
+			productModels,
 			consoleConfig.Config,
 		)
 		if err != nil {

--- a/satellite/payments/paymentsconfig/config.go
+++ b/satellite/payments/paymentsconfig/config.go
@@ -214,6 +214,7 @@ func (p *PriceOverrides) ToModels() (map[string]payments.ProjectUsagePriceModel,
 type ProductUsagePrice struct {
 	ID                     int32
 	Name                   string
+	ShortName              string
 	SmallObjectFee         string
 	MinimumRetentionFee    string
 	SmallObjectFeeSKU      string
@@ -246,6 +247,7 @@ func (*ProductPriceOverrides) Type() string { return "paymentsconfig.ProductPric
 type ProductUsagePriceYaml struct {
 	ID                     int32  `yaml:"id" json:"id"`
 	Name                   string `yaml:"name" json:"name"`
+	ShortName              string `yaml:"short-name" json:"short_name"`
 	Storage                string `yaml:"storage" json:"storage"`
 	StorageSKU             string `yaml:"storage-sku" json:"storage_sku"`
 	Egress                 string `yaml:"egress" json:"egress"`
@@ -276,6 +278,7 @@ func (p *ProductPriceOverrides) String() string {
 		pricesConv[i] = ProductUsagePriceYaml{
 			ID:                     price.ID,
 			Name:                   price.Name,
+			ShortName:              price.ShortName,
 			Storage:                price.StorageTB,
 			StorageSKU:             price.StorageSKU,
 			Egress:                 price.EgressTB,
@@ -347,8 +350,9 @@ func (p *ProductPriceOverrides) Set(s string) error {
 			}
 		}
 		prices[i] = ProductUsagePrice{
-			ID:   price.ID,
-			Name: price.Name,
+			ID:        price.ID,
+			Name:      price.Name,
+			ShortName: price.ShortName,
 			ProductSKUs: ProductSKUs{
 				StorageSKU: price.StorageSKU,
 				EgressSKU:  price.EgressSKU,
@@ -426,6 +430,7 @@ func (p *ProductPriceOverrides) ToModels() (map[int32]payments.ProductUsagePrice
 		models[prices.ID] = payments.ProductUsagePriceModel{
 			ProductID:                prices.ID,
 			ProductName:              prices.Name,
+			ProductShortName:         prices.ShortName,
 			StorageSKU:               prices.StorageSKU,
 			EgressSKU:                prices.EgressSKU,
 			SegmentSKU:               prices.SegmentSKU,
@@ -438,6 +443,7 @@ func (p *ProductPriceOverrides) ToModels() (map[int32]payments.ProductUsagePrice
 			IncludedEgressSKU:        prices.IncludedEgressSKU,
 			StorageRemainderBytes:    storageRemainderBytes,
 			UseGBUnits:               prices.UseGBUnits,
+			PriceSummary:             prices.PriceSummary,
 		}
 	}
 	return models, nil

--- a/satellite/payments/projectcharges.go
+++ b/satellite/payments/projectcharges.go
@@ -71,6 +71,7 @@ type ProjectUsage = accounting.ProjectUsage
 type ProductUsagePriceModel struct {
 	ProductID                int32           `json:"productID"`
 	ProductName              string          `json:"productName"`
+	ProductShortName         string          `json:"productShortName"`
 	StorageSKU               string          `json:"storageSKU"`
 	EgressSKU                string          `json:"egressSKU"`
 	SegmentSKU               string          `json:"segmentSKU"`
@@ -86,5 +87,7 @@ type ProductUsagePriceModel struct {
 	StorageRemainderBytes int64 `json:"-"`
 	// UseGBUnits when true, invoice line items will use GB units instead of MB units.
 	UseGBUnits bool `json:"useGBUnits"`
+	// PriceSummary will be displayed on the Pro Account info card in the UI.
+	PriceSummary string `json:"-"`
 	ProjectUsagePriceModel
 }

--- a/satellite/payments/stripe/accounts_test.go
+++ b/satellite/payments/stripe/accounts_test.go
@@ -142,6 +142,8 @@ func TestSignupCouponCodes(t *testing.T) {
 			pc.PackagePlans.Packages,
 			sat.Config.Entitlements,
 			nil,
+			pc.PlacementPriceOverrides.ToMap(),
+			productPrices,
 			console.Config{PasswordCost: console.TestPasswordCost, DefaultProjectLimit: 5},
 		)
 


### PR DESCRIPTION
This change updates the buckets table "storage tier" column to display product tier names (e.g., "Global Collab", "Regional - US") instead of placement names (e.g., "global-1", "regional-1") when the showNewPricingTiers config is enabled and a product mapping exists for the bucket's placement.

Change-Id: I3181057168a67e4d5688dad4eec6a3f1152c1541


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
