### PR TITLE
Point release v1.156.2-rc

### DIFF
--- a/satellite/metabase/iterator.go
+++ b/satellite/metabase/iterator.go
@@ -428,7 +428,9 @@ func (it *sqlObjectIterator) Close() error {
 	if it.curRows == nil {
 		return nil
 	}
-	return it.curRows.Close()
+	// Err must be called before Close to satisfy the tagsql leak tracker when
+	// the consumer stops iterating before the rows have been fully exhausted.
+	return errs.Combine(it.curRows.Err(), it.curRows.Close())
 }
 
 // ObjectIterator opens a new SQL-backed object iterator on the

--- a/satellite/metabase/iterator_test.go
+++ b/satellite/metabase/iterator_test.go
@@ -746,6 +746,34 @@ func TestIterateObjectsWithStatus(t *testing.T) {
 			require.NoError(t, err)
 		})
 
+		t.Run("verify-early-exit", func(t *testing.T) {
+			// Stopping iteration before the underlying rows are exhausted must
+			// not return an error: the iterator's Close() has to call rows.Err()
+			// before rows.Close() to satisfy the tagsql leak tracker. This
+			// mirrors ListObjects reading a single page out of a full batch.
+			defer metabasetest.DeleteAll{}.Check(ctx, t, db)
+			projectID, bucketName := uuid.UUID{1}, metabase.BucketName("bucky")
+			objects := createObjects(ctx, t, db, 10, projectID, bucketName)
+
+			// BatchSize matches the object count so the first batch is full of
+			// rows that are never read past the first one.
+			readOne := func(ctx context.Context, it metabase.ObjectsIterator) error {
+				var entry metabase.ObjectEntry
+				require.True(t, it.Next(ctx, &entry))
+				return nil
+			}
+			for _, recursive := range []bool{true, false} {
+				opts := metabase.IterateObjectsWithStatus{
+					ProjectID:  projectID,
+					BucketName: bucketName,
+					Recursive:  recursive,
+					BatchSize:  len(objects),
+				}
+				require.NoError(t, db.IterateObjectsAllVersionsWithStatus(ctx, opts, readOne))
+				require.NoError(t, db.IterateObjectsAllVersionsWithStatusAscending(ctx, opts, readOne))
+			}
+		})
+
 		for _, tt := range objectIncludesScenarios {
 			t.Run(tt.name, func(t *testing.T) {
 				defer metabasetest.DeleteAll{}.Check(ctx, t, db)


### PR DESCRIPTION
The shared sqlObjectIterator.Close() introduced during the Postgres/TiDB iterator unification only called rows.Close(). When a consumer stops iterating before the underlying rows are exhausted (e.g. ListObjects reading a single page out of a full batch), the tagsql leak tracker reports "rows.Err() was not called" and combines it into the returned error, failing the listing.

Restore the pre-refactor behavior by calling rows.Err() before Close().

Add a verify-early-exit subtest exercising the early-termination path.

Change-Id: Ib580daffde8fda574c248aa10c53654d120281cb


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
