### PR TITLE
storagenode/monitor: add effective node space calculation

### DIFF
--- a/storagenode/monitor/monitor.go
+++ b/storagenode/monitor/monitor.go
@@ -51,6 +51,10 @@ type DiskSpace struct {
 	Overused int64
 	// Reserved is part of the allocated space, but always should be free.
 	Reserved int64
+	// Effective is the safety-checked allocation actually used for space calculations.
+	// It may be lower than Allocated when PreFlightCheck found the disk too tight to
+	// honor the full configured allocation.
+	Effective int64
 }
 
 // Config defines parameters for storage node disk and bandwidth usage monitoring.

--- a/storagenode/monitor/shared.go
+++ b/storagenode/monitor/shared.go
@@ -55,12 +55,13 @@ type PieceStoreSpaceUsage interface {
 
 // SharedDisk is the default way to check disk space (using usage-space walker).
 type SharedDisk struct {
-	store              PieceStoreSpaceUsage
-	hashStore          HashStoreBackend
-	allocatedDiskSpace int64
-	log                *zap.Logger
-	minimumDiskSpace   int64
-	dir                DiskSpaceInfo
+	store               PieceStoreSpaceUsage
+	hashStore           HashStoreBackend
+	allocatedDiskSpace  int64 // safety-checked; may be reduced by PreFlightCheck to fit available disk
+	configuredDiskSpace int64 // user-configured value; never modified after construction
+	log                 *zap.Logger
+	minimumDiskSpace    int64
+	dir                 DiskSpaceInfo
 }
 
 var _ SpaceReport = (*SharedDisk)(nil)
@@ -74,12 +75,13 @@ func NewSharedDisk(ctx context.Context, log *zap.Logger, store PieceStoreSpaceUs
 		}
 	}
 	s := &SharedDisk{
-		log:                log,
-		dir:                filestore.NewDirSpaceInfo(logsPath),
-		store:              store,
-		hashStore:          hashStore,
-		allocatedDiskSpace: allocatedDiskSpace,
-		minimumDiskSpace:   minimumDiskSpace,
+		log:                 log,
+		dir:                 filestore.NewDirSpaceInfo(logsPath),
+		store:               store,
+		hashStore:           hashStore,
+		allocatedDiskSpace:  allocatedDiskSpace,
+		configuredDiskSpace: allocatedDiskSpace,
+		minimumDiskSpace:    minimumDiskSpace,
 	}
 	return s, s.PreFlightCheck(ctx)
 }
@@ -181,12 +183,21 @@ func (s *SharedDisk) DiskSpace(ctx context.Context) (_ DiskSpace, err error) {
 
 	overused := int64(0)
 
-	allocated := s.allocatedDiskSpace
+	// allocated is what we report to the user — always the configured value (capped to
+	// actual disk size so we don't claim more than the hardware holds).
+	allocated := s.configuredDiskSpace
 	if isLowerThanAllocated(storageStatus.DiskTotal, allocated) {
 		allocated = storageStatus.DiskTotal
 	}
 
-	available := allocated - (usedForPieces + usedForTrash) - hashSpaceUsage.UsedTotal - hashSpaceUsage.Reserved
+	// effective is the safety-checked allocation used to compute available space;
+	// it may be lower than configured if PreFlightCheck found the disk was tight.
+	effective := s.allocatedDiskSpace
+	if isLowerThanAllocated(storageStatus.DiskTotal, effective) {
+		effective = storageStatus.DiskTotal
+	}
+
+	available := effective - (usedForPieces + usedForTrash) - hashSpaceUsage.UsedTotal - hashSpaceUsage.Reserved
 	if available < 0 {
 		overused = -available
 		available = 0
@@ -198,6 +209,7 @@ func (s *SharedDisk) DiskSpace(ctx context.Context) (_ DiskSpace, err error) {
 	diskSpace := DiskSpace{
 		Total:           storageStatus.DiskTotal,
 		Allocated:       allocated,
+		Effective:       effective,
 		UsedForPieces:   usedForPieces + hashSpaceUsage.UsedForPieces,
 		UsedForTrash:    usedForTrash + hashSpaceUsage.UsedForTrash,
 		Free:            storageStatus.DiskFree,

--- a/storagenode/monitor/shared_test.go
+++ b/storagenode/monitor/shared_test.go
@@ -299,6 +299,49 @@ func TestPreFlightCheck_HashStoreOnly_TooSmall(t *testing.T) {
 	require.Error(t, err, "PreFlightCheck should fail for hashstore-only node with insufficient space")
 }
 
+func TestDiskSpace_AllocatedReportsConfiguredValue(t *testing.T) {
+	// Scenario: PreFlightCheck reduces allocatedDiskSpace because free disk is
+	// tighter than the configured allocation allows. DiskSpace should still report
+	// the user-configured allocation, not the safety-checked reduced value.
+	//
+	// Configured: 4TB, hashstore uses 3.5TB, free disk: 300GB.
+	// PreFlightCheck caps allocatedDiskSpace to 3.5TB + 300GB = 3.8TB.
+	// DiskSpace.Allocated must still return 4TB (the configured value).
+
+	const (
+		gb            = int64(1_000_000_000)
+		diskTotal     = 4000 * gb
+		diskFree      = 300 * gb
+		configured    = 4000 * gb
+		hashstoreUsed = 3500 * gb
+		minimumDisk   = 500 * gb
+	)
+
+	ctx := context.Background()
+	log := zaptest.NewLogger(t)
+
+	store := &mockPieceStore{
+		status: StorageStatus{
+			DiskTotal: diskTotal,
+			DiskFree:  diskFree,
+		},
+	}
+
+	hashStore := &mockHashStore{
+		usage: SpaceUsage{
+			UsedTotal: hashstoreUsed,
+		},
+	}
+
+	sd, err := NewSharedDisk(ctx, log, store, hashStore, minimumDisk, configured)
+	require.NoError(t, err)
+	require.Less(t, sd.allocatedDiskSpace, configured, "PreFlightCheck should have reduced allocatedDiskSpace")
+
+	ds, err := sd.DiskSpace(ctx)
+	require.NoError(t, err)
+	require.Equal(t, configured, ds.Allocated, "Allocated should report the user-configured value, not the safety-checked reduction")
+}
+
 func TestDiskSpace_HashStoreOnly_AvailableCappedByFree(t *testing.T) {
 	// Scenario: hashstore-only node where the computed available space
 	// exceeds actual free disk space. Available should be capped by DiskFree.


### PR DESCRIPTION
Add a field for the effective node space to distinguish it from the allocated space provided by the user.

Change-Id: I68138e153ef7f723f20915c76f51f7c62a3eb156


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
