### PR TITLE
storagenode: normalize missing storage usage for dashboard estimates

### DIFF
--- a/storagenode/console/consoleapi/storagenode_test.go
+++ b/storagenode/console/consoleapi/storagenode_test.go
@@ -135,6 +135,11 @@ func TestStorageNodeApi(t *testing.T) {
 					PreviousMonth:            estimation.PreviousMonth,
 					CurrentMonthExpectations: estimation.CurrentMonthExpectations,
 				}
+				// Current-month disk space includes the partial current day, so
+				// the HTTP request and direct service call use slightly different
+				// cut-off times.
+				require.InEpsilon(t, expectedPayout.CurrentMonth.DiskSpace, bodyPayout.CurrentMonth.DiskSpace, 1e-6)
+				expectedPayout.CurrentMonth.DiskSpace = bodyPayout.CurrentMonth.DiskSpace
 				require.EqualValues(t, expectedPayout, bodyPayout)
 			})
 		},

--- a/storagenode/console/service.go
+++ b/storagenode/console/service.go
@@ -243,17 +243,19 @@ type Satellite struct {
 // GetSatelliteData returns satellite related data.
 func (s *Service) GetSatelliteData(ctx context.Context, satelliteID storj.NodeID) (_ *Satellite, err error) {
 	defer mon.Task()(&ctx)(&err)
-	from, to := date.MonthBoundary(time.Now().UTC())
+	now := time.Now().UTC()
+	from, to := date.MonthBoundary(now)
 
 	bandwidthDaily, err := s.bandwidthDB.GetDailySatelliteRollups(ctx, satelliteID, from, to)
 	if err != nil {
 		return nil, SNOServiceErr.Wrap(err)
 	}
 
-	storageDaily, err := s.storageUsageDB.GetDaily(ctx, satelliteID, from, to)
+	rawStorageDaily, err := s.storageUsageDB.GetDailyRawForNormalization(ctx, satelliteID, from, now)
 	if err != nil {
 		return nil, SNOServiceErr.Wrap(err)
 	}
+	storageDaily := storageusage.NormalizeForDisplay(rawStorageDaily, from, now)
 
 	bandwidthSummary, err := s.bandwidthDB.SatelliteSummary(ctx, satelliteID, from, to)
 	if err != nil {
@@ -270,10 +272,11 @@ func (s *Service) GetSatelliteData(ctx context.Context, satelliteID storj.NodeID
 		return nil, SNOServiceErr.Wrap(err)
 	}
 
-	storageSummary, averageUsageInBytes, err := s.storageUsageDB.SatelliteSummary(ctx, satelliteID, from, to)
+	storageSummary, _, err := s.storageUsageDB.SatelliteSummary(ctx, satelliteID, from, to)
 	if err != nil {
 		return nil, SNOServiceErr.Wrap(err)
 	}
+	averageUsageInBytes := storageusage.DisplayAverage(storageDaily)
 
 	rep, err := s.reputationDB.Get(ctx, satelliteID)
 	if err != nil {
@@ -345,19 +348,26 @@ type Audits struct {
 // among all satellites from the node's trust pool.
 func (s *Service) GetAllSatellitesData(ctx context.Context) (_ *Satellites, err error) {
 	defer mon.Task()(&ctx)(nil)
-	from, to := date.MonthBoundary(time.Now().UTC())
+	now := time.Now().UTC()
+	from, to := date.MonthBoundary(now)
 
 	var audits []Audits
+	satellitesIDs := s.trust.GetSatellites(ctx)
 
 	bandwidthDaily, err := s.bandwidthDB.GetDailyRollups(ctx, from, to)
 	if err != nil {
 		return nil, SNOServiceErr.Wrap(err)
 	}
 
-	storageDaily, err := s.storageUsageDB.GetDailyTotal(ctx, from, to)
-	if err != nil {
-		return nil, SNOServiceErr.Wrap(err)
+	normalizedBySatellite := make([][]storageusage.Stamp, 0, len(satellitesIDs))
+	for _, satelliteID := range satellitesIDs {
+		rawStorageDaily, err := s.storageUsageDB.GetDailyRawForNormalization(ctx, satelliteID, from, now)
+		if err != nil {
+			return nil, SNOServiceErr.Wrap(err)
+		}
+		normalizedBySatellite = append(normalizedBySatellite, storageusage.NormalizeForDisplay(rawStorageDaily, from, now))
 	}
+	storageDaily := storageusage.CombineForDisplay(normalizedBySatellite...)
 
 	bandwidthSummary, err := s.bandwidthDB.Summary(ctx, from, to)
 	if err != nil {
@@ -374,12 +384,12 @@ func (s *Service) GetAllSatellitesData(ctx context.Context) (_ *Satellites, err 
 		return nil, SNOServiceErr.Wrap(err)
 	}
 
-	storageSummary, averageUsageInBytes, err := s.storageUsageDB.Summary(ctx, from, to)
+	storageSummary, _, err := s.storageUsageDB.Summary(ctx, from, to)
 	if err != nil {
 		return nil, SNOServiceErr.Wrap(err)
 	}
+	averageUsageInBytes := storageusage.DisplayAverage(storageDaily)
 
-	satellitesIDs := s.trust.GetSatellites(ctx)
 	joinedAt := time.Now().UTC()
 
 	for i := 0; i < len(satellitesIDs); i++ {

--- a/storagenode/payouts/estimatedpayouts/service.go
+++ b/storagenode/payouts/estimatedpayouts/service.go
@@ -115,20 +115,27 @@ func (s *Service) estimatedPayout(ctx context.Context, satelliteID storj.NodeID,
 	if err != nil {
 		return PayoutMonthly{}, PayoutMonthly{}, EstimationServiceErr.Wrap(err)
 	}
-	currentMonthPayout, err = s.estimationUsagePeriod(ctx, now.UTC(), stats.JoinedAt, priceModel)
-	previousMonthPayout, err = s.estimationUsagePeriod(ctx, now.UTC().AddDate(0, -1, 0), stats.JoinedAt, priceModel)
+	currentMonthPayout, err = s.estimationUsagePeriod(ctx, now.UTC(), now.UTC(), stats.JoinedAt, priceModel)
+
+	previousPeriod := now.UTC().AddDate(0, -1, 0)
+	_, previousMonthEnd := date.MonthBoundary(previousPeriod)
+	previousMonthPayout, err = s.estimationUsagePeriod(ctx, previousPeriod, previousMonthEnd.Add(time.Nanosecond), stats.JoinedAt, priceModel)
 
 	return currentMonthPayout, previousMonthPayout, nil
 }
 
 // estimationUsagePeriod returns PayoutMonthly for current satellite and current or previous month.
-func (s *Service) estimationUsagePeriod(ctx context.Context, period time.Time, joinedAt time.Time, priceModel *pricing.Pricing) (payout PayoutMonthly, err error) {
+func (s *Service) estimationUsagePeriod(ctx context.Context, period, usageThrough, joinedAt time.Time, priceModel *pricing.Pricing) (payout PayoutMonthly, err error) {
 	var from, to time.Time
 
 	heldRate := payouts.GetHeldRate(joinedAt, period)
 	payout.HeldRate = heldRate
 
 	from, to = date.MonthBoundary(period)
+	monthThrough := to.Add(time.Nanosecond)
+	if usageThrough.After(monthThrough) {
+		usageThrough = monthThrough
+	}
 
 	bandwidthDaily, err := s.bandwidthDB.GetDailySatelliteRollups(ctx, priceModel.SatelliteID, from, to)
 	if err != nil {
@@ -142,14 +149,17 @@ func (s *Service) estimationUsagePeriod(ctx context.Context, period time.Time, j
 	payout.SetEgressBandwidthPayout(priceModel.EgressBandwidth)
 	payout.SetEgressRepairAuditPayout(priceModel.AuditBandwidth)
 
-	storageDaily, err := s.storageUsageDB.GetDaily(ctx, priceModel.SatelliteID, from, to)
+	normalizeThrough := usageThrough
+	if normalizeThrough.Equal(monthThrough) {
+		normalizeThrough = to
+	}
+	storageDailyRaw, err := s.storageUsageDB.GetDailyRawForNormalization(ctx, priceModel.SatelliteID, from, normalizeThrough)
 	if err != nil {
 		return PayoutMonthly{}, EstimationServiceErr.Wrap(err)
 	}
 
-	for j := 0; j < len(storageDaily); j++ {
-		payout.DiskSpace += storageDaily[j].AtRestTotal
-	}
+	storageDaily := storageusage.NormalizeForDisplay(storageDailyRaw, from, normalizeThrough)
+	payout.DiskSpace = storageusage.DisplayByteHours(storageDaily, from, usageThrough)
 	// dividing by 720 to show tbm instead of tbh.
 	payout.DiskSpace /= 720
 	payout.SetDiskSpacePayout(priceModel.DiskSpace)

--- a/storagenode/storagenodedb/storageusage.go
+++ b/storagenode/storagenodedb/storageusage.go
@@ -110,6 +110,47 @@ func (db *storageUsageDB) GetDaily(ctx context.Context, satelliteID storj.NodeID
 	return stamps, rows.Err()
 }
 
+// GetDailyRawForNormalization returns unmodified satellite storage usage
+// stamps for a particular satellite and time range, together with the two
+// preceding stamps required to normalize the first available rate.
+func (db *storageUsageDB) GetDailyRawForNormalization(ctx context.Context, satelliteID storj.NodeID, from, to time.Time) (_ []storageusage.Stamp, err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	query := `SELECT satellite_id, at_rest_total, timestamp, interval_end_time
+				FROM storage_usage
+				WHERE satellite_id = ?
+				AND (
+					(? <= timestamp AND timestamp <= ?)
+					OR timestamp IN (
+						SELECT timestamp
+						FROM storage_usage
+						WHERE satellite_id = ?
+						AND timestamp < ?
+						ORDER BY timestamp DESC
+						LIMIT 2
+					)
+				)
+				ORDER BY timestamp ASC`
+
+	rows, err := db.QueryContext(ctx, query, satelliteID, from.UTC(), to.UTC(), satelliteID, from.UTC())
+	if err != nil {
+		return nil, err
+	}
+	defer func() { err = errs.Combine(err, rows.Close()) }()
+
+	var stamps []storageusage.Stamp
+	for rows.Next() {
+		var stamp storageusage.Stamp
+		err = rows.Scan(&stamp.SatelliteID, &stamp.AtRestTotal, &stamp.IntervalStart, &stamp.IntervalEndTime)
+		if err != nil {
+			return nil, err
+		}
+		stamps = append(stamps, stamp)
+	}
+
+	return stamps, rows.Err()
+}
+
 // GetDailyTotal returns daily storage usage stamps summed across all known satellites
 // for provided time range.
 func (db *storageUsageDB) GetDailyTotal(ctx context.Context, from, to time.Time) (_ []storageusage.StampGroup, err error) {

--- a/storagenode/storageusage/normalize.go
+++ b/storagenode/storageusage/normalize.go
@@ -149,6 +149,37 @@ func DisplayAverage[T interface{ Stamp | StampGroup }](stamps []T) float64 {
 	return total / float64(len(stamps))
 }
 
+// DisplayByteHours returns the area under the normalized daily graph between
+// from (inclusive) and through (exclusive).
+func DisplayByteHours(stamps []Stamp, from, through time.Time) float64 {
+	from = from.UTC()
+	through = through.UTC()
+	if !through.After(from) {
+		return 0
+	}
+
+	var total float64
+	for _, stamp := range stamps {
+		dayStart := utcDay(stamp.IntervalStart)
+		dayEnd := dayStart.AddDate(0, 0, 1)
+
+		start := dayStart
+		if start.Before(from) {
+			start = from
+		}
+		end := dayEnd
+		if end.After(through) {
+			end = through
+		}
+		if !end.After(start) {
+			continue
+		}
+
+		total += stamp.AtRestTotalBytes * end.Sub(start).Hours()
+	}
+	return total
+}
+
 func validSatelliteStamp(stamp Stamp) bool {
 	return !stamp.IntervalEndTime.IsZero()
 }

--- a/storagenode/storageusage/normalize.go
+++ b/storagenode/storageusage/normalize.go
@@ -1,0 +1,169 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package storageusage
+
+import (
+	"math"
+	"sort"
+	"time"
+
+	"storj.io/common/storj"
+)
+
+// NormalizeForDisplay replaces completed gaps with the average storage rate
+// represented by the next valid satellite tally. It projects a trailing gap
+// from the last valid rate. Calculated rows never add synthetic AtRestTotal.
+func NormalizeForDisplay(stamps []Stamp, from, through time.Time) []Stamp {
+	if len(stamps) == 0 || through.Before(from) {
+		return nil
+	}
+
+	sorted := append([]Stamp(nil), stamps...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].IntervalStart.Before(sorted[j].IntervalStart)
+	})
+
+	fromDay := utcDay(from)
+	throughDay := utcDay(through)
+	byDay := make(map[time.Time]Stamp)
+
+	var previousValid *Stamp
+	var lastRate float64
+
+	for i := range sorted {
+		current := sorted[i]
+		if !validSatelliteStamp(current) {
+			continue
+		}
+
+		rate := current.AtRestTotalBytes
+		intervalHours := current.IntervalInHours
+		if previousValid != nil {
+			intervalHours = current.IntervalEndTime.Sub(previousValid.IntervalEndTime).Hours()
+			if intervalHours <= 0 {
+				continue
+			}
+			rate = current.AtRestTotal / intervalHours
+		} else if intervalHours <= 0 {
+			intervalHours = 24
+			rate = current.AtRestTotal / intervalHours
+		}
+		if rate < 0 || math.IsNaN(rate) || math.IsInf(rate, 0) {
+			continue
+		}
+
+		currentDay := utcDay(current.IntervalStart)
+		if previousValid != nil {
+			for day := utcDay(previousValid.IntervalStart).AddDate(0, 0, 1); day.Before(currentDay); day = day.AddDate(0, 0, 1) {
+				if day.Before(fromDay) || day.After(throughDay) {
+					continue
+				}
+				byDay[day] = calculatedStamp(current.SatelliteID, day, rate, 24)
+			}
+		}
+
+		if !currentDay.Before(fromDay) && !currentDay.After(throughDay) {
+			current.AtRestTotalBytes = rate
+			current.IntervalInHours = intervalHours
+			current.Calculated = false
+			byDay[currentDay] = current
+		}
+
+		previousValid = &current
+		lastRate = rate
+	}
+
+	if previousValid != nil {
+		for day := utcDay(previousValid.IntervalStart).AddDate(0, 0, 1); !day.After(throughDay); day = day.AddDate(0, 0, 1) {
+			if day.Before(fromDay) {
+				continue
+			}
+			if _, exists := byDay[day]; exists {
+				continue
+			}
+
+			hours := float64(24)
+			if day.Equal(throughDay) {
+				hours = through.Sub(day).Hours()
+				if hours <= 0 {
+					hours = 24
+				}
+			}
+			byDay[day] = calculatedStamp(previousValid.SatelliteID, day, lastRate, hours)
+		}
+	}
+
+	result := make([]Stamp, 0, len(byDay))
+	for day := fromDay; !day.After(throughDay); day = day.AddDate(0, 0, 1) {
+		if stamp, exists := byDay[day]; exists {
+			result = append(result, stamp)
+		}
+	}
+	return result
+}
+
+// CombineForDisplay sums normalized per-satellite display rows by UTC day.
+func CombineForDisplay(series ...[]Stamp) []StampGroup {
+	byDay := make(map[time.Time]StampGroup)
+	for _, stamps := range series {
+		for _, stamp := range stamps {
+			day := utcDay(stamp.IntervalStart)
+			group := byDay[day]
+			group.AtRestTotal += stamp.AtRestTotal
+			group.AtRestTotalBytes += stamp.AtRestTotalBytes
+			group.IntervalStart = day
+			group.Calculated = group.Calculated || stamp.Calculated
+			byDay[day] = group
+		}
+	}
+
+	days := make([]time.Time, 0, len(byDay))
+	for day := range byDay {
+		days = append(days, day)
+	}
+	sort.Slice(days, func(i, j int) bool { return days[i].Before(days[j]) })
+
+	result := make([]StampGroup, 0, len(days))
+	for _, day := range days {
+		result = append(result, byDay[day])
+	}
+	return result
+}
+
+// DisplayAverage returns the arithmetic average of normalized daily values.
+func DisplayAverage[T interface{ Stamp | StampGroup }](stamps []T) float64 {
+	if len(stamps) == 0 {
+		return 0
+	}
+
+	var total float64
+	for _, value := range stamps {
+		switch stamp := any(value).(type) {
+		case Stamp:
+			total += stamp.AtRestTotalBytes
+		case StampGroup:
+			total += stamp.AtRestTotalBytes
+		}
+	}
+	return total / float64(len(stamps))
+}
+
+func validSatelliteStamp(stamp Stamp) bool {
+	return !stamp.IntervalEndTime.IsZero()
+}
+
+func calculatedStamp(satelliteID storj.NodeID, day time.Time, rate, hours float64) Stamp {
+	return Stamp{
+		SatelliteID:      satelliteID,
+		AtRestTotalBytes: rate,
+		IntervalInHours:  hours,
+		IntervalStart:    day,
+		Calculated:       true,
+	}
+}
+
+func utcDay(value time.Time) time.Time {
+	value = value.UTC()
+	return time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, time.UTC)
+}

--- a/storagenode/storageusage/normalize_test.go
+++ b/storagenode/storageusage/normalize_test.go
@@ -150,6 +150,22 @@ func TestCombineForDisplayMarksCalculatedContributions(t *testing.T) {
 	require.Equal(t, 1.4e12, DisplayAverage(combined))
 }
 
+func TestDisplayByteHoursUsesGraphValuesAndPartialDay(t *testing.T) {
+	stamps := []Stamp{
+		{AtRestTotalBytes: 100, IntervalStart: date(2026, time.July, 1)},
+		{AtRestTotalBytes: 200, IntervalStart: date(2026, time.July, 2), Calculated: true},
+		{AtRestTotalBytes: 300, IntervalStart: date(2026, time.July, 3)},
+	}
+
+	total := DisplayByteHours(
+		stamps,
+		date(2026, time.July, 1),
+		time.Date(2026, time.July, 2, 12, 0, 0, 0, time.UTC),
+	)
+
+	require.Equal(t, float64(100*24+200*12), total)
+}
+
 func date(year int, month time.Month, day int) time.Time {
 	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 }

--- a/storagenode/storageusage/normalize_test.go
+++ b/storagenode/storageusage/normalize_test.go
@@ -1,0 +1,155 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package storageusage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"storj.io/common/testrand"
+)
+
+func TestNormalizeForDisplayRecoveredUS1Gap(t *testing.T) {
+	satelliteID := testrand.NodeID()
+	stamps := []Stamp{
+		{
+			SatelliteID:      satelliteID,
+			AtRestTotal:      9.74841403446273e12,
+			AtRestTotalBytes: 1.2185517543078412e12,
+			IntervalInHours:  8,
+			IntervalStart:    date(2026, time.July, 8),
+			IntervalEndTime:  time.Date(2026, time.July, 8, 6, 0, 0, 0, time.UTC),
+		},
+		{
+			SatelliteID:     satelliteID,
+			IntervalStart:   date(2026, time.July, 9),
+			IntervalEndTime: time.Time{},
+		},
+		{
+			SatelliteID:     satelliteID,
+			IntervalStart:   date(2026, time.July, 10),
+			IntervalEndTime: time.Time{},
+		},
+		{
+			SatelliteID:      satelliteID,
+			AtRestTotal:      77.8088065756294e12,
+			AtRestTotalBytes: 4.3822659842311144e6,
+			IntervalInHours:  17755382,
+			IntervalStart:    date(2026, time.July, 11),
+			IntervalEndTime:  time.Date(2026, time.July, 11, 14, 0, 0, 0, time.UTC),
+		},
+	}
+
+	normalized := NormalizeForDisplay(
+		stamps,
+		date(2026, time.July, 8),
+		time.Date(2026, time.July, 11, 23, 59, 0, 0, time.UTC),
+	)
+
+	require.Len(t, normalized, 4)
+	expectedRecoveredRate := 77.8088065756294e12 / 80
+
+	require.False(t, normalized[0].Calculated)
+	require.InDelta(t, 1.2185517543078412e12, normalized[0].AtRestTotalBytes, 0.1)
+
+	require.True(t, normalized[1].Calculated)
+	require.True(t, normalized[2].Calculated)
+	require.InDelta(t, expectedRecoveredRate, normalized[1].AtRestTotalBytes, 0.1)
+	require.InDelta(t, expectedRecoveredRate, normalized[2].AtRestTotalBytes, 0.1)
+
+	require.False(t, normalized[3].Calculated)
+	require.Equal(t, float64(80), normalized[3].IntervalInHours)
+	require.InDelta(t, expectedRecoveredRate, normalized[3].AtRestTotalBytes, 0.1)
+
+	var rawBefore, rawAfter float64
+	for _, stamp := range stamps {
+		rawBefore += stamp.AtRestTotal
+	}
+	for _, stamp := range normalized {
+		rawAfter += stamp.AtRestTotal
+	}
+	require.Equal(t, rawBefore, rawAfter)
+}
+
+func TestNormalizeForDisplayProjectsUnresolvedUS1Gap(t *testing.T) {
+	satelliteID := testrand.NodeID()
+	stamps := []Stamp{
+		{
+			SatelliteID:     satelliteID,
+			AtRestTotal:     22.49257205835468e12,
+			IntervalStart:   date(2026, time.July, 19),
+			IntervalEndTime: time.Date(2026, time.July, 19, 13, 0, 0, 0, time.UTC),
+		},
+		{
+			SatelliteID:     satelliteID,
+			AtRestTotal:     12.066757977208667e12,
+			IntervalStart:   date(2026, time.July, 20),
+			IntervalEndTime: date(2026, time.July, 20),
+		},
+		{SatelliteID: satelliteID, IntervalStart: date(2026, time.July, 21)},
+		{SatelliteID: satelliteID, IntervalStart: date(2026, time.July, 22)},
+		{SatelliteID: satelliteID, IntervalStart: date(2026, time.July, 23)},
+	}
+
+	through := time.Date(2026, time.July, 24, 12, 0, 0, 0, time.UTC)
+	normalized := NormalizeForDisplay(stamps, date(2026, time.July, 19), through)
+
+	require.Len(t, normalized, 6)
+	expectedRate := 12.066757977208667e12 / 11
+	for i := 2; i < len(normalized); i++ {
+		require.True(t, normalized[i].Calculated)
+		require.InDelta(t, expectedRate, normalized[i].AtRestTotalBytes, 0.1)
+		require.Zero(t, normalized[i].AtRestTotal)
+	}
+	require.Equal(t, float64(12), normalized[len(normalized)-1].IntervalInHours)
+}
+
+func TestNormalizeForDisplayPreservesValidZeroUsage(t *testing.T) {
+	satelliteID := testrand.NodeID()
+	stamps := []Stamp{
+		{
+			SatelliteID:     satelliteID,
+			AtRestTotal:     2400,
+			IntervalStart:   date(2026, time.July, 1),
+			IntervalEndTime: date(2026, time.July, 1),
+		},
+		{
+			SatelliteID:     satelliteID,
+			AtRestTotal:     0,
+			IntervalStart:   date(2026, time.July, 2),
+			IntervalEndTime: date(2026, time.July, 2),
+		},
+	}
+
+	normalized := NormalizeForDisplay(
+		stamps,
+		date(2026, time.July, 1),
+		time.Date(2026, time.July, 3, 12, 0, 0, 0, time.UTC),
+	)
+
+	require.Len(t, normalized, 3)
+	require.False(t, normalized[1].Calculated)
+	require.Zero(t, normalized[1].AtRestTotalBytes)
+	require.True(t, normalized[2].Calculated)
+	require.Zero(t, normalized[2].AtRestTotalBytes)
+}
+
+func TestCombineForDisplayMarksCalculatedContributions(t *testing.T) {
+	day := date(2026, time.July, 9)
+	combined := CombineForDisplay(
+		[]Stamp{{AtRestTotalBytes: 1e12, IntervalStart: day}},
+		[]Stamp{{AtRestTotalBytes: 0.4e12, IntervalStart: day, Calculated: true}},
+	)
+
+	require.Len(t, combined, 1)
+	require.Equal(t, 1.4e12, combined[0].AtRestTotalBytes)
+	require.True(t, combined[0].Calculated)
+	require.Equal(t, 1.4e12, DisplayAverage(combined))
+}
+
+func date(year int, month time.Month, day int) time.Time {
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}

--- a/storagenode/storageusage/storageusage.go
+++ b/storagenode/storageusage/storageusage.go
@@ -19,6 +19,10 @@ type DB interface {
 	// GetDaily returns daily storage usage stamps for particular satellite
 	// for provided time range
 	GetDaily(ctx context.Context, satelliteID storj.NodeID, from, to time.Time) ([]Stamp, error)
+	// GetDailyRawForNormalization returns unmodified satellite storage usage
+	// stamps for a particular satellite and time range, together with the two
+	// preceding stamps required to normalize the first available rate.
+	GetDailyRawForNormalization(ctx context.Context, satelliteID storj.NodeID, from, to time.Time) ([]Stamp, error)
 	// GetDailyTotal returns daily storage usage stamps summed across all known satellites
 	// for provided time range
 	GetDailyTotal(ctx context.Context, from, to time.Time) ([]StampGroup, error)
@@ -44,6 +48,9 @@ type Stamp struct {
 	// IntervalEndTime represents the timestamp for the last tally run time
 	//  (i.e. last interval_end_time) for the day
 	IntervalEndTime time.Time `json:"-"`
+	// Calculated indicates that the display value was derived locally rather
+	// than reported for this day by the satellite.
+	Calculated bool `json:"calculated"`
 }
 
 // StampGroup is storage usage stamp for all satellites from interval start till next interval
@@ -56,4 +63,7 @@ type StampGroup struct {
 	// IntervalStart represents one tally day
 	//  TODO: rename to timestamp to match DB
 	IntervalStart time.Time `json:"intervalStart"`
+	// Calculated indicates that at least one satellite contribution for this
+	// day was derived locally.
+	Calculated bool `json:"calculated"`
 }

--- a/storagenode/storageusage/storageusage_test.go
+++ b/storagenode/storageusage/storageusage_test.go
@@ -94,6 +94,23 @@ func TestStorageUsage(t *testing.T) {
 			}
 		})
 
+		t.Run("get daily raw for normalization", func(t *testing.T) {
+			from := time.Date(now.Year(), now.Month(), now.Day()-20, 0, 0, 0, 0, time.UTC)
+			res, err := storageUsageDB.GetDailyRawForNormalization(ctx, satelliteID, from, now)
+			assert.NoError(t, err)
+			assert.NotNil(t, res)
+			assert.Len(t, res, 22)
+			assert.Equal(t, from.AddDate(0, 0, -2), res[0].IntervalStart)
+			assert.Equal(t, from.AddDate(0, 0, -1), res[1].IntervalStart)
+
+			for _, stamp := range res {
+				expected := expectedDailyStamps[satelliteID][stamp.IntervalStart]
+				assert.Equal(t, expected.AtRestTotal, stamp.AtRestTotal)
+				assert.Equal(t, expected.IntervalEndTime, stamp.IntervalEndTime)
+				assert.Zero(t, stamp.AtRestTotalBytes)
+			}
+		})
+
 		t.Run("get daily total", func(t *testing.T) {
 			res, err := storageUsageDB.GetDailyTotal(ctx, time.Time{}, now)
 			assert.NoError(t, err)

--- a/web/storagenode/src/app/components/DiskSpaceChart.vue
+++ b/web/storagenode/src/app/components/DiskSpaceChart.vue
@@ -17,7 +17,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { ChartData, ChartType, TooltipModel } from 'chart.js';
+import { ChartData, ChartType, ScriptableLineSegmentContext, TooltipModel } from 'chart.js';
 
 import { Tooltip, TooltipParams } from '@/app/types/chart';
 import { ChartUtils } from '@/app/utils/chart';
@@ -34,11 +34,13 @@ class StampTooltip {
     public atRestTotal: string;
     public atRestTotalBytes: string;
     public date: string;
+    public calculated: boolean;
 
     public constructor(stamp: Stamp) {
         this.atRestTotal = Size.toBase10String(stamp.atRestTotal);
         this.atRestTotalBytes = Size.toBase10String(stamp.atRestTotalBytes);
         this.date = stamp.intervalStart.toUTCString().slice(0, 16);
+        this.calculated = stamp.calculated;
     }
 }
 
@@ -58,6 +60,10 @@ const allStamps = computed<Stamp[]>(() => {
 
 const chartBackgroundColor = computed<string>(() => {
     return props.isDarkMode ? '#4F97F7' : '#F2F6FC';
+});
+
+const calculatedLineColor = computed<string>(() => {
+    return props.isDarkMode ? '#C2A45F' : '#8A6F35';
 });
 
 const chartDataDimension = computed<string>(() => {
@@ -83,12 +89,30 @@ const chartData = computed<ChartData>(() => {
                 fill: true,
                 backgroundColor: chartBackgroundColor.value,
                 borderColor: '#1F49A3',
-                borderWidth: 1,
+                borderWidth: 0,
+                pointBorderColor: allStamps.value.map(stamp => stamp.calculated ? calculatedLineColor.value : '#1F49A3'),
                 pointHoverBorderWidth: 3,
                 hoverRadius: 8,
                 hitRadius: 8,
                 pointRadius: 4,
                 pointBorderWidth: 1,
+                data,
+            },
+            {
+                fill: false,
+                borderColor: '#1F49A3',
+                borderWidth: 1,
+                pointRadius: 0,
+                pointHoverRadius: 0,
+                pointHitRadius: 0,
+                segment: {
+                    borderColor: (context: ScriptableLineSegmentContext): string => {
+                        const first = allStamps.value[context.p0DataIndex];
+                        const second = allStamps.value[context.p1DataIndex];
+
+                        return first?.calculated || second?.calculated ? calculatedLineColor.value : '#1F49A3';
+                    },
+                },
                 data,
             },
         ],
@@ -114,9 +138,14 @@ function tooltipMarkUp(tooltipModel: TooltipModel<ChartType>): string {
     const dataIndex = tooltipModel.dataPoints[0].dataIndex;
     const dataPoint = new StampTooltip(allStamps.value[dataIndex]);
 
+    const calculated = dataPoint.calculated ? '<span>Calculated</span>' : '';
+
     return `<div class='tooltip-body'>
                 <p class='tooltip-body__data'><b>${dataPoint.atRestTotalBytes}</b></p>
-                <p class='tooltip-body__footer'>${dataPoint.date}</p>
+                <p class='tooltip-body__footer'>
+                    <span>${dataPoint.date}</span>
+                    ${calculated}
+                </p>
             </div>`;
 }
 
@@ -177,7 +206,9 @@ watch([() => props.isDarkMode, chartData, () => props.width], rebuildChart);
             display: flex;
             align-items: center;
             justify-content: center;
-            padding: 10px 0;
+            flex-direction: column;
+            gap: 2px;
+            padding: 7px 0;
         }
     }
 </style>

--- a/web/storagenode/src/app/utils/chart.ts
+++ b/web/storagenode/src/app/utils/chart.ts
@@ -16,7 +16,8 @@ export class ChartUtils {
      * @returns data - numeric array of normalized data
      */
     public static normalizeChartData(data: number[]): number[] {
-        const maxBytes = Math.ceil(Math.max(...data));
+        const finiteData = data.filter(Number.isFinite);
+        const maxBytes = finiteData.length ? Math.ceil(Math.max(...finiteData)) : 0;
 
         let divider: number = SizeBreakpoints.PB;
         switch (true) {
@@ -34,7 +35,7 @@ export class ChartUtils {
             break;
         }
 
-        return data.map(elem => elem / divider);
+        return data.map(elem => Number.isFinite(elem) ? elem / divider : Number.NaN);
     }
 
     /**
@@ -43,7 +44,8 @@ export class ChartUtils {
      * @returns dataDimension - string of data dimension
      */
     public static getChartDataDimension(data: number[]): string {
-        const maxBytes = Math.ceil(Math.max(...data));
+        const finiteData = data.filter(Number.isFinite);
+        const maxBytes = finiteData.length ? Math.ceil(Math.max(...finiteData)) : 0;
 
         let dataDimension: string;
         switch (true) {
@@ -133,10 +135,6 @@ export class ChartUtils {
     public static populateEmptyStamps(fetchedData: Stamp[]): Stamp[] {
         const storageChartData: Stamp[] = new Array(new Date().getUTCDate());
         const data: Stamp[] = fetchedData || [];
-
-        if (data.length === 0) {
-            return storageChartData;
-        }
 
         outer:
         for (let i = 0; i < storageChartData.length; i++) {

--- a/web/storagenode/src/storagenode/sno/sno.ts
+++ b/web/storagenode/src/storagenode/sno/sno.ts
@@ -132,11 +132,13 @@ export class Stamp {
     public atRestTotal: number;
     public atRestTotalBytes: number;
     public intervalStart: Date;
+    public calculated: boolean;
 
-    public constructor(atRestTotal = 0, atRestTotalBytes = 0, intervalStart: Date = new Date()) {
+    public constructor(atRestTotal = 0, atRestTotalBytes = 0, intervalStart: Date = new Date(), calculated = false) {
         this.atRestTotal = atRestTotal;
         this.atRestTotalBytes = atRestTotalBytes;
         this.intervalStart = intervalStart;
+        this.calculated = calculated;
     }
 
     /**
@@ -149,7 +151,7 @@ export class Stamp {
         now.setUTCDate(date);
         now.setUTCHours(0, 0, 0, 0);
 
-        return new Stamp(0, 0, now);
+        return new Stamp(0, Number.NaN, now, true);
     }
 }
 
@@ -386,7 +388,7 @@ export class SatelliteByDayInfo {
         const bandwidthDailyJson = data.bandwidthDaily || [];
 
         this.storageDaily = storageDailyJson.map((stamp: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
-            return new Stamp(stamp.atRestTotal, stamp.atRestTotalBytes, new Date(stamp.intervalStart));
+            return new Stamp(stamp.atRestTotal, stamp.atRestTotalBytes, new Date(stamp.intervalStart), stamp.calculated);
         });
 
         this.bandwidthDaily = bandwidthDailyJson.map((bandwidth: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## What

- Recover missing daily storage usage points locally using the next valid
  satellite tally and its actual interval.
- Project unresolved trailing gaps from the last known storage rate.
- Mark locally calculated values in the dashboard graph.
- Calculate the storage component of estimated payouts from the same
  normalized graph.

## Why

Satellite storage usage averages can contain missing daily tallies. Treating
those entries as zero produces gaps in the dashboard and understates the
estimated storage payout.

This change affects only local dashboard values and payout estimates. It does
not modify raw satellite tallies, submitted orders, or actual payouts
calculated by satellites.

Forum discussion:
https://forum.storj.io/t/massive-estimated-payout-drop/

## Verification

- Raw `AtRestTotal` values remain unchanged.
- Aggregate normalized values equal the sum of per-satellite values.
- Storage payout estimates match the area under the normalized graph.
- Recovered and unresolved gaps were tested on a running storage node.

Tests:

- `go test ./storagenode/storageusage`
- `go test ./storagenode/payouts/estimatedpayouts`
- `go test ./storagenode/console/...`
- `go test ./storagenode/multinode/...`
- `npm run lint-ci`
- `npm run build`
