### PR TITLE
Point release v1.161.9

### DIFF
--- a/satellite/metabase/loop.go
+++ b/satellite/metabase/loop.go
@@ -16,7 +16,12 @@ import (
 	"storj.io/storj/shared/tagsql"
 )
 
-const loopIteratorBatchSizeLimit = intLimitRange(50000)
+// MaxLoopIteratorBatchSize is the largest BatchSize IterateLoopSegments accepts.
+// Callers taking their batch size from configuration should cap it here, because
+// a larger one is rejected rather than clamped.
+const MaxLoopIteratorBatchSize = 50000
+
+const loopIteratorBatchSizeLimit = intLimitRange(MaxLoopIteratorBatchSize)
 
 // LoopSegmentEntry contains information about segment metadata needed by metainfo loop.
 type LoopSegmentEntry struct {
@@ -48,6 +53,10 @@ type LoopSegmentsIterator interface {
 
 // IterateLoopSegments contains arguments necessary for listing segments in metabase.
 type IterateLoopSegments struct {
+	// BatchSize is how many segments are read per query. Zero means
+	// MaxLoopIteratorBatchSize; anything above it is rejected rather than
+	// clamped, so a caller grouping entries by the size it asked for keeps
+	// pace with the pages the iterator hands out.
 	BatchSize          int
 	StartStreamID      uuid.UUID
 	EndStreamID        uuid.UUID
@@ -63,6 +72,12 @@ type IterateLoopSegments struct {
 func (opts *IterateLoopSegments) Verify() error {
 	if opts.BatchSize < 0 {
 		return ErrInvalidRequest.New("BatchSize is negative")
+	}
+	// Refuse to silently page at a smaller size than asked for: callers group the
+	// entries they receive by the size they requested, and the iterator's buffers
+	// are only safe to reuse once the page they belong to has been handed over.
+	if opts.BatchSize > MaxLoopIteratorBatchSize {
+		return ErrInvalidRequest.New("BatchSize is too large, maximum is %d", MaxLoopIteratorBatchSize)
 	}
 	if !opts.EndStreamID.IsZero() {
 		if opts.EndStreamID.Less(opts.StartStreamID) {
@@ -149,6 +164,7 @@ func tagsqlIterateLoopSegments(ctx context.Context, db tagsqlAdapter, aliasCache
 		readTimestamp:      opts.ReadTimestamp,
 		batchSize:          opts.BatchSize,
 		batchPieces:        make([]Pieces, opts.BatchSize),
+		batchAliasPieces:   make([]AliasPieces, opts.BatchSize),
 
 		curIndex: 0,
 		cursor: loopSegmentIteratorCursor{
@@ -192,8 +208,17 @@ type tagsqlLoopSegmentIterator struct {
 	aliasCache *NodeAliasCache
 
 	batchSize int
-	// batchPieces are reused between result pages to reduce memory consumption
-	batchPieces []Pieces
+	// batchPieces and batchAliasPieces are reused between result pages to reduce
+	// memory consumption. They are indexed by the position within the page so that
+	// every entry of a batch keeps its own storage: consumers are handed the whole
+	// batch at once, so sharing one buffer would leave every entry pointing at the
+	// last scanned row.
+	//
+	// Reuse between pages is only safe while a consumer's batch never spans two
+	// pages. Verify rejects a BatchSize above the limit rather than clamping it,
+	// so a consumer grouping by the size it requested pages in lockstep with us.
+	batchPieces      []Pieces
+	batchAliasPieces []AliasPieces
 
 	asOfSystemInterval time.Duration
 	readTimestamp      time.Time
@@ -288,6 +313,10 @@ func (it *tagsqlLoopSegmentIterator) doNextQuery(ctx context.Context) (_ tagsql.
 
 // scanItem scans doNextQuery results into LoopSegmentEntry.
 func (it *tagsqlLoopSegmentIterator) scanItem(ctx context.Context, item *LoopSegmentEntry) error {
+	// AliasPieces.SetBytes reuses the backing array when it has capacity, so scan into
+	// this position's own buffer rather than whatever the previous row left behind.
+	item.AliasPieces = it.batchAliasPieces[it.curIndex]
+
 	err := it.curRows.Scan(
 		&item.StreamID, &item.Position,
 		&item.CreatedAt, &item.ExpiresAt, &item.RepairedAt,
@@ -301,6 +330,8 @@ func (it *tagsqlLoopSegmentIterator) scanItem(ctx context.Context, item *LoopSeg
 	if err != nil {
 		return Error.New("failed to scan segments: %w", err)
 	}
+	// keep the grown buffer so the next page over this position can reuse it
+	it.batchAliasPieces[it.curIndex] = item.AliasPieces
 
 	// allocate new Pieces only if existing have not enough capacity
 	if cap(it.batchPieces[it.curIndex]) < len(item.AliasPieces) {

--- a/satellite/metabase/loop_test.go
+++ b/satellite/metabase/loop_test.go
@@ -13,6 +13,7 @@ import (
 
 	"storj.io/common/storj"
 	"storj.io/common/testcontext"
+	"storj.io/common/testrand"
 	"storj.io/common/uuid"
 	"storj.io/storj/satellite/metabase"
 	"storj.io/storj/satellite/metabase/metabasetest"
@@ -29,6 +30,21 @@ func TestIterateLoopSegments(t *testing.T) {
 				},
 				ErrClass: &metabase.ErrInvalidRequest,
 				ErrText:  "BatchSize is negative",
+			}.Check(ctx, t, db)
+			metabasetest.Verify{}.Check(ctx, t, db)
+		})
+
+		t.Run("Limit is too large", func(t *testing.T) {
+			defer metabasetest.DeleteAll{}.Check(ctx, t, db)
+			// rejected rather than clamped, so that a caller grouping the entries it
+			// receives by the size it asked for cannot end up with a group spanning
+			// two pages, whose earlier entries the iterator has already overwritten
+			metabasetest.IterateLoopSegments{
+				Opts: metabase.IterateLoopSegments{
+					BatchSize: 50001,
+				},
+				ErrClass: &metabase.ErrInvalidRequest,
+				ErrText:  "BatchSize is too large, maximum is 50000",
 			}.Check(ctx, t, db)
 			metabasetest.Verify{}.Check(ctx, t, db)
 		})
@@ -348,6 +364,84 @@ func TestIterateLoopSegments(t *testing.T) {
 				return nil
 			})
 			require.NoError(t, err)
+		})
+
+		t.Run("entries of a batch do not share AliasPieces", func(t *testing.T) {
+			defer metabasetest.DeleteAll{}.Check(ctx, t, db)
+
+			// AliasPieces.SetBytes reuses the backing array, so an iterator scanning
+			// every row into one entry used to hand out entries that all pointed at the
+			// last row's aliases. Consumers (the ranged loop's provider) collect a whole
+			// batch before processing it, so each entry must own its aliases.
+			const numberOfSegments = 5
+
+			obj := metabasetest.RandObjectStream()
+			metabasetest.CreateTestObject{
+				// give every segment its own storage node, hence its own alias
+				CreateSegment: func(object metabase.Object, index int) metabase.Segment {
+					pieces := metabase.Pieces{{Number: 0, StorageNode: testrand.NodeID()}}
+					position := metabase.SegmentPosition{Part: 0, Index: uint32(index)}
+
+					metabasetest.BeginSegment{
+						Opts: metabase.BeginSegment{
+							ObjectStream:        object.ObjectStream,
+							Position:            position,
+							RootPieceID:         storj.PieceID{byte(index + 1)},
+							Pieces:              pieces,
+							ObjectExistsChecked: true,
+						},
+					}.Check(ctx, t, db)
+
+					metabasetest.CommitSegment{
+						Opts: metabase.CommitSegment{
+							ObjectStream:      object.ObjectStream,
+							Position:          position,
+							RootPieceID:       storj.PieceID{1},
+							Pieces:            pieces,
+							EncryptedKey:      []byte{3},
+							EncryptedKeyNonce: []byte{4},
+							EncryptedETag:     []byte{5},
+							EncryptedChecksum: []byte{6},
+							EncryptedSize:     1024,
+							PlainSize:         512,
+							PlainOffset:       int64(index) * 512,
+							Redundancy:        metabasetest.DefaultRedundancy,
+						},
+					}.Check(ctx, t, db)
+
+					return metabase.Segment{}
+				},
+			}.Run(ctx, t, db, obj, numberOfSegments)
+
+			var entries []metabase.LoopSegmentEntry
+			err := db.IterateLoopSegments(ctx, metabase.IterateLoopSegments{
+				BatchSize: numberOfSegments,
+			}, func(ctx context.Context, lsi metabase.LoopSegmentsIterator) error {
+				var entry metabase.LoopSegmentEntry
+				for lsi.Next(ctx, &entry) {
+					entries = append(entries, entry)
+				}
+				return nil
+			})
+			require.NoError(t, err)
+			require.Len(t, entries, numberOfSegments)
+
+			aliasMap, err := db.LatestNodesAliasMap(ctx)
+			require.NoError(t, err)
+
+			seen := map[metabase.NodeAlias]bool{}
+			for _, entry := range entries {
+				require.Len(t, entry.AliasPieces, 1)
+				alias := entry.AliasPieces[0].Alias
+				require.False(t, seen[alias], "AliasPieces are shared between entries of a batch")
+				seen[alias] = true
+
+				// and they must still describe the same node as the converted pieces
+				require.Len(t, entry.Pieces, 1)
+				id, ok := aliasMap.Node(alias)
+				require.True(t, ok)
+				require.Equal(t, entry.Pieces[0].StorageNode, id)
+			}
 		})
 
 		t.Run("batch size", func(t *testing.T) {

--- a/satellite/metabase/rangedloop/providerdb.go
+++ b/satellite/metabase/rangedloop/providerdb.go
@@ -55,6 +55,20 @@ func (provider *MetabaseRangeSplitter) CreateRanges(ctx context.Context, nRanges
 		return nil, err
 	}
 
+	// batchSize comes from operator configuration, while the iterator rejects
+	// anything above its maximum. Cap it here so that a misconfigured satellite
+	// keeps making progress instead of failing every run, and so that the size we
+	// group the entries by stays the size the iterator really pages at: the
+	// iterator recycles its buffers once a page has been handed over, and a group
+	// spanning two pages would carry entries it has already overwritten.
+	if batchSize > metabase.MaxLoopIteratorBatchSize {
+		provider.log.Warn("configured batch size is above the maximum, using the maximum instead",
+			zap.Int("configured", batchSize),
+			zap.Int("batch_size", metabase.MaxLoopIteratorBatchSize),
+		)
+		batchSize = metabase.MaxLoopIteratorBatchSize
+	}
+
 	readTimestamp := provider.overrideReadTimestamp
 	if readTimestamp.IsZero() && provider.config.StaleInterval > 0 {
 		readTimestamp = time.Now().Add(-provider.config.StaleInterval)

--- a/satellite/metabase/rangedloop/providerdb_test.go
+++ b/satellite/metabase/rangedloop/providerdb_test.go
@@ -75,6 +75,22 @@ func TestMetabaseSegementProvider(t *testing.T) {
 				},
 			},
 			{
+				// a batch size above the iterator's maximum is capped rather than
+				// rejected, so a misconfigured satellite keeps making progress
+				in: in{
+					streamIDs: []string{
+						"00000000-0000-0000-0000-000000000001",
+						"00000000-0000-0000-0000-000000000002",
+					},
+					nRanges:   1,
+					batchSize: metabase.MaxLoopIteratorBatchSize + 1,
+				},
+				expected: expected{
+					nBatches:  1,
+					nSegments: 2,
+				},
+			},
+			{
 				in: in{
 					streamIDs: []string{
 						"00000000-0000-0000-0000-000000000001",

--- a/satellite/metabase/rangedloop/service.go
+++ b/satellite/metabase/rangedloop/service.go
@@ -28,7 +28,7 @@ var (
 // Config contains configurable values for the shared loop.
 type Config struct {
 	Parallelism        int           `help:"how many chunks of segments to process in parallel" default:"2"`
-	BatchSize          int           `help:"how many items to query in a batch" default:"2500"`
+	BatchSize          int           `help:"how many items to query in a batch, capped at 50000" default:"2500"`
 	AsOfSystemInterval time.Duration `help:"as of system interval" releaseDefault:"-5m" devDefault:"-1us" testDefault:"-1us"`
 	Interval           time.Duration `help:"how often to run the loop" releaseDefault:"2h" devDefault:"10s" testDefault:"0"`
 	StaleInterval      time.Duration `help:"sets the fixed read timestamp as now()-interval" default:"0"`

--- a/satellite/satellite-config.yaml.lock
+++ b/satellite/satellite-config.yaml.lock
@@ -1899,7 +1899,7 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # as of system interval
 # ranged-loop.as-of-system-interval: -5m0s
 
-# how many items to query in a batch
+# how many items to query in a batch, capped at 50000
 # ranged-loop.batch-size: 2500
 
 # how often to run the loop


### PR DESCRIPTION
Cherry-pick 08b95ebae4bbf7d842ac114287109b87695fb5c8 (`satellite/metabase: give each batched loop entry its own AliasPieces`) onto `release-v1.161` for point release v1.161.9.