### PR TITLE
Add package-level documentation to example package

### DIFF
--- a/private/apigen/example/doc.go
+++ b/private/apigen/example/doc.go
@@ -1,6 +1,7 @@
 // Copyright (C) 2022 Storj Labs, Inc.
 // See LICENSE for copying information.
 
+// Package example provides examples for API generation.
 package example
 
 //go:generate go run gen.go


### PR DESCRIPTION
## Problem
The `example` package in `private/apigen/example/doc.go` lacked a package-level documentation comment. In Go, this is important for describing the package's purpose and usage, and it improves code clarity and maintainability.

## Solution
Added a docstring: "Package example provides examples for API generation." This follows Go conventions for package documentation, ensuring the package has clear documentation without altering functionality.

## Verification
To verify, run `go doc example` from the repository root and confirm the documentation is displayed correctly. No code behavior changes, so existing tests remain unaffected.