### PR TITLE
Cherry pick v1.146.7

### DIFF
--- a/satellite/eventing/mud.go
+++ b/satellite/eventing/mud.go
@@ -18,12 +18,4 @@ func Module(ball *mud.Ball) {
 
 	mud.Provide[*ConfigCache](ball, NewConfigCache)
 	mud.RegisterInterfaceImplementation[BucketNotificationConfigGetter, *ConfigCache](ball)
-
-	config.RegisterConfig[PubSubConfig](ball, "change-stream.pubsub")
-	mud.Provide[*PubSubPublisher](ball, NewPubSubPublisher)
-	mud.Provide[*LogPublisher](ball, NewLogPublisher)
-	mud.RegisterInterfaceImplementation[Publisher, *PubSubPublisher](ball)
-
-	config.RegisterConfig[PubSubClientConfig](ball, "")
-	mud.Provide[*PubSubClient](ball, NewPubSubClient)
 }

--- a/satellite/eventing/pubsub.go
+++ b/satellite/eventing/pubsub.go
@@ -12,6 +12,7 @@ import (
 	"cloud.google.com/go/pubsub/v2"
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"
+	"google.golang.org/api/option"
 )
 
 // Publisher defines an interface for publishing events.
@@ -22,7 +23,7 @@ type Publisher interface {
 }
 
 // NewPublisher creates a new EventPublisher based on the provided topic name.
-func NewPublisher(ctx context.Context, topicName string) (Publisher, error) {
+func NewPublisher(ctx context.Context, topicName string, opts ...option.ClientOption) (Publisher, error) {
 	if topicName == "@log" {
 		return NewLogPublisher(zap.L()), nil
 	}
@@ -35,7 +36,7 @@ func NewPublisher(ctx context.Context, topicName string) (Publisher, error) {
 	return NewPubSubPublisher(ctx, PubSubConfig{
 		ProjectID: projectID,
 		TopicID:   topicID,
-	})
+	}, opts...)
 }
 
 // PubSubConfig holds configuration for Pub/Sub publisher.
@@ -51,8 +52,8 @@ type PubSubPublisher struct {
 }
 
 // NewPubSubPublisher initializes a Pub/Sub client and publisher.
-func NewPubSubPublisher(ctx context.Context, cfg PubSubConfig) (*PubSubPublisher, error) {
-	client, err := pubsub.NewClient(ctx, cfg.ProjectID)
+func NewPubSubPublisher(ctx context.Context, cfg PubSubConfig, opts ...option.ClientOption) (*PubSubPublisher, error) {
+	client, err := pubsub.NewClient(ctx, cfg.ProjectID, opts...)
 	if err != nil {
 		return nil, errs.Wrap(err)
 	}

--- a/satellite/metainfo/config.go
+++ b/satellite/metainfo/config.go
@@ -245,6 +245,8 @@ type Config struct {
 
 	BucketTaggingEnabled bool `help:"enable the use of the bucket tagging endpoints" default:"false"`
 
+	BucketEventingServiceAccount string `help:"service account email to impersonate for sending bucket eventing test event" default:""`
+
 	APIKeyTailsConfig APIKeyTailsConfig `help:"Config for API key tails processing"`
 
 	CopyMoveSegmentLimit int64 `help:"the maximum number of segments that can be copied or moved in a single operation" default:"10000"`

--- a/satellite/satellite-config.yaml.lock
+++ b/satellite/satellite-config.yaml.lock
@@ -1199,6 +1199,9 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # size of API key tails combiner queue
 # metainfo.api-key-tails-config.queue-size: 100
 
+# service account email to impersonate for sending bucket eventing test event
+# metainfo.bucket-eventing-service-account: ""
+
 # enable the use of the bucket tagging endpoints
 # metainfo.bucket-tagging-enabled: false
 


### PR DESCRIPTION
The API pod must impersonate the bucket eventing service account for the successful delivery of the S3 Test Event message to the user's Pub/Sub topic.

The impersonation is done only if the
metainfo.bucket-eventing-service-account is set.

Change-Id: Ibc66a8725c14ece9025f4f8c1ce42a58aaf37779


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
