### PR TITLE
Point release v1.161.2

### DIFF
--- a/cmd/satellite/gc-bf.go
+++ b/cmd/satellite/gc-bf.go
@@ -69,6 +69,9 @@ func cmdGCBloomFilterRun(cmd *cobra.Command, args []string) (err error) {
 			PDEndpoints: safepoint.PDEndpoints,
 			ServiceID:   safepoint.ServiceID,
 			TTL:         safepoint.TTL,
+			CAPath:      safepoint.CACertPath,
+			CertPath:    safepoint.CertPath,
+			KeyPath:     safepoint.KeyPath,
 		})
 		if holdErr != nil {
 			return errs.New("Error acquiring GC safepoint: %+v", holdErr)

--- a/satellite/metabase/rangedloop/service.go
+++ b/satellite/metabase/rangedloop/service.go
@@ -47,6 +47,13 @@ type SafepointConfig struct {
 	ServiceID   string        `help:"identifier prefix for the GC barrier/safepoint registered with PD" default:"storj-gc-bf"`
 	TTL         time.Duration `help:"the safepoint auto-expires this long after the last successful heartbeat" default:"1h"`
 	MaxDuration time.Duration `help:"abort the scan when the safepoint has been held longer than this" default:"48h"`
+
+	// PD requires client certificates on a cluster deployed with TLS between
+	// components, and the PD client only enables TLS when it has a certificate
+	// and key, so all three paths go together.
+	CACertPath string `help:"path to the CA certificate verifying PD; required together with cert-path and key-path when the TiDB cluster has TLS enabled" default:""`
+	CertPath   string `help:"path to the client certificate presented to PD" default:""`
+	KeyPath    string `help:"path to the client private key presented to PD" default:""`
 }
 
 // Enabled reports whether safepoint pinning is configured.

--- a/satellite/metabase/stats.go
+++ b/satellite/metabase/stats.go
@@ -97,28 +97,36 @@ func (c *CockroachAdapter) GetTableStats(ctx context.Context, opts GetTableStats
 // GetTableStats implements Adapter.
 func (t *TiDBAdapter) GetTableStats(ctx context.Context, opts GetTableStats) (result TableStats, err error) {
 	defer mon.Task()(&ctx)(&err)
-	// Prefer INFORMATION_SCHEMA.TABLES.TABLE_ROWS (a cached estimate set by
-	// ANALYZE, analogous to pg_stat_user_tables.n_live_tup on Postgres).
-	// Trust it only if UPDATE_TIME is recent — meaning the table has been
-	// modified within statsUpToDateThreshold, so TiDB's auto-analyze has
-	// likely kept the estimate close to reality. Otherwise (UPDATE_TIME
-	// missing or stale, or no cached row count), fall back to an exact
-	// COUNT(1) to match the Postgres/CockroachDB staleness contract.
+	// Read TiDB's persisted statistics from mysql.stats_meta directly, rather
+	// than INFORMATION_SCHEMA.TABLES.TABLE_ROWS/UPDATE_TIME. The latter is
+	// derived from the in-memory stats handle and reports UPDATE_TIME as NULL
+	// for a large, never-fully-analyzed table (pseudo stats), which would make
+	// the freshness check below never pass and force an exact COUNT(1) on
+	// billions of rows every time. mysql.stats_meta.count is the row-count
+	// estimate TiDB keeps continuously updated via background delta-dumping,
+	// and version is a TSO whose physical time tells us how fresh it is. Trust
+	// the estimate only if it is within statsUpToDateThreshold, otherwise fall
+	// back to an exact COUNT(1) to match the Postgres/CockroachDB contract.
+	//
+	// Note: reading mysql.stats_meta requires SELECT on the mysql schema for
+	// the connecting user.
 	var (
-		tableRows  sql.NullInt64
-		updateTime sql.NullTime
+		count      sql.NullInt64
+		ageSeconds sql.NullInt64
 	)
 	err = t.db.QueryRowContext(ctx, `
-		SELECT TABLE_ROWS, UPDATE_TIME
-		FROM INFORMATION_SCHEMA.TABLES
-		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'segments'
-	`).Scan(&tableRows, &updateTime)
+		SELECT sm.count,
+		       TIMESTAMPDIFF(SECOND, TIDB_PARSE_TSO(sm.version), NOW())
+		FROM mysql.stats_meta sm
+		JOIN INFORMATION_SCHEMA.TABLES it ON it.tidb_table_id = sm.table_id
+		WHERE it.table_schema = DATABASE() AND it.table_name = 'segments'
+	`).Scan(&count, &ageSeconds)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return TableStats{}, err
 	}
-	if tableRows.Valid && tableRows.Int64 > 0 &&
-		updateTime.Valid && time.Since(updateTime.Time) <= statsUpToDateThreshold {
-		result.SegmentCount = tableRows.Int64
+	if count.Valid && count.Int64 > 0 &&
+		ageSeconds.Valid && time.Duration(ageSeconds.Int64)*time.Second <= statsUpToDateThreshold {
+		result.SegmentCount = count.Int64
 		return result, nil
 	}
 	err = t.db.QueryRowContext(ctx, `SELECT COUNT(1) FROM segments`).Scan(&result.SegmentCount)

--- a/satellite/metabase/stats_test.go
+++ b/satellite/metabase/stats_test.go
@@ -91,7 +91,9 @@ func TestGetTableStats(t *testing.T) {
 					},
 				}.Check(ctx, t, db)
 			})
+		}
 
+		if db.Implementation() == dbutil.Cockroach || db.Implementation() == dbutil.TiDB {
 			t.Run("use statistics", func(t *testing.T) {
 				defer metabasetest.DeleteAll{}.Check(ctx, t, db)
 

--- a/satellite/satellite-config.yaml.lock
+++ b/satellite/satellite-config.yaml.lock
@@ -1908,6 +1908,15 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # how many chunks of segments to process in parallel
 # ranged-loop.parallelism: 2
 
+# path to the CA certificate verifying PD; required together with cert-path and key-path when the TiDB cluster has TLS enabled
+# ranged-loop.safepoint.ca-cert-path: ""
+
+# path to the client certificate presented to PD
+# ranged-loop.safepoint.cert-path: ""
+
+# path to the client private key presented to PD
+# ranged-loop.safepoint.key-path: ""
+
 # abort the scan when the safepoint has been held longer than this
 # ranged-loop.safepoint.max-duration: 48h0m0s
 

--- a/shared/dbutil/tidbutil/safepoint.go
+++ b/shared/dbutil/tidbutil/safepoint.go
@@ -45,6 +45,46 @@ type SafepointConfig struct {
 	// TTL is how long after the last successful heartbeat the safepoint
 	// auto-expires on the PD side.
 	TTL time.Duration
+
+	// CAPath, CertPath and KeyPath enable mTLS to PD. All three are required
+	// on a cluster deployed with TLS between components ("tiup cluster tls
+	// enable"): PD then advertises https client URLs and rejects plaintext
+	// connections, so a client built without them cannot connect at all.
+	CAPath   string
+	CertPath string
+	KeyPath  string
+}
+
+// securityOption converts the TLS paths into the PD client's security option.
+func (config SafepointConfig) securityOption() pd.SecurityOption {
+	return pd.SecurityOption{
+		CAPath:   config.CAPath,
+		CertPath: config.CertPath,
+		KeyPath:  config.KeyPath,
+	}
+}
+
+// validateTLS rejects a partially configured TLS setup.
+//
+// The PD client decides whether to use TLS from the certificate and key alone:
+// with both empty its TLS config is nil, it rewrites every endpoint to http and
+// ignores CAPath entirely. A CA-only configuration would therefore look
+// configured while connecting in plaintext, which against a TLS-enabled PD
+// surfaces only as an opaque connect timeout. Refuse it up front instead.
+func (config SafepointConfig) validateTLS() error {
+	switch {
+	case config.CertPath != "" && config.KeyPath != "":
+		if config.CAPath == "" {
+			return Error.New("safepoint TLS requires a CA path alongside the client certificate and key")
+		}
+	case config.CertPath != "" || config.KeyPath != "":
+		return Error.New("safepoint TLS requires both a client certificate and key (cert: %q, key: %q)",
+			config.CertPath, config.KeyPath)
+	case config.CAPath != "":
+		return Error.New("safepoint CA path %q is set without a client certificate and key; "+
+			"the PD client ignores the CA in that case and connects in plaintext", config.CAPath)
+	}
+	return nil
 }
 
 // pdClient is the subset of the PD client used by Holder.
@@ -103,6 +143,9 @@ func Hold(ctx context.Context, log *zap.Logger, config SafepointConfig) (_ *Hold
 		// scan would keep running unprotected. Refuse instead.
 		return nil, Error.New("safepoint TTL must be at least 1s, got %s", config.TTL)
 	}
+	if err := config.validateTLS(); err != nil {
+		return nil, err
+	}
 
 	// The PD client's background loops -- including the safepoint heartbeats --
 	// run off the context it is built with, so it has to outlive acquiring the
@@ -117,7 +160,7 @@ func Hold(ctx context.Context, log *zap.Logger, config SafepointConfig) (_ *Hold
 	acquireCtx, cancelAcquire := context.WithTimeout(ctx, acquireTimeout)
 	defer cancelAcquire()
 
-	client, err := connectPD(clientCtx, acquireCtx, config.PDEndpoints)
+	client, err := connectPD(clientCtx, acquireCtx, config)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +182,9 @@ func Hold(ctx context.Context, log *zap.Logger, config SafepointConfig) (_ *Hold
 // The timeout is the whole point: the PD client retries discovery until its
 // context ends and never returns an error of its own, so an unreachable PD
 // would otherwise leave the caller blocked forever rather than failing.
-func connectPD(clientCtx, acquireCtx context.Context, endpoints string) (pd.Client, error) {
+func connectPD(clientCtx, acquireCtx context.Context, config SafepointConfig) (pd.Client, error) {
+	endpoints := splitEndpoints(config.PDEndpoints)
+
 	type connected struct {
 		client pd.Client
 		err    error
@@ -149,7 +194,7 @@ func connectPD(clientCtx, acquireCtx context.Context, endpoints string) (pd.Clie
 	done := make(chan connected, 1)
 	go func() {
 		client, err := pd.NewClientWithContext(clientCtx, caller.Component("storj/gc-safepoint"),
-			strings.Split(endpoints, ","), pd.SecurityOption{})
+			endpoints, config.securityOption())
 		done <- connected{client, err}
 	}()
 
@@ -168,8 +213,23 @@ func connectPD(clientCtx, acquireCtx context.Context, endpoints string) (pd.Clie
 				result.client.Close()
 			}
 		}()
-		return nil, Error.New("connecting to PD at %q: %w", endpoints, acquireCtx.Err())
+		return nil, Error.New("connecting to PD at %q: %w", config.PDEndpoints, acquireCtx.Err())
 	}
+}
+
+// splitEndpoints splits the comma-separated endpoint list, tolerating the
+// spaces that a list written by hand in a config file tends to pick up. The PD
+// client would otherwise treat " 10.0.0.2:2389" as a hostname and never reach
+// the second member.
+func splitEndpoints(endpoints string) []string {
+	parts := strings.Split(endpoints, ",")
+	trimmed := parts[:0]
+	for _, part := range parts {
+		if part = strings.TrimSpace(part); part != "" {
+			trimmed = append(trimmed, part)
+		}
+	}
+	return trimmed
 }
 
 // hold implements Hold on an already-connected client. Separated for testing.

--- a/shared/dbutil/tidbutil/safepoint_test.go
+++ b/shared/dbutil/tidbutil/safepoint_test.go
@@ -206,6 +206,51 @@ func TestHold_RejectsSubSecondTTL(t *testing.T) {
 	}
 }
 
+// TestHold_RejectsPartialTLS covers the configurations that would otherwise
+// dial PD in plaintext. The PD client turns TLS on only when it has both a
+// certificate and a key, so a CA-only config is silently insecure: against a
+// TLS-enabled PD it fails as a connect timeout an hour into debugging, and
+// against a plaintext PD it succeeds while looking like it verified something.
+func TestHold_RejectsPartialTLS(t *testing.T) {
+	ctx := testcontext.New(t)
+	defer ctx.Cleanup()
+
+	for _, tt := range []struct {
+		name   string
+		config SafepointConfig
+	}{
+		{"CA only", SafepointConfig{CAPath: "ca.crt"}},
+		{"cert without key", SafepointConfig{CAPath: "ca.crt", CertPath: "client.crt"}},
+		{"key without cert", SafepointConfig{CAPath: "ca.crt", KeyPath: "client.key"}},
+		{"cert and key without CA", SafepointConfig{CertPath: "client.crt", KeyPath: "client.key"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tt.config
+			config.PDEndpoints = "fake:2379"
+			config.ServiceID = "test"
+			config.TTL = time.Minute
+
+			// rejected before dialing, so no PD is needed
+			if _, err := Hold(ctx, zaptest.NewLogger(t), config); err == nil {
+				t.Fatal("expected Hold to refuse a partial TLS configuration")
+			}
+		})
+	}
+}
+
+func TestSplitEndpoints(t *testing.T) {
+	got := splitEndpoints(" 10.0.0.1:2389, 10.0.0.2:2389 ,,10.0.0.3:2389")
+	want := []string{"10.0.0.1:2389", "10.0.0.2:2389", "10.0.0.3:2389"}
+	if len(got) != len(want) {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	}
+}
+
 func TestHolder_RejectsAdvancedSafepoint(t *testing.T) {
 	ctx := testcontext.New(t)
 	defer ctx.Cleanup()


### PR DESCRIPTION
Cherry-picks onto `release-v1.161` for point release **v1.161.2**:

- `shared/dbutil/tidbutil: support PD mTLS for GC safepoints` (068780780237246d888f960a817f0ec003987c2c)
- `satellite/metabase: use persisted TiDB stats for segment count` (95aa1f77c242010b03af9e7ecc66c9d752280d74)

Both applied cleanly with no conflicts. Affected packages build successfully.