### PR TITLE
satellite/metainfo: add ProjectToAdapter config

### DIFF
--- a/satellite/metabase/db.go
+++ b/satellite/metabase/db.go
@@ -57,6 +57,8 @@ type Config struct {
 
 	Compression string
 
+	ProjectToAdapter map[uuid.UUID]int
+
 	FlightRecorder *flightrecorder.Box
 	*dbutil.ConnParams
 }
@@ -196,6 +198,9 @@ func (db *DB) Implementation() dbutil.Implementation {
 func (db *DB) ChooseAdapter(projectID uuid.UUID) Adapter {
 	if adapter, ok := db.projectsAdapters[projectID]; ok {
 		return adapter
+	}
+	if adapterIndex, ok := db.config.ProjectToAdapter[projectID]; ok {
+		return db.adapters[adapterIndex]
 	}
 	return db.adapters[0]
 }

--- a/satellite/metabase/db.go
+++ b/satellite/metabase/db.go
@@ -199,7 +199,7 @@ func (db *DB) ChooseAdapter(projectID uuid.UUID) Adapter {
 	if adapter, ok := db.projectsAdapters[projectID]; ok {
 		return adapter
 	}
-	if adapterIndex, ok := db.config.ProjectToAdapter[projectID]; ok {
+	if adapterIndex, ok := db.config.ProjectToAdapter[projectID]; ok && adapterIndex >= 0 && adapterIndex < len(db.adapters) {
 		return db.adapters[adapterIndex]
 	}
 	return db.adapters[0]

--- a/satellite/metainfo/config.go
+++ b/satellite/metainfo/config.go
@@ -324,6 +324,8 @@ type Config struct {
 	TestingAlternativeBeginObject         bool      `default:"true" help:"enable alternative (negative version) begin object implementation globally" hidden:"true"`
 	TestingAlternativeBeginObjectProjects UUIDsFlag `default:"" help:"list of project IDs for which will use alternative (negative version) begin object implementation" hidden:"true"`
 
+	ProjectToAdapter string `default:"" help:"comma separated list of project IDs and their corresponding adapter indexes in format 'project_id:adapter_index'" hidden:"true"`
+
 	// TODO we need to split this into separate config with other metabase related flags
 	MetabaseCompression       string `help:"Compression type to be used in spanner client for gRPC calls, disabled by default (gzip)" default:"" devDefault:"gzip"`
 	SpannerGRPCConnectionPool int    `help:"Number of gRPC connections to Spanner. Each connection supports ~100 concurrent streams. 0 means use default (4)." default:"0" hidden:"true"`
@@ -344,7 +346,39 @@ func (c Config) Metabase(applicationName string) metabase.Config {
 		TestingTimestampVersioning: c.TestingTimestampVersioning,
 		SpannerGRPCConnectionPool:  c.SpannerGRPCConnectionPool,
 		Compression:                c.MetabaseCompression,
+		ProjectToAdapter:           projectToAdapterMap(c.ProjectToAdapter),
 	}
+}
+
+// projectToAdapterMap parses the ProjectToAdapter string into a map of project IDs to adapter indexes.
+// Silently ignores any invalid entries in the string.
+func projectToAdapterMap(projectToAdapter string) map[uuid.UUID]int {
+	result := make(map[uuid.UUID]int)
+	if projectToAdapter == "" {
+		return result
+	}
+	pairs := strings.Split(projectToAdapter, ",")
+	for _, pair := range pairs {
+		parts := strings.Split(pair, ":")
+		if len(parts) != 2 {
+			continue
+		}
+		projectIDStr := parts[0]
+		adapterIndexStr := parts[1]
+
+		projectID, err := uuid.FromString(projectIDStr)
+		if err != nil {
+			continue
+		}
+
+		adapterIndex, err := strconv.Atoi(adapterIndexStr)
+		if err != nil {
+			continue
+		}
+
+		result[projectID] = adapterIndex
+	}
+	return result
 }
 
 // UUIDsFlag is a configuration struct that keeps info about project IDs

--- a/satellite/metainfo/config_test.go
+++ b/satellite/metainfo/config_test.go
@@ -18,6 +18,7 @@ import (
 	"storj.io/common/rpc/rpcstatus"
 	"storj.io/common/testcontext"
 	"storj.io/common/testrand"
+	"storj.io/common/uuid"
 	"storj.io/storj/private/testplanet"
 	"storj.io/storj/satellite"
 	"storj.io/storj/satellite/metainfo"
@@ -187,4 +188,92 @@ func TestMigrationModeFlag(t *testing.T) {
 		err = planet.Uplinks[0].Upload(ctx, planet.Satellites[0], "testbucket", "testobject", testrand.Bytes(1*memory.KiB))
 		require.NoError(t, err)
 	})
+}
+
+func TestProjectToAdapterMap(t *testing.T) {
+	projectA := testrand.UUID()
+	projectB := testrand.UUID()
+
+	tests := []struct {
+		description string
+		input       string
+		expected    map[uuid.UUID]int
+	}{
+		{
+			description: "empty string",
+			input:       "",
+			expected:    map[uuid.UUID]int{},
+		},
+		{
+			description: "single valid entry",
+			input:       fmt.Sprintf("%s:0", projectA),
+			expected:    map[uuid.UUID]int{projectA: 0},
+		},
+		{
+			description: "multiple valid entries",
+			input:       fmt.Sprintf("%s:0,%s:1", projectA, projectB),
+			expected:    map[uuid.UUID]int{projectA: 0, projectB: 1},
+		},
+		{
+			description: "mix of valid and invalid UUID",
+			input:       fmt.Sprintf("invalid-uuid:0,%s:1", projectA),
+			expected:    map[uuid.UUID]int{projectA: 1},
+		},
+		{
+			description: "non-numeric adapter index is ignored",
+			input:       fmt.Sprintf("%s:abc,%s:2", projectA, projectB),
+			expected:    map[uuid.UUID]int{projectB: 2},
+		},
+		{
+			description: "missing colon separator",
+			input:       projectA.String(),
+			expected:    map[uuid.UUID]int{},
+		},
+		{
+			description: "too many colons",
+			input:       fmt.Sprintf("%s:0:extra", projectA),
+			expected:    map[uuid.UUID]int{},
+		},
+		{
+			description: "empty pair between commas",
+			input:       fmt.Sprintf("%s:0,,%s:1", projectA, projectB),
+			expected:    map[uuid.UUID]int{projectA: 0, projectB: 1},
+		},
+		{
+			description: "negative adapter index",
+			input:       fmt.Sprintf("%s:-1", projectA),
+			expected:    map[uuid.UUID]int{projectA: -1},
+		},
+		{
+			description: "duplicate project ID, last wins",
+			input:       fmt.Sprintf("%s:0,%s:5", projectA, projectA),
+			expected:    map[uuid.UUID]int{projectA: 5},
+		},
+		{
+			description: "all invalid entries",
+			input:       "invalid-uuid:0,another-invalid:1",
+			expected:    map[uuid.UUID]int{},
+		},
+		{
+			description: "empty project ID",
+			input:       ":0",
+			expected:    map[uuid.UUID]int{},
+		},
+		{
+			description: "empty adapter index",
+			input:       fmt.Sprintf("%s:", projectA),
+			expected:    map[uuid.UUID]int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			config := metainfo.Config{
+				ProjectToAdapter: tt.input,
+			}
+
+			result := config.Metabase("test")
+			require.Equal(t, tt.expected, result.ProjectToAdapter)
+		})
+	}
 }


### PR DESCRIPTION
Adds a new ProjectToAdapter config option that allows mapping specific project IDs to a particular metabase adapter index. Invalid entries in the config string are silently ignored.

Change-Id: I13147383c3cf44a971419367a182aec87255d548


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
