### PR TITLE
Point release v1.161.8

### DIFF
--- a/satellite/metabase/rangedloop/service.go
+++ b/satellite/metabase/rangedloop/service.go
@@ -40,7 +40,7 @@ type Config struct {
 // SafepointConfig configures pinning a TiKV GC safepoint so a run-once scan
 // reads a consistent snapshot of a TiDB metabase (see shared/dbutil/tidbutil).
 type SafepointConfig struct {
-	PDEndpoints string        `help:"PD endpoints per metabase backend in format 'backend_label=host:port,host:port' separated by semicolons (the label defaults to the backend's position in database-url); when set, gc-bf pins a TiKV GC safepoint on each and scans a consistent snapshot; requires run-once mode and a TiDB metabase" default:""`
+	PDEndpoints string        `help:"PD endpoints per TiDB cluster in format 'backend_label=host:port,host:port' separated by semicolons (the label defaults to the backend's position in database-url; join labels with '+' when backends share a cluster); when set, gc-bf pins a TiKV GC safepoint on each and scans a consistent snapshot; requires run-once mode and a TiDB metabase" default:""`
 	ServiceID   string        `help:"identifier prefix for the GC barrier/safepoint registered with PD" default:"storj-gc-bf"`
 	TTL         time.Duration `help:"the safepoint auto-expires this long after the last successful heartbeat" default:"1h"`
 	MaxDuration time.Duration `help:"abort the scan when the safepoint has been held longer than this" default:"48h"`
@@ -50,9 +50,9 @@ type SafepointConfig struct {
 	// and key, so all three paths go together. Each may be a single path shared
 	// by every cluster, or one labeled path per backend when the clusters do
 	// not share a certificate authority.
-	CACertPath string `help:"path to the CA certificate verifying PD; required together with cert-path and key-path when the TiDB cluster has TLS enabled; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons to give each backend its own" default:""`
-	CertPath   string `help:"path to the client certificate presented to PD; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons" default:""`
-	KeyPath    string `help:"path to the client private key presented to PD; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons" default:""`
+	CACertPath string `help:"path to the CA certificate verifying PD; required together with cert-path and key-path when the TiDB cluster has TLS enabled; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons (labels joined with '+') to give each backend its own" default:""`
+	CertPath   string `help:"path to the client certificate presented to PD; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons (labels joined with '+')" default:""`
+	KeyPath    string `help:"path to the client private key presented to PD; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons (labels joined with '+')" default:""`
 }
 
 // Enabled reports whether safepoint pinning is configured.

--- a/satellite/metabase/rangedloop/service.go
+++ b/satellite/metabase/rangedloop/service.go
@@ -47,10 +47,12 @@ type SafepointConfig struct {
 
 	// PD requires client certificates on a cluster deployed with TLS between
 	// components, and the PD client only enables TLS when it has a certificate
-	// and key, so all three paths go together.
-	CACertPath string `help:"path to the CA certificate verifying PD; required together with cert-path and key-path when the TiDB cluster has TLS enabled" default:""`
-	CertPath   string `help:"path to the client certificate presented to PD" default:""`
-	KeyPath    string `help:"path to the client private key presented to PD" default:""`
+	// and key, so all three paths go together. Each may be a single path shared
+	// by every cluster, or one labeled path per backend when the clusters do
+	// not share a certificate authority.
+	CACertPath string `help:"path to the CA certificate verifying PD; required together with cert-path and key-path when the TiDB cluster has TLS enabled; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons to give each backend its own" default:""`
+	CertPath   string `help:"path to the client certificate presented to PD; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons" default:""`
+	KeyPath    string `help:"path to the client private key presented to PD; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons" default:""`
 }
 
 // Enabled reports whether safepoint pinning is configured.

--- a/satellite/satellite-config.yaml.lock
+++ b/satellite/satellite-config.yaml.lock
@@ -1908,13 +1908,13 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # how many chunks of segments to process in parallel
 # ranged-loop.parallelism: 2
 
-# path to the CA certificate verifying PD; required together with cert-path and key-path when the TiDB cluster has TLS enabled
+# path to the CA certificate verifying PD; required together with cert-path and key-path when the TiDB cluster has TLS enabled; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons to give each backend its own
 # ranged-loop.safepoint.ca-cert-path: ""
 
-# path to the client certificate presented to PD
+# path to the client certificate presented to PD; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons
 # ranged-loop.safepoint.cert-path: ""
 
-# path to the client private key presented to PD
+# path to the client private key presented to PD; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons
 # ranged-loop.safepoint.key-path: ""
 
 # abort the scan when the safepoint has been held longer than this

--- a/satellite/satellite-config.yaml.lock
+++ b/satellite/satellite-config.yaml.lock
@@ -1908,19 +1908,19 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # how many chunks of segments to process in parallel
 # ranged-loop.parallelism: 2
 
-# path to the CA certificate verifying PD; required together with cert-path and key-path when the TiDB cluster has TLS enabled; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons to give each backend its own
+# path to the CA certificate verifying PD; required together with cert-path and key-path when the TiDB cluster has TLS enabled; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons (labels joined with '+') to give each backend its own
 # ranged-loop.safepoint.ca-cert-path: ""
 
-# path to the client certificate presented to PD; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons
+# path to the client certificate presented to PD; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons (labels joined with '+')
 # ranged-loop.safepoint.cert-path: ""
 
-# path to the client private key presented to PD; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons
+# path to the client private key presented to PD; a plain path applies to every backend, or use 'backend_label=path' entries separated by semicolons (labels joined with '+')
 # ranged-loop.safepoint.key-path: ""
 
 # abort the scan when the safepoint has been held longer than this
 # ranged-loop.safepoint.max-duration: 48h0m0s
 
-# PD endpoints per metabase backend in format 'backend_label=host:port,host:port' separated by semicolons (the label defaults to the backend's position in database-url); when set, gc-bf pins a TiKV GC safepoint on each and scans a consistent snapshot; requires run-once mode and a TiDB metabase
+# PD endpoints per TiDB cluster in format 'backend_label=host:port,host:port' separated by semicolons (the label defaults to the backend's position in database-url; join labels with '+' when backends share a cluster); when set, gc-bf pins a TiKV GC safepoint on each and scans a consistent snapshot; requires run-once mode and a TiDB metabase
 # ranged-loop.safepoint.pd-endpoints: ""
 
 # identifier prefix for the GC barrier/safepoint registered with PD

--- a/shared/dbutil/labeled.go
+++ b/shared/dbutil/labeled.go
@@ -17,6 +17,14 @@ type Labeled struct {
 	Value string
 }
 
+// LabeledGroup is one entry of a labeled list whose label may name more than
+// one thing at once, for a value that genuinely belongs to all of them -- the
+// PD endpoints of a cluster that backs several metabase backends, say.
+type LabeledGroup struct {
+	Labels []string
+	Value  string
+}
+
 // SplitLabeled splits a sep-separated list into labeled entries, tolerating the
 // spaces a list written by hand in a config file tends to pick up.
 //
@@ -27,7 +35,31 @@ type Labeled struct {
 // a ":" belongs to the value -- a query parameter of a connection string, say
 // -- rather than introducing a label.
 func SplitLabeled(list, sep string) ([]Labeled, error) {
-	var entries []Labeled
+	groups, err := SplitLabeledGroups(list, sep, "")
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]Labeled, 0, len(groups))
+	for _, group := range groups {
+		entries = append(entries, Labeled{Label: group.Labels[0], Value: group.Value})
+	}
+	return entries, nil
+}
+
+// SplitLabeledGroups splits a sep-separated list the way SplitLabeled does,
+// additionally letting one entry carry several labels joined by groupSep:
+//
+//	west+south=pd-w1:2379,pd-w2:2379;east=pd-e1:2379
+//
+// which says the value belongs to all of them rather than repeating it once per
+// label. Repetition would say something different -- two entries are two things
+// that merely look alike -- and callers that act on the thing behind the value
+// would then act on it twice. An empty groupSep disables grouping, so every
+// entry carries exactly one label.
+//
+// Labels stay unique across the whole list, grouped or not.
+func SplitLabeledGroups(list, sep, groupSep string) ([]LabeledGroup, error) {
+	var entries []LabeledGroup
 	seen := map[string]bool{}
 	for _, entry := range strings.Split(list, sep) {
 		entry = strings.TrimSpace(entry)
@@ -35,30 +67,47 @@ func SplitLabeled(list, sep string) ([]Labeled, error) {
 			continue
 		}
 
-		labeled := Labeled{Label: strconv.Itoa(len(entries)), Value: entry}
+		group := LabeledGroup{Labels: []string{strconv.Itoa(len(entries))}, Value: entry}
 		if eq := strings.Index(entry, "="); eq >= 0 {
 			if colon := strings.Index(entry, ":"); colon < 0 || eq < colon {
-				labeled = Labeled{
-					Label: strings.TrimSpace(entry[:eq]),
-					Value: strings.TrimSpace(entry[eq+1:]),
+				group = LabeledGroup{
+					Labels: splitLabels(entry[:eq], groupSep),
+					Value:  strings.TrimSpace(entry[eq+1:]),
 				}
 			}
 		}
 
-		if labeled.Label == "" || labeled.Value == "" {
+		if group.Value == "" {
 			return nil, errs.New("entry %q has an empty label or value", entry)
 		}
-		if !ValidLabel(labeled.Label) {
-			return nil, errs.New("label %q must consist of letters, digits, '-' or '_'", labeled.Label)
+		for _, label := range group.Labels {
+			if label == "" {
+				return nil, errs.New("entry %q has an empty label or value", entry)
+			}
+			if !ValidLabel(label) {
+				return nil, errs.New("label %q must consist of letters, digits, '-' or '_'", label)
+			}
+			if seen[label] {
+				return nil, errs.New("duplicate label %q", label)
+			}
+			seen[label] = true
 		}
-		if seen[labeled.Label] {
-			return nil, errs.New("duplicate label %q", labeled.Label)
-		}
-		seen[labeled.Label] = true
 
-		entries = append(entries, labeled)
+		entries = append(entries, group)
 	}
 	return entries, nil
+}
+
+// splitLabels splits the label part of an entry into the labels it names.
+func splitLabels(labels, groupSep string) []string {
+	if groupSep == "" {
+		return []string{strings.TrimSpace(labels)}
+	}
+	parts := strings.Split(labels, groupSep)
+	for i, part := range parts {
+		parts[i] = strings.TrimSpace(part)
+	}
+	return parts
 }
 
 // ValidLabel reports whether a label is safe to name a backend with elsewhere.

--- a/shared/dbutil/labeled_test.go
+++ b/shared/dbutil/labeled_test.go
@@ -86,3 +86,72 @@ func TestSplitLabeled(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitLabeledGroups(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		list     string
+		sep      string
+		groupSep string
+		want     []dbutil.LabeledGroup
+		wantErr  bool
+	}{
+		{
+			name:     "one entry may name several labels",
+			list:     "west=pd-a:2379;east+south=pd-c:2379",
+			sep:      ";",
+			groupSep: "+",
+			want: []dbutil.LabeledGroup{
+				{Labels: []string{"west"}, Value: "pd-a:2379"},
+				{Labels: []string{"east", "south"}, Value: "pd-c:2379"},
+			},
+		}, {
+			name:     "grouped labels tolerate spaces",
+			list:     " 1 + 2 = pd-a:2379,pd-b:2379 ",
+			sep:      ";",
+			groupSep: "+",
+			want: []dbutil.LabeledGroup{
+				{Labels: []string{"1", "2"}, Value: "pd-a:2379,pd-b:2379"},
+			},
+		}, {
+			// grouping does not change what an unlabeled list means
+			name:     "unlabeled entries keep their position as label",
+			list:     "pd-a:2379;pd-b:2379",
+			sep:      ";",
+			groupSep: "+",
+			want: []dbutil.LabeledGroup{
+				{Labels: []string{"0"}, Value: "pd-a:2379"},
+				{Labels: []string{"1"}, Value: "pd-b:2379"},
+			},
+		}, {
+			name:     "labels stay unique across groups",
+			list:     "west+east=pd-a:2379;east=pd-c:2379",
+			sep:      ";",
+			groupSep: "+",
+			wantErr:  true,
+		}, {
+			name:     "an empty label in a group is refused",
+			list:     "west+=pd-a:2379",
+			sep:      ";",
+			groupSep: "+",
+			wantErr:  true,
+		}, {
+			// without a group separator the whole label is one label, and "+"
+			// is not a character a label may carry
+			name:    "grouping is off by default",
+			list:    "west+east=pd-a:2379",
+			sep:     ";",
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := dbutil.SplitLabeledGroups(tt.list, tt.sep, tt.groupSep)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/shared/dbutil/tidbutil/safepoint.go
+++ b/shared/dbutil/tidbutil/safepoint.go
@@ -6,6 +6,7 @@ package tidbutil
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -68,18 +69,89 @@ type SafepointConfig struct {
 	// on a cluster deployed with TLS between components ("tiup cluster tls
 	// enable"): PD then advertises https client URLs and rejects plaintext
 	// connections, so a client built without them cannot connect at all.
+	//
+	// Isolated clusters may each have their own certificate authority, so each
+	// of the three may also be a labeled, semicolon-separated list in the same
+	// form as PDEndpoints, naming exactly the same backends:
+	//
+	//	west=/certs/west/ca.crt;east=/certs/east/ca.crt
+	//
+	// A plain path is shared by every cluster, which is the usual case of one
+	// deployment-wide CA. The three are resolved independently, so a shared CA
+	// combines with per-cluster client certificates.
 	CAPath   string
 	CertPath string
 	KeyPath  string
 }
 
-// securityOption converts the TLS paths into the PD client's security option.
-func (config SafepointConfig) securityOption() pd.SecurityOption {
-	return pd.SecurityOption{
-		CAPath:   config.CAPath,
-		CertPath: config.CertPath,
-		KeyPath:  config.KeyPath,
+// securityOptions resolves the TLS paths into one PD security option per
+// cluster, keyed by backend label.
+func (config SafepointConfig) securityOptions(labels []string) (map[string]pd.SecurityOption, error) {
+	ca, err := resolvePaths("ca-cert-path", config.CAPath, labels)
+	if err != nil {
+		return nil, err
 	}
+	cert, err := resolvePaths("cert-path", config.CertPath, labels)
+	if err != nil {
+		return nil, err
+	}
+	key, err := resolvePaths("key-path", config.KeyPath, labels)
+	if err != nil {
+		return nil, err
+	}
+
+	options := make(map[string]pd.SecurityOption, len(labels))
+	for _, label := range labels {
+		option := pd.SecurityOption{
+			CAPath:   ca[label],
+			CertPath: cert[label],
+			KeyPath:  key[label],
+		}
+		if err := validateTLS(option); err != nil {
+			return nil, Error.New("backend %q: %w", label, err)
+		}
+		options[label] = option
+	}
+	return options, nil
+}
+
+// resolvePaths spreads one TLS path setting over the clusters.
+//
+// A plain path -- no label, no separator -- belongs to all of them. Anything
+// else is a labeled list that has to name the backends exactly: a cluster
+// missing from it would be dialed without the material the setting was meant
+// to give it, in plaintext, which is the failure validateTLS exists to keep
+// from happening silently.
+func resolvePaths(name, value string, labels []string) (map[string]string, error) {
+	paths := make(map[string]string, len(labels))
+
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return paths, nil
+	}
+	if !strings.ContainsAny(value, "=;") {
+		for _, label := range labels {
+			paths[label] = value
+		}
+		return paths, nil
+	}
+
+	entries, err := dbutil.SplitLabeled(value, ";")
+	if err != nil {
+		return nil, Error.New("parsing safepoint %s: %w", name, err)
+	}
+	for _, entry := range entries {
+		if !slices.Contains(labels, entry.Label) {
+			return nil, Error.New("safepoint %s names %q, which is not a configured backend", name, entry.Label)
+		}
+		paths[entry.Label] = entry.Value
+	}
+	for _, label := range labels {
+		if _, ok := paths[label]; !ok {
+			return nil, Error.New("safepoint %s has no entry for backend %q", name, label)
+		}
+	}
+	return paths, nil
 }
 
 // validateTLS rejects a partially configured TLS setup.
@@ -89,18 +161,18 @@ func (config SafepointConfig) securityOption() pd.SecurityOption {
 // ignores CAPath entirely. A CA-only configuration would therefore look
 // configured while connecting in plaintext, which against a TLS-enabled PD
 // surfaces only as an opaque connect timeout. Refuse it up front instead.
-func (config SafepointConfig) validateTLS() error {
+func validateTLS(security pd.SecurityOption) error {
 	switch {
-	case config.CertPath != "" && config.KeyPath != "":
-		if config.CAPath == "" {
+	case security.CertPath != "" && security.KeyPath != "":
+		if security.CAPath == "" {
 			return Error.New("safepoint TLS requires a CA path alongside the client certificate and key")
 		}
-	case config.CertPath != "" || config.KeyPath != "":
+	case security.CertPath != "" || security.KeyPath != "":
 		return Error.New("safepoint TLS requires both a client certificate and key (cert: %q, key: %q)",
-			config.CertPath, config.KeyPath)
-	case config.CAPath != "":
+			security.CertPath, security.KeyPath)
+	case security.CAPath != "":
 		return Error.New("safepoint CA path %q is set without a client certificate and key; "+
-			"the PD client ignores the CA in that case and connects in plaintext", config.CAPath)
+			"the PD client ignores the CA in that case and connects in plaintext", security.CAPath)
 	}
 	return nil
 }
@@ -171,10 +243,19 @@ func Hold(ctx context.Context, log *zap.Logger, config SafepointConfig) (_ Holds
 		return nil, err
 	}
 
+	labels := make([]string, 0, len(clusters))
+	for _, cluster := range clusters {
+		labels = append(labels, cluster.Label)
+	}
+	security, err := config.securityOptions(labels)
+	if err != nil {
+		return nil, err
+	}
+
 	holds := Holds{}
 	for _, cluster := range clusters {
 		log := log.With(zap.String("backend", cluster.Label), zap.String("pd_endpoints", cluster.Value))
-		holder, err := holdCluster(ctx, log, config, cluster.Value)
+		holder, err := holdCluster(ctx, log, config, cluster.Value, security[cluster.Label])
 		if err != nil {
 			return nil, errs.Combine(err, holds.release(ctx))
 		}
@@ -309,11 +390,11 @@ func (config SafepointConfig) validate() error {
 		// scan would keep running unprotected. Refuse instead.
 		return Error.New("safepoint TTL must be at least 1s, got %s", config.TTL)
 	}
-	return config.validateTLS()
+	return nil
 }
 
 // holdCluster takes the hold on a single cluster.
-func holdCluster(ctx context.Context, log *zap.Logger, config SafepointConfig, endpoints string) (_ *Holder, err error) {
+func holdCluster(ctx context.Context, log *zap.Logger, config SafepointConfig, endpoints string, security pd.SecurityOption) (_ *Holder, err error) {
 	// The PD client's background loops -- including the safepoint heartbeats --
 	// run off the context it is built with, so it has to outlive acquiring the
 	// hold and is torn down by Release instead. Only acquisition is bounded.
@@ -327,7 +408,7 @@ func holdCluster(ctx context.Context, log *zap.Logger, config SafepointConfig, e
 	acquireCtx, cancelAcquire := context.WithTimeout(ctx, acquireTimeout)
 	defer cancelAcquire()
 
-	client, err := connectPD(clientCtx, acquireCtx, config, endpoints)
+	client, err := connectPD(clientCtx, acquireCtx, security, endpoints)
 	if err != nil {
 		return nil, err
 	}
@@ -349,7 +430,7 @@ func holdCluster(ctx context.Context, log *zap.Logger, config SafepointConfig, e
 // The timeout is the whole point: the PD client retries discovery until its
 // context ends and never returns an error of its own, so an unreachable PD
 // would otherwise leave the caller blocked forever rather than failing.
-func connectPD(clientCtx, acquireCtx context.Context, config SafepointConfig, endpoints string) (pd.Client, error) {
+func connectPD(clientCtx, acquireCtx context.Context, security pd.SecurityOption, endpoints string) (pd.Client, error) {
 	type connected struct {
 		client pd.Client
 		err    error
@@ -359,7 +440,7 @@ func connectPD(clientCtx, acquireCtx context.Context, config SafepointConfig, en
 	done := make(chan connected, 1)
 	go func() {
 		client, err := pd.NewClientWithContext(clientCtx, caller.Component("storj/gc-safepoint"),
-			splitEndpoints(endpoints, ","), config.securityOption())
+			splitEndpoints(endpoints, ","), security)
 		done <- connected{client, err}
 	}()
 

--- a/shared/dbutil/tidbutil/safepoint.go
+++ b/shared/dbutil/tidbutil/safepoint.go
@@ -42,6 +42,8 @@ const acquireTimeout = time.Minute
 // through. Whatever is not removed expires with its TTL.
 const releaseTimeout = 30 * time.Second
 
+const groupSeparator = "+"
+
 // SafepointConfig configures pinning a TiKV GC safepoint for the duration of a
 // consistent scan.
 type SafepointConfig struct {
@@ -57,6 +59,16 @@ type SafepointConfig struct {
 	//
 	// Without a label an entry takes its position as one, which is also the
 	// default label of a backend, so a single unlabeled list keeps working.
+	//
+	// Backends do not have to be on a cluster each -- a metabase may keep two
+	// of them in separate schemas of one cluster -- and such backends share a
+	// single entry, their labels joined by "+":
+	//
+	//	west=pd-w1:2379;east+south=pd-e1:2379
+	//
+	// One entry is one cluster and takes one hold, which is what covers those
+	// backends. Repeating the endpoints under a label each would instead claim
+	// they are separate clusters, and is refused for it.
 	PDEndpoints string
 	// ServiceID is the identifier prefix for the GC barrier/safepoint
 	// registered with PD; a unique per-run suffix is appended.
@@ -72,13 +84,18 @@ type SafepointConfig struct {
 	//
 	// Isolated clusters may each have their own certificate authority, so each
 	// of the three may also be a labeled, semicolon-separated list in the same
-	// form as PDEndpoints, naming exactly the same backends:
+	// form as PDEndpoints, naming exactly the same backends and joining with
+	// "+" the ones that share an entry there:
 	//
-	//	west=/certs/west/ca.crt;east=/certs/east/ca.crt
+	//	west=/certs/west/ca.crt;east+south=/certs/east/ca.crt
 	//
 	// A plain path is shared by every cluster, which is the usual case of one
 	// deployment-wide CA. The three are resolved independently, so a shared CA
 	// combines with per-cluster client certificates.
+	//
+	// Grouping here need not follow PDEndpoints: this is only a way to spell
+	// the same path once for several backends, and backends that do share a
+	// cluster are checked afterwards to have ended up with the same material.
 	CAPath   string
 	CertPath string
 	KeyPath  string
@@ -136,15 +153,17 @@ func resolvePaths(name, value string, labels []string) (map[string]string, error
 		return paths, nil
 	}
 
-	entries, err := dbutil.SplitLabeled(value, ";")
+	entries, err := dbutil.SplitLabeledGroups(value, ";", groupSeparator)
 	if err != nil {
 		return nil, Error.New("parsing safepoint %s: %w", name, err)
 	}
 	for _, entry := range entries {
-		if !slices.Contains(labels, entry.Label) {
-			return nil, Error.New("safepoint %s names %q, which is not a configured backend", name, entry.Label)
+		for _, label := range entry.Labels {
+			if !slices.Contains(labels, label) {
+				return nil, Error.New("safepoint %s names %q, which is not a configured backend", name, label)
+			}
+			paths[label] = entry.Value
 		}
-		paths[entry.Label] = entry.Value
 	}
 	for _, label := range labels {
 		if _, ok := paths[label]; !ok {
@@ -225,27 +244,62 @@ type Holder struct {
 // metabase backend it serves. A metabase may be spread over several isolated
 // TiDB clusters, each with its own PD, and a scan is only consistent if all of
 // them are pinned.
+//
+// Backends sharing a cluster share the one hold on it, so several labels may
+// map to the same Holder. Anything acting on the cluster rather than on the
+// backend has to do so once per Holder: see clusters.
 type Holds map[string]*Holder
+
+// cluster is one hold together with the backends it covers.
+type cluster struct {
+	labels []string
+	holder *Holder
+}
+
+// name renders the backends the cluster covers the way PDEndpoints spells them.
+func (c cluster) name() string { return strings.Join(c.labels, groupSeparator) }
+
+// clusters returns each distinct hold once, with the backends it covers, sorted
+// by backend.
+//
+// Ranging over Holds itself visits a shared hold once per backend, which for
+// anything acting on the cluster -- releasing it, watching it, asking PD who it
+// is -- means doing it as many times as there are backends on it. Releasing
+// twice is the sharp end: the second call deletes a barrier that is already
+// gone and closes a client that is already closed.
+func (holds Holds) clusters() []cluster {
+	byHolder := make(map[*Holder][]string, len(holds))
+	for label, holder := range holds {
+		byHolder[holder] = append(byHolder[holder], label)
+	}
+	clusters := make([]cluster, 0, len(byHolder))
+	for holder, labels := range byHolder {
+		sort.Strings(labels)
+		clusters = append(clusters, cluster{labels: labels, holder: holder})
+	}
+	sort.Slice(clusters, func(i, j int) bool { return clusters[i].labels[0] < clusters[j].labels[0] })
+	return clusters
+}
 
 // Hold connects to every configured PD, registers a GC safepoint at each
 // cluster's current timestamp and starts heartbeating them. Callers must call
 // Release when the scan is done; if the process dies, the safepoints expire
 // after TTL.
 func Hold(ctx context.Context, log *zap.Logger, config SafepointConfig) (_ Holds, err error) {
-	clusters, err := dbutil.SplitLabeled(config.PDEndpoints, ";")
+	entries, err := dbutil.SplitLabeledGroups(config.PDEndpoints, ";", groupSeparator)
 	if err != nil {
 		return nil, Error.New("parsing PD endpoints: %w", err)
 	}
-	if len(clusters) == 0 {
+	if len(entries) == 0 {
 		return nil, Error.New("PD endpoints are not configured")
 	}
 	if err := config.validate(); err != nil {
 		return nil, err
 	}
 
-	labels := make([]string, 0, len(clusters))
-	for _, cluster := range clusters {
-		labels = append(labels, cluster.Label)
+	var labels []string
+	for _, entry := range entries {
+		labels = append(labels, entry.Labels...)
 	}
 	security, err := config.securityOptions(labels)
 	if err != nil {
@@ -253,13 +307,21 @@ func Hold(ctx context.Context, log *zap.Logger, config SafepointConfig) (_ Holds
 	}
 
 	holds := Holds{}
-	for _, cluster := range clusters {
-		log := log.With(zap.String("backend", cluster.Label), zap.String("pd_endpoints", cluster.Value))
-		holder, err := holdCluster(ctx, log, config, cluster.Value, security[cluster.Label])
+	for _, entry := range entries {
+		name := strings.Join(entry.Labels, groupSeparator)
+		option, err := sharedSecurity(name, entry.Labels, security)
 		if err != nil {
 			return nil, errs.Combine(err, holds.release(ctx))
 		}
-		holds[cluster.Label] = holder
+
+		log := log.With(zap.String("backends", name), zap.String("pd_endpoints", entry.Value))
+		holder, err := holdCluster(ctx, log, config, entry.Value, option)
+		if err != nil {
+			return nil, errs.Combine(err, holds.release(ctx))
+		}
+		for _, label := range entry.Labels {
+			holds[label] = holder
+		}
 	}
 
 	if err := holds.verifyDistinctClusters(ctx); err != nil {
@@ -271,22 +333,48 @@ func Hold(ctx context.Context, log *zap.Logger, config SafepointConfig) (_ Holds
 	return holds, nil
 }
 
-// verifyDistinctClusters rejects two labels pointing at the same cluster.
+// sharedSecurity returns the TLS material for a cluster its backends agree on.
+//
+// Backends sharing a cluster are dialed once, so they cannot be dialed with
+// different certificates; asking for that says one of the two settings is not
+// what the operator thinks it is, and picking either would quietly ignore the
+// other.
+func sharedSecurity(name string, labels []string, security map[string]pd.SecurityOption) (pd.SecurityOption, error) {
+	// compared field by field: SecurityOption also carries the inline PEM
+	// alternatives, which are never set here and are not comparable anyway
+	option := security[labels[0]]
+	for _, label := range labels[1:] {
+		other := security[label]
+		if other.CAPath != option.CAPath || other.CertPath != option.CertPath || other.KeyPath != option.KeyPath {
+			return pd.SecurityOption{}, Error.New(
+				"backends %q share a cluster but are given different TLS material, and it is dialed once",
+				name)
+		}
+	}
+	return option, nil
+}
+
+// verifyDistinctClusters rejects two entries pointing at the same cluster.
 //
 // Every other check passes for "west=pd-w1:2379;east=pd-w1:2379" -- the labels
 // differ, and they match the metabase backends exactly -- while it takes two
 // barriers on west and leaves east unpinned, so the scan reads east live. That
 // is the data loss the safepoint exists to prevent, and without this it is
 // silent.
+//
+// Backends that really do share a cluster say so in one entry ("west+east=..."),
+// which is one hold and passes here; the point of the check is that sharing has
+// to be stated rather than inferred from endpoints that happen to match.
 func (holds Holds) verifyDistinctClusters(ctx context.Context) error {
 	byCluster := make(map[uint64]string, len(holds))
-	for label, holder := range holds {
-		clusterID := holder.client.GetClusterID(ctx)
+	for _, cluster := range holds.clusters() {
+		clusterID := cluster.holder.client.GetClusterID(ctx)
 		if other, ok := byCluster[clusterID]; ok {
-			return Error.New("backends %q and %q point at the same TiDB cluster %d, so one of them is left unpinned",
-				min(label, other), max(label, other), clusterID)
+			return Error.New("backends %q and %q point at the same TiDB cluster %d, so one of them is left unpinned; "+
+				"if they do share it, name them in one entry as %q",
+				cluster.name(), other, clusterID, other+"+"+cluster.name())
 		}
-		byCluster[clusterID] = label
+		byCluster[clusterID] = cluster.name()
 	}
 	return nil
 }
@@ -305,21 +393,22 @@ func (holds Holds) ReadTime() time.Time {
 }
 
 // ServiceIDs returns the identifier registered with each PD as
-// "backend=service-id", sorted by backend.
+// "backend=service-id", sorted by backend. Backends sharing a cluster share the
+// one identifier and are named together, the way PDEndpoints spells them.
 func (holds Holds) ServiceIDs() []string {
-	ids := make([]string, 0, len(holds))
-	for label, holder := range holds {
-		ids = append(ids, label+"="+holder.serviceID)
+	clusters := holds.clusters()
+	ids := make([]string, 0, len(clusters))
+	for _, cluster := range clusters {
+		ids = append(ids, cluster.name()+"="+cluster.holder.serviceID)
 	}
-	sort.Strings(ids)
 	return ids
 }
 
 // Context returns a context that is cancelled when any of the holds is lost or
 // the parent is done. Run the scan under this context.
 func (holds Holds) Context(parent context.Context) context.Context {
-	for _, holder := range holds {
-		parent = holder.Context(parent)
+	for _, cluster := range holds.clusters() {
+		parent = cluster.holder.Context(parent)
 	}
 	return parent
 }
@@ -328,8 +417,8 @@ func (holds Holds) Context(parent context.Context) context.Context {
 // remains the backstop for the ones that fail.
 func (holds Holds) Release(ctx context.Context) error {
 	var group errs.Group
-	for _, holder := range holds {
-		group.Add(holder.Release(ctx))
+	for _, cluster := range holds.clusters() {
+		group.Add(cluster.holder.Release(ctx))
 	}
 	return group.Err()
 }
@@ -350,8 +439,10 @@ func (holds Holds) release(ctx context.Context) error {
 // rejects a stale read of the future outright, so let the laggards catch up
 // here instead of failing the first query of the scan.
 func (holds Holds) alignReadTime(ctx context.Context) error {
-	if len(holds) < 2 {
-		// the only timestamp there is came from this cluster's own clock
+	clusters := holds.clusters()
+	if len(clusters) < 2 {
+		// the only timestamp there is came from this cluster's own clock, so
+		// there is nothing to catch up to -- however many backends sit on it
 		return nil
 	}
 
@@ -359,9 +450,9 @@ func (holds Holds) alignReadTime(ctx context.Context) error {
 	defer cancel()
 
 	readTime := holds.ReadTime()
-	for label, holder := range holds {
+	for _, cluster := range clusters {
 		for {
-			physical, _, err := holder.client.GetTS(ctx)
+			physical, _, err := cluster.holder.client.GetTS(ctx)
 			if err != nil {
 				return Error.New("getting cluster timestamp: %w", err)
 			}
@@ -369,12 +460,12 @@ func (holds Holds) alignReadTime(ctx context.Context) error {
 			if behind <= 0 {
 				break
 			}
-			holder.log.Info("waiting for the PD clock to reach the read timestamp",
+			cluster.holder.log.Info("waiting for the PD clock to reach the read timestamp",
 				zap.Time("read_timestamp", readTime), zap.Duration("behind", behind))
 
 			if !sync2.Sleep(ctx, min(behind, time.Second)) {
 				return Error.New("waiting for the PD clock of backend %q to reach %s: %w",
-					label, readTime, ctx.Err())
+					cluster.name(), readTime, ctx.Err())
 			}
 		}
 	}

--- a/shared/dbutil/tidbutil/safepoint_test.go
+++ b/shared/dbutil/tidbutil/safepoint_test.go
@@ -6,6 +6,7 @@ package tidbutil
 import (
 	"context"
 	"reflect"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -38,6 +39,7 @@ type fakePD struct {
 	legacy       map[string]uint64
 	minSafepoint uint64
 	closed       bool
+	closes       int // counts Close calls, so releasing one cluster twice is visible
 }
 
 // barrierSetCount reports how many times SetGCBarrier has been called.
@@ -88,6 +90,7 @@ func (f *fakePD) Close() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.closed = true
+	f.closes++
 }
 
 type fakeGCStates struct {
@@ -319,6 +322,44 @@ func TestSecurityOptions(t *testing.T) {
 	}
 }
 
+// TestSecurityOptions_GroupedLabels covers the metabase with more backends than
+// clusters: the backends sharing a cluster name their path once, the way they
+// name their PD endpoints once, rather than repeating it under a label each.
+func TestSecurityOptions_GroupedLabels(t *testing.T) {
+	// PD endpoints of the same shape: "west=...;east+south=..."
+	config := SafepointConfig{
+		CAPath:   "west=/certs/west/ca.crt;east+south=/certs/east/ca.crt",
+		CertPath: "/certs/client.crt",
+		KeyPath:  "/certs/client.key",
+	}
+	want := map[string]pd.SecurityOption{
+		"west":  {CAPath: "/certs/west/ca.crt", CertPath: "/certs/client.crt", KeyPath: "/certs/client.key"},
+		"east":  {CAPath: "/certs/east/ca.crt", CertPath: "/certs/client.crt", KeyPath: "/certs/client.key"},
+		"south": {CAPath: "/certs/east/ca.crt", CertPath: "/certs/client.crt", KeyPath: "/certs/client.key"},
+	}
+
+	got, err := config.securityOptions([]string{"west", "east", "south"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+
+	// a path carrying a "+" but no label is still one plain path for everyone
+	plain, err := SafepointConfig{
+		CAPath:   "/certs/a+b/ca.crt",
+		CertPath: "/certs/a+b/client.crt",
+		KeyPath:  "/certs/a+b/client.key",
+	}.securityOptions([]string{"west", "east"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plain["west"].CAPath != "/certs/a+b/ca.crt" {
+		t.Fatalf("CA path %q, want the path unsplit", plain["west"].CAPath)
+	}
+}
+
 // TestSecurityOptions_Invalid covers the labeled configurations that would
 // leave a cluster dialed with something other than what was intended for it.
 func TestSecurityOptions_Invalid(t *testing.T) {
@@ -346,6 +387,9 @@ func TestSecurityOptions_Invalid(t *testing.T) {
 		// a typo in a label would otherwise pass unnoticed as the case above
 		{"unknown backend", full(SafepointConfig{CAPath: "west=/certs/west/ca.crt;west2=/certs/east/ca.crt"})},
 		{"duplicate backend", full(SafepointConfig{CAPath: "west=/certs/west/ca.crt;west=/certs/east/ca.crt"})},
+		// a grouped entry is still a list of labels and every one of them counts
+		{"unknown backend in a group", full(SafepointConfig{CAPath: "west+west2=/certs/west/ca.crt;east=/certs/east/ca.crt"})},
+		{"duplicate backend across groups", full(SafepointConfig{CAPath: "west+east=/certs/west/ca.crt;east=/certs/east/ca.crt"})},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			if _, err := tt.config.securityOptions([]string{"west", "east"}); err == nil {
@@ -488,6 +532,121 @@ func TestHolds_RejectsSameClusterTwice(t *testing.T) {
 	east.clusterID = west.clusterID + 1
 	if err := holds.verifyDistinctClusters(ctx); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestHolds_SharedCluster covers backends that really do live on one cluster --
+// separate schemas of the same TiDB, which is how a metabase gets more backends
+// than there are clusters. One entry names them both, so there is one hold, and
+// everything acting on the cluster has to act on it once however many backends
+// point at it.
+func TestHolds_SharedCluster(t *testing.T) {
+	ctx := testcontext.New(t)
+	defer ctx.Cleanup()
+
+	log := zaptest.NewLogger(t)
+	now := time.Now().UnixMilli()
+
+	// "west=...;east+south=..." -- east and south are two schemas of one cluster
+	west, shared := newFakePD(now, 0), newFakePD(now, 0)
+	westHold, err := hold(ctx, log, west, SafepointConfig{ServiceID: "test", TTL: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sharedHold, err := hold(ctx, log, shared, SafepointConfig{ServiceID: "test", TTL: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	holds := Holds{"west": westHold, "east": sharedHold, "south": sharedHold}
+
+	// the shared cluster is one cluster, not two backends colliding on one
+	if err := holds.verifyDistinctClusters(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// both clocks read now, so there is nothing to wait for; the point is that
+	// three backends over two clusters still compares two clocks
+	if err := holds.alignReadTime(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := holds.ServiceIDs(), []string{
+		"east+south=" + sharedHold.ServiceID(), "west=" + westHold.ServiceID(),
+	}; !slices.Equal(got, want) {
+		t.Fatalf("service ids %v, want the shared cluster named once as %v", got, want)
+	}
+
+	if err := holds.Release(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for name, fake := range map[string]*fakePD{"west": west, "east+south": shared} {
+		fake.mu.Lock()
+		barriers, closes := len(fake.barriers), fake.closes
+		fake.mu.Unlock()
+		if barriers != 0 {
+			t.Fatalf("hold on %q not released: %d barriers left", name, barriers)
+		}
+		// releasing the shared cluster once per backend would delete a barrier
+		// that is already gone and close a client that is already closed
+		if closes != 1 {
+			t.Fatalf("cluster %q closed %d times, want exactly once", name, closes)
+		}
+	}
+}
+
+// TestHolds_SharedClusterAlone covers the single cluster carrying every backend:
+// there is one clock, so there is nothing for the read timestamp to catch up to
+// even though the labels outnumber the clusters.
+func TestHolds_SharedClusterAlone(t *testing.T) {
+	ctx := testcontext.New(t)
+	defer ctx.Cleanup()
+
+	log := zaptest.NewLogger(t)
+
+	fake := newFakePD(time.Now().UnixMilli(), 0)
+	holder, err := hold(ctx, log, fake, SafepointConfig{ServiceID: "test", TTL: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	holds := Holds{"east": holder, "south": holder}
+	defer func() { _ = holds.Release(ctx) }()
+
+	// with a lagging clock this would be the one cluster waiting for itself
+	fake.mu.Lock()
+	fake.physical -= 300
+	fake.mu.Unlock()
+
+	aligned := make(chan error, 1)
+	go func() { aligned <- holds.alignReadTime(ctx) }()
+	select {
+	case err := <-aligned:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("alignReadTime waited for the only cluster to catch up with itself")
+	}
+}
+
+// TestSharedSecurity covers backends on one cluster given different TLS
+// material: the cluster is dialed once, so one of the two settings would be
+// silently ignored.
+func TestSharedSecurity(t *testing.T) {
+	security := map[string]pd.SecurityOption{
+		"east":  {CAPath: "/ca.crt", CertPath: "/east.crt", KeyPath: "/east.key"},
+		"south": {CAPath: "/ca.crt", CertPath: "/south.crt", KeyPath: "/south.key"},
+	}
+	if _, err := sharedSecurity("east+south", []string{"east", "south"}, security); err == nil {
+		t.Fatal("backends sharing a cluster were accepted with different certificates")
+	}
+
+	security["south"] = security["east"]
+	got, err := sharedSecurity("east+south", []string{"east", "south"}, security)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, security["east"]) {
+		t.Fatalf("security option %v, want %v", got, security["east"])
 	}
 }
 

--- a/shared/dbutil/tidbutil/safepoint_test.go
+++ b/shared/dbutil/tidbutil/safepoint_test.go
@@ -5,11 +5,13 @@ package tidbutil
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	pd "github.com/tikv/pd/client"
 	"github.com/tikv/pd/client/clients/gc"
 	"github.com/zeebo/errs"
 	"go.uber.org/zap/zaptest"
@@ -246,6 +248,108 @@ func TestHold_RejectsPartialTLS(t *testing.T) {
 			// rejected before dialing, so no PD is needed
 			if _, err := Hold(ctx, zaptest.NewLogger(t), config); err == nil {
 				t.Fatal("expected Hold to refuse a partial TLS configuration")
+			}
+		})
+	}
+}
+
+// TestSecurityOptions covers spreading the TLS paths over the clusters:
+// isolated clusters may each have their own certificate authority, while the
+// usual deployment has one for all of them.
+func TestSecurityOptions(t *testing.T) {
+	labels := []string{"west", "east"}
+
+	for _, tt := range []struct {
+		name   string
+		config SafepointConfig
+		want   map[string]pd.SecurityOption
+	}{
+		{
+			name:   "no TLS",
+			config: SafepointConfig{},
+			want: map[string]pd.SecurityOption{
+				"west": {},
+				"east": {},
+			},
+		},
+		{
+			name:   "shared by every cluster",
+			config: SafepointConfig{CAPath: "ca.crt", CertPath: "client.crt", KeyPath: "client.key"},
+			want: map[string]pd.SecurityOption{
+				"west": {CAPath: "ca.crt", CertPath: "client.crt", KeyPath: "client.key"},
+				"east": {CAPath: "ca.crt", CertPath: "client.crt", KeyPath: "client.key"},
+			},
+		},
+		{
+			name: "one certificate authority per cluster",
+			config: SafepointConfig{
+				CAPath:   "west=/certs/west/ca.crt; east=/certs/east/ca.crt",
+				CertPath: "west=/certs/west/client.crt;east=/certs/east/client.crt",
+				KeyPath:  "west=/certs/west/client.key;east=/certs/east/client.key",
+			},
+			want: map[string]pd.SecurityOption{
+				"west": {CAPath: "/certs/west/ca.crt", CertPath: "/certs/west/client.crt", KeyPath: "/certs/west/client.key"},
+				"east": {CAPath: "/certs/east/ca.crt", CertPath: "/certs/east/client.crt", KeyPath: "/certs/east/client.key"},
+			},
+		},
+		{
+			// the settings resolve independently, so one deployment-wide CA
+			// combines with a client certificate per cluster
+			name: "shared CA with per-cluster client certificates",
+			config: SafepointConfig{
+				CAPath:   "ca.crt",
+				CertPath: "west=/certs/west/client.crt;east=/certs/east/client.crt",
+				KeyPath:  "west=/certs/west/client.key;east=/certs/east/client.key",
+			},
+			want: map[string]pd.SecurityOption{
+				"west": {CAPath: "ca.crt", CertPath: "/certs/west/client.crt", KeyPath: "/certs/west/client.key"},
+				"east": {CAPath: "ca.crt", CertPath: "/certs/east/client.crt", KeyPath: "/certs/east/client.key"},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.config.securityOptions(labels)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSecurityOptions_Invalid covers the labeled configurations that would
+// leave a cluster dialed with something other than what was intended for it.
+func TestSecurityOptions_Invalid(t *testing.T) {
+	full := func(config SafepointConfig) SafepointConfig {
+		if config.CAPath == "" {
+			config.CAPath = "ca.crt"
+		}
+		if config.CertPath == "" {
+			config.CertPath = "client.crt"
+		}
+		if config.KeyPath == "" {
+			config.KeyPath = "client.key"
+		}
+		return config
+	}
+
+	for _, tt := range []struct {
+		name   string
+		config SafepointConfig
+	}{
+		// a cluster missing from a labeled list would be dialed in plaintext
+		{"backend missing from the CA list", full(SafepointConfig{CAPath: "west=/certs/west/ca.crt"})},
+		{"backend missing from the cert list", full(SafepointConfig{CertPath: "west=/certs/west/client.crt"})},
+		{"backend missing from the key list", full(SafepointConfig{KeyPath: "west=/certs/west/client.key"})},
+		// a typo in a label would otherwise pass unnoticed as the case above
+		{"unknown backend", full(SafepointConfig{CAPath: "west=/certs/west/ca.crt;west2=/certs/east/ca.crt"})},
+		{"duplicate backend", full(SafepointConfig{CAPath: "west=/certs/west/ca.crt;west=/certs/east/ca.crt"})},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.config.securityOptions([]string{"west", "east"}); err == nil {
+				t.Fatal("expected an error")
 			}
 		})
 	}


### PR DESCRIPTION
Cherry-picks onto `release-v1.161` for point release v1.161.8:

* `6f99ba3e84e1b73b4142cdf568fb5d8ec13c3b5c` shared/dbutil/tidbutil: allow a PD certificate per cluster
* `32e1eae4237394bcf4dcb51d79a60e7ad097257e` shared/dbutil/tidbutil: let backends share a TiDB cluster

Both applied cleanly with no conflicts.