### PR TITLE
Point release v1.162.1-rc

### DIFF
--- a/satellite/console/accountfreezes.go
+++ b/satellite/console/accountfreezes.go
@@ -81,7 +81,11 @@ type EventWithUser struct {
 // GetEscalatedEventsBeforeParams contains parameters for the
 // GetEscalatedEventsBefore method.
 type GetEscalatedEventsBeforeParams struct {
-	Limit      int
+	Limit int
+	// Offset is the number of leading rows to skip, ordered by status_updated_at ascending.
+	// Callers that do not delete every returned event (e.g. because data is retained) must advance
+	// the offset past the retained events, otherwise the same events are returned on every call.
+	Offset     int
 	EventTypes []EventTypeAndTime
 }
 

--- a/satellite/console/dbcleanup/pendingdelete/chore.go
+++ b/satellite/console/dbcleanup/pendingdelete/chore.go
@@ -49,10 +49,68 @@ type Config struct {
 	TrialFreeze     DeleteTypeConfig
 }
 
+// namedDeleteType pairs a delete type config with the name its flags are
+// registered under, so both can be reported together.
+type namedDeleteType struct {
+	name string
+	cfg  DeleteTypeConfig
+}
+
+// deleteTypes returns every delete type config for iteration.
+func (c Config) deleteTypes() []namedDeleteType {
+	return []namedDeleteType{
+		{"project", c.Project},
+		{"user", c.User},
+		{"violation-freeze", c.ViolationFreeze},
+		{"billing-freeze", c.BillingFreeze},
+		{"trial-freeze", c.TrialFreeze},
+	}
+}
+
+// Validate checks that the enabled delete type configurations are safe to run with.
+func (c Config) Validate() error {
+	for _, deleteType := range c.deleteTypes() {
+		if !deleteType.cfg.Enabled {
+			continue
+		}
+		// a buffer time longer than the lock buffer time would delete the data of
+		// buckets with object lock enabled before that of buckets without it.
+		if deleteType.cfg.BufferTime > deleteType.cfg.LockBufferTime {
+			return Error.New("%s: buffer-time (%s) must not be greater than lock-buffer-time (%s)",
+				deleteType.name, deleteType.cfg.BufferTime, deleteType.cfg.LockBufferTime)
+		}
+	}
+	return nil
+}
+
+// warnUnbufferedDeletes logs the enabled delete types whose data in buckets
+// without object lock is deleted as soon as the resource is picked up, leaving no
+// window to catch a resource that was marked for deletion by mistake.
+func warnUnbufferedDeletes(log *zap.Logger, config Config) {
+	for _, deleteType := range config.deleteTypes() {
+		if deleteType.cfg.Enabled && deleteType.cfg.BufferTime == 0 {
+			log.Warn("buffer time is zero, data in buckets without object lock is deleted as soon as the resource is picked up",
+				zap.String("delete_type", deleteType.name),
+			)
+		}
+	}
+}
+
 // DeleteTypeConfig holds configuration for a specific type of pending deletion data to delete.
 type DeleteTypeConfig struct {
-	Enabled    bool          `help:"whether data of this type of pending deletion resource should be deleted or not" default:"false"`
-	BufferTime time.Duration `help:"how long after the resource is marked for deletion should we wait before deleting data" default:"720h"`
+	Enabled        bool          `help:"whether data of this type of pending deletion resource should be deleted or not" default:"false"`
+	BufferTime     time.Duration `help:"how long after the resource is marked for deletion to wait before deleting data in buckets without object lock enabled" default:"0h"`
+	LockBufferTime time.Duration `help:"how long after the resource is marked for deletion to wait before deleting data in buckets with object lock enabled" default:"720h"`
+}
+
+// listBufferTime is the buffer time used when listing resources for deletion.
+// It is the earlier of the two thresholds so that a resource becomes visible as
+// soon as it has any data eligible for deletion.
+func (c DeleteTypeConfig) listBufferTime() time.Duration {
+	if c.BufferTime < c.LockBufferTime {
+		return c.BufferTime
+	}
+	return c.LockBufferTime
 }
 
 // Chore completes deletion of data for projects
@@ -83,6 +141,8 @@ func NewChore(log *zap.Logger, accounts payments.Accounts,
 	remainderChargeRecorder *accounting.RemainderChargeRecorder,
 	config Config,
 ) *Chore {
+	warnUnbufferedDeletes(log, config)
+
 	return &Chore{
 		log:    log,
 		config: config,
@@ -108,6 +168,10 @@ func (chore *Chore) Run(ctx context.Context) (err error) {
 
 	if !chore.config.Enabled {
 		return nil
+	}
+
+	if err := chore.config.Validate(); err != nil {
+		return err
 	}
 
 	return chore.Loop.Run(ctx, func(ctx context.Context) error {
@@ -155,12 +219,14 @@ func (chore *Chore) runDeleteProjects(ctx context.Context) (err error) {
 		mu.Unlock()
 	}
 
-	var skippedProjects, deletedProjects atomic.Int64
+	var skippedProjects, deletedProjects, retainedProjects atomic.Int64
+	cfg := chore.config.Project
+	var offset int64
 	hasNext := true
 	for hasNext {
 		idsPage, err := chore.store.Projects().ListPendingDeletionBefore(
-			ctx, 0, // always on offset 0 because updating project status removes it from the list
-			chore.config.ListLimit, chore.nowFn().Add(-chore.config.Project.BufferTime),
+			ctx, offset,
+			chore.config.ListLimit, chore.nowFn().Add(-cfg.listBufferTime()),
 		)
 		if err != nil {
 			chore.log.Error("failed to get projects for deletion",
@@ -173,6 +239,10 @@ func (chore *Chore) runDeleteProjects(ctx context.Context) (err error) {
 			break
 		}
 
+		// stayed counts resources still pending deletion after this batch (retained
+		// for object lock, or failed). The next page starts after them, since
+		// finalized resources leave the list but retained ones do not.
+		var stayed atomic.Int64
 		limiter := sync2.NewLimiter(chore.config.DeleteConcurrency)
 
 		for _, p := range idsPage.Ids {
@@ -187,6 +257,7 @@ func (chore *Chore) runDeleteProjects(ctx context.Context) (err error) {
 						zap.Error(err),
 					)
 					addErr(err)
+					stayed.Add(1)
 					return
 				}
 
@@ -200,37 +271,33 @@ func (chore *Chore) runDeleteProjects(ctx context.Context) (err error) {
 					return
 				}
 
-				// check if the project contains buckets with object lock enabled
-				count, err := chore.bucketsDB.CountObjectLockBuckets(ctx, project.ID)
+				deleteUnlocked, deleteLocked := chore.bucketDeletability(project.StatusUpdatedAt, cfg)
+				retainedBuckets, err := chore.deleteData(ctx, p.ProjectID, p.ProjectPublicID, p.OwnerID, projectDataTask, true, deleteUnlocked, deleteLocked)
 				if err != nil {
-					chore.log.Error("failed to check for object lock enabled buckets",
-						zap.String("task", projectDataTask),
-						zap.String("public_project_id", p.ProjectPublicID.String()),
-						zap.String("user_id", p.OwnerID.String()),
-						zap.Error(err),
-					)
 					addErr(err)
-					return
-				}
-				if count > 0 {
-					chore.log.Info("project contains buckets with object lock enabled, skipping deletion",
-						zap.String("task", projectDataTask),
-						zap.String("public_project_id", p.ProjectPublicID.String()),
-						zap.String("user_id", p.OwnerID.String()),
-					)
-					skippedProjects.Add(1)
+					stayed.Add(1)
 					return
 				}
 
-				err = chore.deleteData(ctx, p.ProjectID, p.ProjectPublicID, p.OwnerID, projectDataTask, true)
-				if err != nil {
-					addErr(err)
+				// if the project still has buckets whose deletion threshold has not
+				// elapsed (object lock within its retention window), retain their data
+				// and keep the project pending deletion.
+				if retainedBuckets > 0 {
+					chore.log.Info("project has buckets within their retention window, retaining data and skipping project deletion",
+						zap.String("task", projectDataTask),
+						zap.String("public_project_id", p.ProjectPublicID.String()),
+						zap.String("user_id", p.OwnerID.String()),
+						zap.Int("retained_buckets", retainedBuckets),
+					)
+					retainedProjects.Add(1)
+					stayed.Add(1)
 					return
 				}
 
 				err = chore.disableProject(ctx, p.ProjectID, p.ProjectPublicID, p.OwnerID, projectDataTask)
 				if err != nil {
 					addErr(err)
+					stayed.Add(1)
 					return
 				}
 				deletedProjects.Add(1)
@@ -238,11 +305,13 @@ func (chore *Chore) runDeleteProjects(ctx context.Context) (err error) {
 		}
 
 		limiter.Wait()
+		offset += stayed.Load()
 	}
 
 	chore.log.Info("finished deleting projects",
 		zap.String("task", projectDataTask),
 		zap.Int64("skipped_projects", skippedProjects.Load()),
+		zap.Int64("retained_projects", retainedProjects.Load()),
 		zap.Int64("deleted_projects", deletedProjects.Load()),
 	)
 
@@ -264,18 +333,20 @@ func (chore *Chore) runDeletePendingDeletionUsers(ctx context.Context) (err erro
 	}
 
 	errorLog := func(msg string, err2 error, args ...zap.Field) {
-		chore.log.Error(msg,
+		chore.log.Error(msg, append([]zap.Field{
 			zap.String("task", pendingDeleteUserDataTask),
 			zap.Error(err2),
-		)
+		}, args...)...)
 	}
 
-	var skippedUsers, deletedUsers, deletedProjects atomic.Int64
+	var skippedUsers, deletedUsers, retainedUsers, deletedProjects atomic.Int64
+	cfg := chore.config.User
+	var offset int64
 	hasNext := true
 	for hasNext {
 		idsPage, err := chore.store.Users().ListPendingDeletionBefore(
-			ctx,
-			chore.config.ListLimit, chore.nowFn().Add(-chore.config.User.BufferTime),
+			ctx, offset,
+			chore.config.ListLimit, chore.nowFn().Add(-cfg.listBufferTime()),
 		)
 		if err != nil {
 			chore.log.Error("failed to get users for deletion",
@@ -288,6 +359,7 @@ func (chore *Chore) runDeletePendingDeletionUsers(ctx context.Context) (err erro
 			break
 		}
 
+		var stayed atomic.Int64
 		limiter := sync2.NewLimiter(chore.config.DeleteConcurrency)
 
 		for _, userID := range idsPage.IDs {
@@ -301,6 +373,7 @@ func (chore *Chore) runDeletePendingDeletionUsers(ctx context.Context) (err erro
 						zap.Error(err),
 					)
 					addErr(err)
+					stayed.Add(1)
 					return
 				}
 
@@ -317,28 +390,53 @@ func (chore *Chore) runDeletePendingDeletionUsers(ctx context.Context) (err erro
 				if err != nil {
 					errorLog("failed to get projects for deletion", err, zap.String("user_id", userID.String()))
 					addErr(err)
+					stayed.Add(1)
 					return
 				}
 
+				deleteUnlocked, deleteLocked := chore.bucketDeletability(user.StatusUpdatedAt, cfg)
+				var retainedBuckets int
 				for _, project := range projects {
-					err := chore.deleteData(ctx, project.ID, project.PublicID, userID, pendingDeleteUserDataTask, false)
+					r, err := chore.deleteData(ctx, project.ID, project.PublicID, userID, pendingDeleteUserDataTask, false, deleteUnlocked, deleteLocked)
 					if err != nil {
 						addErr(err)
+						stayed.Add(1)
 						return
+					}
+
+					// retain projects whose buckets are still within their window.
+					if r > 0 {
+						retainedBuckets += r
+						continue
 					}
 
 					err = chore.disableProject(ctx, project.ID, project.PublicID, userID, pendingDeleteUserDataTask)
 					if err != nil {
 						addErr(err)
+						stayed.Add(1)
 						return
 					}
 
 					deletedProjects.Add(1)
 				}
 
+				// don't deactivate the user while any of their projects still hold
+				// retained (object lock) data.
+				if retainedBuckets > 0 {
+					chore.log.Info("user has buckets within their retention window, retaining data and skipping user deletion",
+						zap.String("task", pendingDeleteUserDataTask),
+						zap.String("user_id", userID.String()),
+						zap.Int("retained_buckets", retainedBuckets),
+					)
+					retainedUsers.Add(1)
+					stayed.Add(1)
+					return
+				}
+
 				err = chore.deactivateUser(ctx, userID, nil, pendingDeleteUserDataTask)
 				if err != nil {
 					addErr(err)
+					stayed.Add(1)
 					return
 				}
 				deletedUsers.Add(1)
@@ -346,11 +444,13 @@ func (chore *Chore) runDeletePendingDeletionUsers(ctx context.Context) (err erro
 		}
 
 		limiter.Wait()
+		offset += stayed.Load()
 	}
 
 	chore.log.Info("finished deleting users",
 		zap.String("task", pendingDeleteUserDataTask),
 		zap.Int64("skipped_users", skippedUsers.Load()),
+		zap.Int64("retained_users", retainedUsers.Load()),
 		zap.Int64("deleted_users", deletedUsers.Load()),
 		zap.Int64("deleted_projects", deletedProjects.Load()),
 	)
@@ -363,19 +463,19 @@ func (chore *Chore) enabledFrozenDeleteTypes() []console.EventTypeAndTime {
 	if chore.config.ViolationFreeze.Enabled {
 		eventTypes = append(eventTypes, console.EventTypeAndTime{
 			EventType: console.ViolationFreeze,
-			OlderThan: chore.nowFn().Add(-chore.config.ViolationFreeze.BufferTime),
+			OlderThan: chore.nowFn().Add(-chore.config.ViolationFreeze.listBufferTime()),
 		})
 	}
 	if chore.config.BillingFreeze.Enabled {
 		eventTypes = append(eventTypes, console.EventTypeAndTime{
 			EventType: console.BillingFreeze,
-			OlderThan: chore.nowFn().Add(-chore.config.BillingFreeze.BufferTime),
+			OlderThan: chore.nowFn().Add(-chore.config.BillingFreeze.listBufferTime()),
 		})
 	}
 	if chore.config.TrialFreeze.Enabled {
 		eventTypes = append(eventTypes, console.EventTypeAndTime{
 			EventType: console.TrialExpirationFreeze,
-			OlderThan: chore.nowFn().Add(-chore.config.TrialFreeze.BufferTime),
+			OlderThan: chore.nowFn().Add(-chore.config.TrialFreeze.listBufferTime()),
 		})
 	}
 	if len(eventTypes) == 0 {
@@ -386,6 +486,20 @@ func (chore *Chore) enabledFrozenDeleteTypes() []console.EventTypeAndTime {
 	}
 
 	return eventTypes
+}
+
+// freezeDeleteConfig returns the delete config matching a freeze event type.
+func (chore *Chore) freezeDeleteConfig(eventType console.AccountFreezeEventType) (DeleteTypeConfig, error) {
+	switch eventType {
+	case console.ViolationFreeze:
+		return chore.config.ViolationFreeze, nil
+	case console.BillingFreeze:
+		return chore.config.BillingFreeze, nil
+	case console.TrialExpirationFreeze:
+		return chore.config.TrialFreeze, nil
+	default:
+		return DeleteTypeConfig{}, Error.New("no delete config for freeze event type %d", eventType)
+	}
 }
 
 func (chore *Chore) runDeleteFrozenUsers(ctx context.Context) (err error) {
@@ -403,18 +517,20 @@ func (chore *Chore) runDeleteFrozenUsers(ctx context.Context) (err error) {
 	}
 
 	errorLog := func(msg string, err2 error, args ...zap.Field) {
-		chore.log.Error(msg,
+		chore.log.Error(msg, append([]zap.Field{
 			zap.String("task", frozenDataTask),
 			zap.Error(err2),
-		)
+		}, args...)...)
 	}
 
-	var deletedUsers, skippedUsers, deletedProjects atomic.Int64
+	var deletedUsers, skippedUsers, retainedUsers, deletedProjects atomic.Int64
 	eventTypes := chore.enabledFrozenDeleteTypes()
+	var offset int
 	hasMore := true
 	for hasMore {
 		events, err := chore.freezeService.GetEscalatedEventsBefore(ctx, console.GetEscalatedEventsBeforeParams{
 			Limit:      chore.config.ListLimit,
+			Offset:     offset,
 			EventTypes: eventTypes,
 		})
 		if err != nil {
@@ -427,6 +543,7 @@ func (chore *Chore) runDeleteFrozenUsers(ctx context.Context) (err error) {
 			break
 		}
 
+		var stayed atomic.Int64
 		limiter := sync2.NewLimiter(chore.config.DeleteConcurrency)
 
 		for _, event := range events {
@@ -436,6 +553,7 @@ func (chore *Chore) runDeleteFrozenUsers(ctx context.Context) (err error) {
 				if err != nil {
 					errorLog("failed to get user for deletion", err, zap.String("user_id", event.UserID.String()))
 					addErr(err)
+					stayed.Add(1)
 					return
 				}
 
@@ -452,28 +570,62 @@ func (chore *Chore) runDeleteFrozenUsers(ctx context.Context) (err error) {
 				if err != nil {
 					errorLog("failed to get projects for deletion", err, zap.String("user_id", event.UserID.String()))
 					addErr(err)
+					stayed.Add(1)
 					return
 				}
 
+				cfg, err := chore.freezeDeleteConfig(event.Type)
+				if err != nil {
+					errorLog("failed to get delete config for freeze event", err,
+						zap.String("user_id", event.UserID.String()))
+					addErr(err)
+					stayed.Add(1)
+					return
+				}
+
+				deleteUnlocked, deleteLocked := chore.bucketDeletability(user.StatusUpdatedAt, cfg)
+				var retainedBuckets int
 				for _, project := range projects {
-					err := chore.deleteData(ctx, project.ID, project.PublicID, event.UserID, frozenDataTask, false)
+					r, err := chore.deleteData(ctx, project.ID, project.PublicID, event.UserID, frozenDataTask, false, deleteUnlocked, deleteLocked)
 					if err != nil {
 						addErr(err)
+						stayed.Add(1)
 						return
+					}
+
+					// retain projects whose buckets are still within their window.
+					if r > 0 {
+						retainedBuckets += r
+						continue
 					}
 
 					err = chore.disableProject(ctx, project.ID, project.PublicID, event.UserID, frozenDataTask)
 					if err != nil {
 						addErr(err)
+						stayed.Add(1)
 						return
 					}
 
 					deletedProjects.Add(1)
 				}
 
+				// don't deactivate the user while any of their projects still hold
+				// retained (object lock) data.
+				if retainedBuckets > 0 {
+					chore.log.Info("user has buckets within their retention window, retaining data and skipping user deletion",
+						zap.String("task", frozenDataTask),
+						zap.String("user_id", event.UserID.String()),
+						zap.Int("retained_buckets", retainedBuckets),
+					)
+					retainedUsers.Add(1)
+					stayed.Add(1)
+					return
+				}
+
 				err = chore.deactivateUser(ctx, event.UserID, &event.Type, frozenDataTask)
 				if err != nil {
 					addErr(err)
+					stayed.Add(1)
 					return
 				}
 				deletedUsers.Add(1)
@@ -481,11 +633,13 @@ func (chore *Chore) runDeleteFrozenUsers(ctx context.Context) (err error) {
 		}
 
 		limiter.Wait()
+		offset += int(stayed.Load())
 	}
 
 	chore.log.Info("finished deleting pending deletion users and data",
 		zap.String("task", frozenDataTask),
 		zap.Int64("skipped_users", skippedUsers.Load()),
+		zap.Int64("retained_users", retainedUsers.Load()),
 		zap.Int64("deleted_users", deletedUsers.Load()),
 		zap.Int64("deleted_projects", deletedProjects.Load()),
 	)
@@ -493,8 +647,14 @@ func (chore *Chore) runDeleteFrozenUsers(ctx context.Context) (err error) {
 	return Error.Wrap(errGrp.Err())
 }
 
-func (chore *Chore) deleteData(ctx context.Context, projectID, projectPublicID, ownerID uuid.UUID, task string, trackRemainder bool) (err error) {
-	mon.Task()(&ctx)(&err)
+// deleteData deletes the objects contained in the project's buckets whose
+// deletion threshold has elapsed: buckets without object lock are deleted when
+// deleteUnlocked is true, buckets with object lock enabled when deleteLocked is
+// true. Buckets whose threshold has not yet elapsed are retained; the number of
+// retained buckets is returned so the caller can decide whether the
+// project/account can be fully deleted yet.
+func (chore *Chore) deleteData(ctx context.Context, projectID, projectPublicID, ownerID uuid.UUID, task string, trackRemainder, deleteUnlocked, deleteLocked bool) (retainedBuckets int, err error) {
+	defer mon.Task()(&ctx)(&err)
 
 	// first list buckets and delete data contained within them.
 	listOptions := buckets.ListOptions{
@@ -516,11 +676,36 @@ func (chore *Chore) deleteData(ctx context.Context, projectID, projectPublicID, 
 				zap.String("public_project_id", projectPublicID.String()),
 				zap.Error(err),
 			)
-			return err
+			return retainedBuckets, err
 		}
 
 		maxCommitDelay := 25 * time.Millisecond
 		for _, bucket := range bucketList.Items {
+			if bucket.ObjectLock.Enabled {
+				// retain object lock data until its (longer) threshold elapses.
+				if !deleteLocked {
+					retainedBuckets++
+					chore.log.Info("bucket has object lock enabled and is within the retention window, retaining data",
+						zap.String("task", task),
+						zap.String("user_id", ownerID.String()),
+						zap.String("public_project_id", projectPublicID.String()),
+						zap.String("bucket", bucket.Name),
+					)
+					continue
+				}
+				// threshold elapsed: object lock is intentionally overridden for
+				// terminated (pending deletion) accounts.
+				chore.log.Info("object lock retention window elapsed, deleting bucket data",
+					zap.String("task", task),
+					zap.String("user_id", ownerID.String()),
+					zap.String("public_project_id", projectPublicID.String()),
+					zap.String("bucket", bucket.Name),
+				)
+			} else if !deleteUnlocked {
+				retainedBuckets++
+				continue
+			}
+
 			bucketName := bucket.Name
 			bucketPlacement := bucket.Placement
 
@@ -556,7 +741,7 @@ func (chore *Chore) deleteData(ctx context.Context, projectID, projectPublicID, 
 					zap.String("public_project_id", projectPublicID.String()),
 					zap.String("bucket", bucket.Name), zap.Error(err),
 				)
-				return err
+				return retainedBuckets, err
 			}
 
 			chore.log.Info(
@@ -568,9 +753,27 @@ func (chore *Chore) deleteData(ctx context.Context, projectID, projectPublicID, 
 				zap.String("bucket", bucket.Name),
 			)
 		}
+
+		// advance the cursor so the next iteration lists the following page
+		// rather than re-listing (and re-counting retained buckets from) this one.
+		listOptions = listOptions.NextPage(bucketList)
 	}
 
-	return nil
+	return retainedBuckets, nil
+}
+
+// bucketDeletability reports, for a resource marked for deletion at markedAt,
+// whether its buckets without object lock and its buckets with object lock may
+// have their data deleted yet, according to the given config's thresholds.
+// A nil markedAt (legacy rows without a status timestamp) is treated as long past due.
+func (chore *Chore) bucketDeletability(markedAt *time.Time, cfg DeleteTypeConfig) (deleteUnlocked, deleteLocked bool) {
+	if markedAt == nil {
+		return true, true
+	}
+	now := chore.nowFn()
+	deleteUnlocked = !markedAt.After(now.Add(-cfg.BufferTime))
+	deleteLocked = !markedAt.After(now.Add(-cfg.LockBufferTime))
+	return deleteUnlocked, deleteLocked
 }
 
 func (chore *Chore) disableProject(ctx context.Context, projectID, projectPublicID, ownerID uuid.UUID, task string) (err error) {

--- a/satellite/console/dbcleanup/pendingdelete/chore_test.go
+++ b/satellite/console/dbcleanup/pendingdelete/chore_test.go
@@ -631,6 +631,7 @@ func TestPendingDeleteChore_PendingDeletionUsers(t *testing.T) {
 			Satellite: func(log *zap.Logger, index int, config *satellite.Config) {
 				config.PendingDeleteCleanup.Enabled = true
 				config.PendingDeleteCleanup.User.Enabled = true
+				config.PendingDeleteCleanup.User.BufferTime = time.Hour
 				config.PendingDeleteCleanup.ListLimit = 1 // small limit to test batching
 			},
 		},
@@ -750,8 +751,8 @@ func TestPendingDeleteChore_PendingDeletionUsers(t *testing.T) {
 		}
 
 		chore.TestSetNowFn(func() time.Time {
-			// set the chore time to some time beyond the escalation buffer time
-			return time.Now().Add(sat.Config.PendingDeleteCleanup.BillingFreeze.BufferTime + time.Hour)
+			// set the chore time to some time beyond the buffer time
+			return time.Now().Add(sat.Config.PendingDeleteCleanup.User.BufferTime + time.Hour)
 		})
 		chore.Loop.TriggerWait()
 
@@ -849,6 +850,290 @@ func TestPendingDeleteChore_PendingDeletionUsers(t *testing.T) {
 			testObjectsLength(nilUser, 0)
 			testDeactivated(nilUser)
 		})
+	})
+}
+
+// TestPendingDeleteChore_ObjectLockThresholds verifies the two deletion thresholds:
+// buckets without object lock are deleted after BufferTime, while buckets with
+// object lock enabled are retained until the later LockBufferTime and only then
+// deleted (object lock is intentionally overridden for terminated accounts).
+// The owning project/user is finalized only once nothing remains retained.
+// Checked for both the project deletion path and the user deletion path.
+func TestPendingDeleteChore_ObjectLockThresholds(t *testing.T) {
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1, StorageNodeCount: 1, UplinkCount: 1,
+		Reconfigure: testplanet.Reconfigure{
+			Satellite: func(log *zap.Logger, index int, config *satellite.Config) {
+				config.PendingDeleteCleanup.Enabled = true
+				config.PendingDeleteCleanup.Project.Enabled = true
+				config.PendingDeleteCleanup.Project.BufferTime = time.Hour
+				config.PendingDeleteCleanup.Project.LockBufferTime = 3 * time.Hour
+				config.PendingDeleteCleanup.User.Enabled = true
+				config.PendingDeleteCleanup.User.BufferTime = time.Hour
+				config.PendingDeleteCleanup.User.LockBufferTime = 3 * time.Hour
+			},
+		},
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		sat := planet.Satellites[0]
+		upl := planet.Uplinks[0]
+		chore := sat.Core.ConsoleDBCleanup.PendingDeleteChore
+		projectsDB := sat.DB.Console().Projects()
+		usersDB := sat.DB.Console().Users()
+
+		chore.Loop.Pause()
+
+		// delete the default project to start fresh.
+		require.NoError(t, projectsDB.Delete(ctx, upl.Projects[0].ID))
+
+		now := time.Now().Truncate(time.Minute)
+		projectsDB.TestSetNowFn(func() time.Time { return now })
+		chore.TestSetNowFn(func() time.Time { return now })
+
+		const lockedBucket = "locked-bucket"
+		const plainBucket = "plain-bucket"
+
+		// setupProject creates a project owned by ownerID holding two buckets, one
+		// with object lock enabled and one without, each containing a single object.
+		setupProject := func(ownerID uuid.UUID) uuid.UUID {
+			p, err := sat.AddProject(ctx, ownerID, "object-lock-project")
+			require.NoError(t, err)
+
+			ownerCtx, err := sat.UserContext(ctx, ownerID)
+			require.NoError(t, err)
+			_, apiKey, err := sat.API.Console.Service.CreateAPIKey(
+				ownerCtx, p.ID, "root", macaroon.APIKeyVersionObjectLock,
+			)
+			require.NoError(t, err)
+			access, err := upl.Config.RequestAccessWithPassphrase(ctx, sat.URL(), apiKey.Serialize(), "")
+			require.NoError(t, err)
+			uplProject, err := uplink.OpenProject(ctx, access)
+			require.NoError(t, err)
+			defer ctx.Check(uplProject.Close)
+
+			_, err = uplProject.EnsureBucket(ctx, lockedBucket)
+			require.NoError(t, err)
+			_, err = sat.DB.Buckets().UpdateBucketObjectLockSettings(ctx, buckets.UpdateBucketObjectLockParams{
+				ObjectLockEnabled: true,
+				ProjectID:         p.ID,
+				Name:              lockedBucket,
+			})
+			require.NoError(t, err)
+
+			_, err = uplProject.EnsureBucket(ctx, plainBucket)
+			require.NoError(t, err)
+
+			for _, bucket := range []string{lockedBucket, plainBucket} {
+				upload, err := uplProject.UploadObject(ctx, bucket, "test-object", nil)
+				require.NoError(t, err)
+				_, err = upload.Write(testrand.Bytes(14 * memory.KiB))
+				require.NoError(t, err)
+				require.NoError(t, upload.Commit())
+			}
+
+			return p.ID
+		}
+
+		countObjects := func(projID uuid.UUID, bucket string) (count int) {
+			objs, err := sat.Metabase.DB.TestingAllObjects(ctx)
+			require.NoError(t, err)
+			for _, o := range objs {
+				if o.ProjectID == projID && o.BucketName == metabase.BucketName(bucket) {
+					count++
+				}
+			}
+			return count
+		}
+
+		owner, err := usersDB.GetByEmailAndTenant(ctx, upl.User[sat.ID()].Email, nil)
+		require.NoError(t, err)
+
+		// project deletion path: a project marked pending deletion.
+		projectPathID := setupProject(owner.ID)
+		require.NoError(t, projectsDB.UpdateStatus(ctx, projectPathID, console.ProjectPendingDeletion))
+
+		// user deletion path: a user marked pending deletion, owning a project.
+		pendingUser, err := sat.AddUser(ctx, console.CreateUser{
+			FullName: "pending_lock_user",
+			Email:    "pending-lock@test.test",
+		}, 1)
+		require.NoError(t, err)
+		userPathID := setupProject(pendingUser.ID)
+		pd := console.PendingDeletion
+		require.NoError(t, usersDB.Update(ctx, pendingUser.ID, console.UpdateUserRequest{Status: &pd}))
+
+		// both buckets in both projects start with one object.
+		for _, projID := range []uuid.UUID{projectPathID, userPathID} {
+			require.Equal(t, 1, countObjects(projID, lockedBucket))
+			require.Equal(t, 1, countObjects(projID, plainBucket))
+		}
+
+		// move past the buffer time and run the chore.
+		chore.TestSetNowFn(func() time.Time { return now.Add(2 * time.Hour) })
+		chore.Loop.TriggerWait()
+
+		// project path: plain bucket data deleted, object lock data retained,
+		// project kept pending deletion.
+		require.Equal(t, 0, countObjects(projectPathID, plainBucket))
+		require.Equal(t, 1, countObjects(projectPathID, lockedBucket))
+		p, err := projectsDB.Get(ctx, projectPathID)
+		require.NoError(t, err)
+		require.NotNil(t, p.Status)
+		require.Equal(t, console.ProjectPendingDeletion, *p.Status)
+
+		// user path: plain bucket data deleted, object lock data retained, and
+		// the user is not deactivated while object lock data remains.
+		require.Equal(t, 0, countObjects(userPathID, plainBucket))
+		require.Equal(t, 1, countObjects(userPathID, lockedBucket))
+		u, err := usersDB.Get(ctx, pendingUser.ID)
+		require.NoError(t, err)
+		require.Equal(t, console.PendingDeletion, u.Status)
+		up, err := projectsDB.Get(ctx, userPathID)
+		require.NoError(t, err)
+		require.NotNil(t, up.Status)
+		require.Equal(t, console.ProjectActive, *up.Status)
+
+		// move past the object lock buffer time and run again: object lock data
+		// is now deleted (override) and the project/user are finalized.
+		chore.TestSetNowFn(func() time.Time { return now.Add(4 * time.Hour) })
+		chore.Loop.TriggerWait()
+
+		// project path: object lock data deleted, project disabled.
+		require.Equal(t, 0, countObjects(projectPathID, lockedBucket))
+		p, err = projectsDB.Get(ctx, projectPathID)
+		require.NoError(t, err)
+		require.NotNil(t, p.Status)
+		require.Equal(t, console.ProjectDisabled, *p.Status)
+
+		// user path: object lock data deleted, project disabled, user deactivated.
+		require.Equal(t, 0, countObjects(userPathID, lockedBucket))
+		up, err = projectsDB.Get(ctx, userPathID)
+		require.NoError(t, err)
+		require.NotNil(t, up.Status)
+		require.Equal(t, console.ProjectDisabled, *up.Status)
+		u, err = usersDB.Get(ctx, pendingUser.ID)
+		require.NoError(t, err)
+		require.Equal(t, console.Deleted, u.Status)
+	})
+}
+
+// TestPendingDeleteChore_Pagination verifies that the chore pages past retained
+// (object lock) resources to reach deletable ones behind them, even when the
+// number of retained resources exceeds ListLimit. The retained projects are the
+// oldest, so they sit at the front of the (status_updated_at ASC) queue; a
+// broken pagination (re-querying from offset 0, or advancing by batch size)
+// would either loop forever on them or skip the deletable projects behind them.
+func TestPendingDeleteChore_Pagination(t *testing.T) {
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1, StorageNodeCount: 1, UplinkCount: 1,
+		Reconfigure: testplanet.Reconfigure{
+			Satellite: func(log *zap.Logger, index int, config *satellite.Config) {
+				config.PendingDeleteCleanup.Enabled = true
+				config.PendingDeleteCleanup.Project.Enabled = true
+				config.PendingDeleteCleanup.Project.BufferTime = 0
+				config.PendingDeleteCleanup.Project.LockBufferTime = 720 * time.Hour
+				config.PendingDeleteCleanup.ListLimit = 1 // force many single-item batches
+			},
+		},
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		sat := planet.Satellites[0]
+		upl := planet.Uplinks[0]
+		chore := sat.Core.ConsoleDBCleanup.PendingDeleteChore
+		projectsDB := sat.DB.Console().Projects()
+		usersDB := sat.DB.Console().Users()
+
+		chore.Loop.Pause()
+
+		require.NoError(t, projectsDB.Delete(ctx, upl.Projects[0].ID))
+
+		owner, err := usersDB.GetByEmailAndTenant(ctx, upl.User[sat.ID()].Email, nil)
+		require.NoError(t, err)
+		ownerCtx, err := sat.UserContext(ctx, owner.ID)
+		require.NoError(t, err)
+
+		now := time.Now().Truncate(time.Minute)
+
+		// createProject marks a project pending deletion at markedAt, holding one
+		// object in a bucket that is object-lock enabled (retained) or not (deletable).
+		createProject := func(markedAt time.Time, objectLock bool) uuid.UUID {
+			p, err := sat.AddProject(ctx, owner.ID, "p")
+			require.NoError(t, err)
+
+			_, apiKey, err := sat.API.Console.Service.CreateAPIKey(ownerCtx, p.ID, "root", macaroon.APIKeyVersionObjectLock)
+			require.NoError(t, err)
+			access, err := upl.Config.RequestAccessWithPassphrase(ctx, sat.URL(), apiKey.Serialize(), "")
+			require.NoError(t, err)
+			uplProject, err := uplink.OpenProject(ctx, access)
+			require.NoError(t, err)
+			defer ctx.Check(uplProject.Close)
+
+			_, err = uplProject.EnsureBucket(ctx, "bucket")
+			require.NoError(t, err)
+			if objectLock {
+				_, err = sat.DB.Buckets().UpdateBucketObjectLockSettings(ctx, buckets.UpdateBucketObjectLockParams{
+					ObjectLockEnabled: true,
+					ProjectID:         p.ID,
+					Name:              "bucket",
+				})
+				require.NoError(t, err)
+			}
+			upload, err := uplProject.UploadObject(ctx, "bucket", "test-object", nil)
+			require.NoError(t, err)
+			_, err = upload.Write(testrand.Bytes(14 * memory.KiB))
+			require.NoError(t, err)
+			require.NoError(t, upload.Commit())
+
+			// mark pending deletion with a controlled status_updated_at.
+			projectsDB.TestSetNowFn(func() time.Time { return markedAt })
+			require.NoError(t, projectsDB.UpdateStatus(ctx, p.ID, console.ProjectPendingDeletion))
+			return p.ID
+		}
+
+		// The object lock (retained) projects are the oldest, so they head the
+		// queue; there are more of them than ListLimit. The deletable projects are
+		// newer and sit behind them.
+		const retainedCount = 3
+		const deletableCount = 3
+		var retained, deletable []uuid.UUID
+		for i := range retainedCount {
+			retained = append(retained, createProject(now.Add(time.Duration(i)*time.Minute), true))
+		}
+		for i := range deletableCount {
+			deletable = append(deletable, createProject(now.Add(time.Duration(retainedCount+i)*time.Minute), false))
+		}
+
+		countObjects := func(projID uuid.UUID) (count int) {
+			objs, err := sat.Metabase.DB.TestingAllObjects(ctx)
+			require.NoError(t, err)
+			for _, o := range objs {
+				if o.ProjectID == projID {
+					count++
+				}
+			}
+			return count
+		}
+
+		// run past BufferTime (0) but well before LockBufferTime (720h).
+		chore.TestSetNowFn(func() time.Time { return now.Add(time.Hour) })
+		chore.Loop.TriggerWait()
+
+		// every deletable project behind the retained ones was reached: its data
+		// is gone and the project is disabled.
+		for _, id := range deletable {
+			require.Equal(t, 0, countObjects(id), "deletable project should have no objects")
+			p, err := projectsDB.Get(ctx, id)
+			require.NoError(t, err)
+			require.NotNil(t, p.Status)
+			require.Equal(t, console.ProjectDisabled, *p.Status)
+		}
+
+		// the object lock projects were retained: still pending, data intact.
+		for _, id := range retained {
+			require.Equal(t, 1, countObjects(id), "object lock project should retain its object")
+			p, err := projectsDB.Get(ctx, id)
+			require.NoError(t, err)
+			require.NotNil(t, p.Status)
+			require.Equal(t, console.ProjectPendingDeletion, *p.Status)
+		}
 	})
 }
 

--- a/satellite/console/users.go
+++ b/satellite/console/users.go
@@ -102,11 +102,12 @@ type Users interface {
 	// The function return an error on system failure and an sql.ErrNoRows if the account doesn't exist
 	// or doesn't fulfill the requirements.
 	SetStatusPendingDeletion(ctx context.Context, userID uuid.UUID, defaultDaysTillEscalation uint) error
-	// ListPendingDeletionBefore returns a list of user IDs that are pending deletion and were marked before the specified time.
+	// ListPendingDeletionBefore returns a page of user IDs that are pending deletion and were marked
+	// before the specified time, ordered by status_updated_at ascending and starting at the given offset.
 	// This does not include users that have been frozen.
-	// NB: This is intended to be used to delete the users this list returns so that every next call
-	// does not return the same users again.
-	ListPendingDeletionBefore(ctx context.Context, limit int, before time.Time) (page UserIDsPage, err error)
+	// NB: callers that do not delete every returned user (e.g. because data is retained) must advance
+	// the offset past the retained users, otherwise the same users are returned on every call.
+	ListPendingDeletionBefore(ctx context.Context, offset int64, limit int, before time.Time) (page UserIDsPage, err error)
 	// ListUsersToOptOutFreeze returns active paid users who have not already been frozen. By default,
 	// it returns users whose OptInStatus is not OptedIn and not Excluded (including NoAction/unset);
 	// when opts.OptedOutOnly is true it returns only users whose OptInStatus is OptedOut.

--- a/satellite/metabase/loop.go
+++ b/satellite/metabase/loop.go
@@ -16,7 +16,12 @@ import (
 	"storj.io/storj/shared/tagsql"
 )
 
-const loopIteratorBatchSizeLimit = intLimitRange(50000)
+// MaxLoopIteratorBatchSize is the largest BatchSize IterateLoopSegments accepts.
+// Callers taking their batch size from configuration should cap it here, because
+// a larger one is rejected rather than clamped.
+const MaxLoopIteratorBatchSize = 50000
+
+const loopIteratorBatchSizeLimit = intLimitRange(MaxLoopIteratorBatchSize)
 
 // LoopSegmentEntry contains information about segment metadata needed by metainfo loop.
 type LoopSegmentEntry struct {
@@ -48,6 +53,10 @@ type LoopSegmentsIterator interface {
 
 // IterateLoopSegments contains arguments necessary for listing segments in metabase.
 type IterateLoopSegments struct {
+	// BatchSize is how many segments are read per query. Zero means
+	// MaxLoopIteratorBatchSize; anything above it is rejected rather than
+	// clamped, so a caller grouping entries by the size it asked for keeps
+	// pace with the pages the iterator hands out.
 	BatchSize          int
 	StartStreamID      uuid.UUID
 	EndStreamID        uuid.UUID
@@ -63,6 +72,12 @@ type IterateLoopSegments struct {
 func (opts *IterateLoopSegments) Verify() error {
 	if opts.BatchSize < 0 {
 		return ErrInvalidRequest.New("BatchSize is negative")
+	}
+	// Refuse to silently page at a smaller size than asked for: callers group the
+	// entries they receive by the size they requested, and the iterator's buffers
+	// are only safe to reuse once the page they belong to has been handed over.
+	if opts.BatchSize > MaxLoopIteratorBatchSize {
+		return ErrInvalidRequest.New("BatchSize is too large, maximum is %d", MaxLoopIteratorBatchSize)
 	}
 	if !opts.EndStreamID.IsZero() {
 		if opts.EndStreamID.Less(opts.StartStreamID) {
@@ -149,6 +164,7 @@ func tagsqlIterateLoopSegments(ctx context.Context, db tagsqlAdapter, aliasCache
 		readTimestamp:      opts.ReadTimestamp,
 		batchSize:          opts.BatchSize,
 		batchPieces:        make([]Pieces, opts.BatchSize),
+		batchAliasPieces:   make([]AliasPieces, opts.BatchSize),
 
 		curIndex: 0,
 		cursor: loopSegmentIteratorCursor{
@@ -192,8 +208,17 @@ type tagsqlLoopSegmentIterator struct {
 	aliasCache *NodeAliasCache
 
 	batchSize int
-	// batchPieces are reused between result pages to reduce memory consumption
-	batchPieces []Pieces
+	// batchPieces and batchAliasPieces are reused between result pages to reduce
+	// memory consumption. They are indexed by the position within the page so that
+	// every entry of a batch keeps its own storage: consumers are handed the whole
+	// batch at once, so sharing one buffer would leave every entry pointing at the
+	// last scanned row.
+	//
+	// Reuse between pages is only safe while a consumer's batch never spans two
+	// pages. Verify rejects a BatchSize above the limit rather than clamping it,
+	// so a consumer grouping by the size it requested pages in lockstep with us.
+	batchPieces      []Pieces
+	batchAliasPieces []AliasPieces
 
 	asOfSystemInterval time.Duration
 	readTimestamp      time.Time
@@ -288,6 +313,10 @@ func (it *tagsqlLoopSegmentIterator) doNextQuery(ctx context.Context) (_ tagsql.
 
 // scanItem scans doNextQuery results into LoopSegmentEntry.
 func (it *tagsqlLoopSegmentIterator) scanItem(ctx context.Context, item *LoopSegmentEntry) error {
+	// AliasPieces.SetBytes reuses the backing array when it has capacity, so scan into
+	// this position's own buffer rather than whatever the previous row left behind.
+	item.AliasPieces = it.batchAliasPieces[it.curIndex]
+
 	err := it.curRows.Scan(
 		&item.StreamID, &item.Position,
 		&item.CreatedAt, &item.ExpiresAt, &item.RepairedAt,
@@ -301,6 +330,8 @@ func (it *tagsqlLoopSegmentIterator) scanItem(ctx context.Context, item *LoopSeg
 	if err != nil {
 		return Error.New("failed to scan segments: %w", err)
 	}
+	// keep the grown buffer so the next page over this position can reuse it
+	it.batchAliasPieces[it.curIndex] = item.AliasPieces
 
 	// allocate new Pieces only if existing have not enough capacity
 	if cap(it.batchPieces[it.curIndex]) < len(item.AliasPieces) {

--- a/satellite/metabase/loop_test.go
+++ b/satellite/metabase/loop_test.go
@@ -13,6 +13,7 @@ import (
 
 	"storj.io/common/storj"
 	"storj.io/common/testcontext"
+	"storj.io/common/testrand"
 	"storj.io/common/uuid"
 	"storj.io/storj/satellite/metabase"
 	"storj.io/storj/satellite/metabase/metabasetest"
@@ -29,6 +30,21 @@ func TestIterateLoopSegments(t *testing.T) {
 				},
 				ErrClass: &metabase.ErrInvalidRequest,
 				ErrText:  "BatchSize is negative",
+			}.Check(ctx, t, db)
+			metabasetest.Verify{}.Check(ctx, t, db)
+		})
+
+		t.Run("Limit is too large", func(t *testing.T) {
+			defer metabasetest.DeleteAll{}.Check(ctx, t, db)
+			// rejected rather than clamped, so that a caller grouping the entries it
+			// receives by the size it asked for cannot end up with a group spanning
+			// two pages, whose earlier entries the iterator has already overwritten
+			metabasetest.IterateLoopSegments{
+				Opts: metabase.IterateLoopSegments{
+					BatchSize: 50001,
+				},
+				ErrClass: &metabase.ErrInvalidRequest,
+				ErrText:  "BatchSize is too large, maximum is 50000",
 			}.Check(ctx, t, db)
 			metabasetest.Verify{}.Check(ctx, t, db)
 		})
@@ -348,6 +364,84 @@ func TestIterateLoopSegments(t *testing.T) {
 				return nil
 			})
 			require.NoError(t, err)
+		})
+
+		t.Run("entries of a batch do not share AliasPieces", func(t *testing.T) {
+			defer metabasetest.DeleteAll{}.Check(ctx, t, db)
+
+			// AliasPieces.SetBytes reuses the backing array, so an iterator scanning
+			// every row into one entry used to hand out entries that all pointed at the
+			// last row's aliases. Consumers (the ranged loop's provider) collect a whole
+			// batch before processing it, so each entry must own its aliases.
+			const numberOfSegments = 5
+
+			obj := metabasetest.RandObjectStream()
+			metabasetest.CreateTestObject{
+				// give every segment its own storage node, hence its own alias
+				CreateSegment: func(object metabase.Object, index int) metabase.Segment {
+					pieces := metabase.Pieces{{Number: 0, StorageNode: testrand.NodeID()}}
+					position := metabase.SegmentPosition{Part: 0, Index: uint32(index)}
+
+					metabasetest.BeginSegment{
+						Opts: metabase.BeginSegment{
+							ObjectStream:        object.ObjectStream,
+							Position:            position,
+							RootPieceID:         storj.PieceID{byte(index + 1)},
+							Pieces:              pieces,
+							ObjectExistsChecked: true,
+						},
+					}.Check(ctx, t, db)
+
+					metabasetest.CommitSegment{
+						Opts: metabase.CommitSegment{
+							ObjectStream:      object.ObjectStream,
+							Position:          position,
+							RootPieceID:       storj.PieceID{1},
+							Pieces:            pieces,
+							EncryptedKey:      []byte{3},
+							EncryptedKeyNonce: []byte{4},
+							EncryptedETag:     []byte{5},
+							EncryptedChecksum: []byte{6},
+							EncryptedSize:     1024,
+							PlainSize:         512,
+							PlainOffset:       int64(index) * 512,
+							Redundancy:        metabasetest.DefaultRedundancy,
+						},
+					}.Check(ctx, t, db)
+
+					return metabase.Segment{}
+				},
+			}.Run(ctx, t, db, obj, numberOfSegments)
+
+			var entries []metabase.LoopSegmentEntry
+			err := db.IterateLoopSegments(ctx, metabase.IterateLoopSegments{
+				BatchSize: numberOfSegments,
+			}, func(ctx context.Context, lsi metabase.LoopSegmentsIterator) error {
+				var entry metabase.LoopSegmentEntry
+				for lsi.Next(ctx, &entry) {
+					entries = append(entries, entry)
+				}
+				return nil
+			})
+			require.NoError(t, err)
+			require.Len(t, entries, numberOfSegments)
+
+			aliasMap, err := db.LatestNodesAliasMap(ctx)
+			require.NoError(t, err)
+
+			seen := map[metabase.NodeAlias]bool{}
+			for _, entry := range entries {
+				require.Len(t, entry.AliasPieces, 1)
+				alias := entry.AliasPieces[0].Alias
+				require.False(t, seen[alias], "AliasPieces are shared between entries of a batch")
+				seen[alias] = true
+
+				// and they must still describe the same node as the converted pieces
+				require.Len(t, entry.Pieces, 1)
+				id, ok := aliasMap.Node(alias)
+				require.True(t, ok)
+				require.Equal(t, entry.Pieces[0].StorageNode, id)
+			}
 		})
 
 		t.Run("batch size", func(t *testing.T) {

--- a/satellite/metabase/rangedloop/providerdb.go
+++ b/satellite/metabase/rangedloop/providerdb.go
@@ -55,6 +55,20 @@ func (provider *MetabaseRangeSplitter) CreateRanges(ctx context.Context, nRanges
 		return nil, err
 	}
 
+	// batchSize comes from operator configuration, while the iterator rejects
+	// anything above its maximum. Cap it here so that a misconfigured satellite
+	// keeps making progress instead of failing every run, and so that the size we
+	// group the entries by stays the size the iterator really pages at: the
+	// iterator recycles its buffers once a page has been handed over, and a group
+	// spanning two pages would carry entries it has already overwritten.
+	if batchSize > metabase.MaxLoopIteratorBatchSize {
+		provider.log.Warn("configured batch size is above the maximum, using the maximum instead",
+			zap.Int("configured", batchSize),
+			zap.Int("batch_size", metabase.MaxLoopIteratorBatchSize),
+		)
+		batchSize = metabase.MaxLoopIteratorBatchSize
+	}
+
 	readTimestamp := provider.overrideReadTimestamp
 	if readTimestamp.IsZero() && provider.config.StaleInterval > 0 {
 		readTimestamp = time.Now().Add(-provider.config.StaleInterval)

--- a/satellite/metabase/rangedloop/providerdb_test.go
+++ b/satellite/metabase/rangedloop/providerdb_test.go
@@ -75,6 +75,22 @@ func TestMetabaseSegementProvider(t *testing.T) {
 				},
 			},
 			{
+				// a batch size above the iterator's maximum is capped rather than
+				// rejected, so a misconfigured satellite keeps making progress
+				in: in{
+					streamIDs: []string{
+						"00000000-0000-0000-0000-000000000001",
+						"00000000-0000-0000-0000-000000000002",
+					},
+					nRanges:   1,
+					batchSize: metabase.MaxLoopIteratorBatchSize + 1,
+				},
+				expected: expected{
+					nBatches:  1,
+					nSegments: 2,
+				},
+			},
+			{
 				in: in{
 					streamIDs: []string{
 						"00000000-0000-0000-0000-000000000001",

--- a/satellite/metabase/rangedloop/service.go
+++ b/satellite/metabase/rangedloop/service.go
@@ -28,7 +28,7 @@ var (
 // Config contains configurable values for the shared loop.
 type Config struct {
 	Parallelism        int           `help:"how many chunks of segments to process in parallel" default:"2"`
-	BatchSize          int           `help:"how many items to query in a batch" default:"2500"`
+	BatchSize          int           `help:"how many items to query in a batch, capped at 50000" default:"2500"`
 	AsOfSystemInterval time.Duration `help:"as of system interval" releaseDefault:"-5m" devDefault:"-1us" testDefault:"-1us"`
 	Interval           time.Duration `help:"how often to run the loop" releaseDefault:"2h" devDefault:"10s" testDefault:"0"`
 	StaleInterval      time.Duration `help:"sets the fixed read timestamp as now()-interval" default:"0"`

--- a/satellite/repair/classification.go
+++ b/satellite/repair/classification.go
@@ -74,7 +74,9 @@ func ClassifySegmentPieces(pieces metabase.Pieces, nodes []nodeselection.Selecte
 	result.Exiting = intset.NewSet(maxPieceNum)
 	result.Retrievable = intset.NewSet(maxPieceNum)
 	result.InExcludedCountry = intset.NewSet(maxPieceNum)
-	for index, nodeRecord := range nodes {
+	for index := range nodes {
+		// avoid heap allocation
+		nodeRecord := &nodes[index]
 		pieceNum := pieces[index].Number
 
 		if !nodeRecord.ID.IsZero() && pieces[index].StorageNode != nodeRecord.ID {
@@ -110,11 +112,13 @@ func ClassifySegmentPieces(pieces metabase.Pieces, nodes []nodeselection.Selecte
 		// mark all pieces that are out of placement.
 
 		result.OutOfPlacement = intset.NewSet(maxPieceNum)
-		for index, nodeRecord := range nodes {
+		for index := range nodes {
+			// avoid heap allocation
+			nodeRecord := &nodes[index]
 			if nodeRecord.ID.IsZero() {
 				continue
 			}
-			if placement.NodeFilter == nil || placement.NodeFilter.Match(&nodeRecord) {
+			if placement.NodeFilter == nil || placement.NodeFilter.Match(nodeRecord) {
 				continue
 			}
 			pieceNum := pieces[index].Number

--- a/satellite/repair/classification_alloc_bench_test.go
+++ b/satellite/repair/classification_alloc_bench_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package repair_test
+
+import (
+	"testing"
+
+	"storj.io/storj/satellite/nodeselection"
+	"storj.io/storj/satellite/repair"
+	"storj.io/storj/shared/location"
+)
+
+// BenchmarkClassifySegmentPieces measures the per-segment allocation cost of a
+// 54-piece segment.
+func BenchmarkClassifySegmentPieces(b *testing.B) {
+	const pieceCount = 54
+
+	indexes := make([]int, pieceCount)
+	for i := range indexes {
+		indexes[i] = i
+	}
+
+	nodes := generateNodes(pieceCount, func(ix int) bool {
+		return true
+	}, func(ix int, node *nodeselection.SelectedNode) {
+		node.CountryCode = location.UnitedStates
+		node.LastNet = "10.0.0.0"
+	})
+	pieces := createPieces(nodes, indexes...)
+	placement := nodeselection.TestPlacementDefinitions()[0]
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = repair.ClassifySegmentPieces(pieces, nodes, nil, true, true, placement)
+	}
+}

--- a/satellite/repair/classification_test.go
+++ b/satellite/repair/classification_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2023 Storj Labs, Inc.
 // See LICENSE for copying information.
 
-package repair
+package repair_test
 
 import (
 	"fmt"
@@ -13,6 +13,7 @@ import (
 	"storj.io/common/storj"
 	"storj.io/storj/satellite/metabase"
 	"storj.io/storj/satellite/nodeselection"
+	"storj.io/storj/satellite/repair"
 	"storj.io/storj/shared/location"
 )
 
@@ -37,7 +38,7 @@ func TestClassifySegmentPieces(t *testing.T) {
 		})
 
 		pieces := createPieces(selectedNodes, 0, 1, 2, 3, 4)
-		result := ClassifySegmentPieces(pieces, getNodes(selectedNodes, pieces), map[location.CountryCode]struct{}{}, true, false, nodeselection.TestPlacementDefinitions()[0])
+		result := repair.ClassifySegmentPieces(pieces, getNodes(selectedNodes, pieces), map[location.CountryCode]struct{}{}, true, false, nodeselection.TestPlacementDefinitions()[0])
 
 		require.Equal(t, 0, result.Missing.Count())
 		require.Equal(t, 0, result.Clumped.Count())
@@ -63,7 +64,7 @@ func TestClassifySegmentPieces(t *testing.T) {
 		require.NoError(t, err)
 
 		pieces := createPieces(selectedNodes, 1, 2, 3, 4, 7, 8)
-		result := ClassifySegmentPieces(pieces, getNodes(selectedNodes, pieces), map[location.CountryCode]struct{}{}, true, false, c[10])
+		result := repair.ClassifySegmentPieces(pieces, getNodes(selectedNodes, pieces), map[location.CountryCode]struct{}{}, true, false, c[10])
 
 		require.Equal(t, 0, result.Missing.Count())
 		require.Equal(t, 0, result.Clumped.Count())
@@ -86,7 +87,7 @@ func TestClassifySegmentPieces(t *testing.T) {
 		require.NoError(t, err)
 
 		pieces := createPieces(selectedNodes, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
-		result := ClassifySegmentPieces(pieces, getNodes(selectedNodes, pieces), map[location.CountryCode]struct{}{}, true, false, c[10])
+		result := repair.ClassifySegmentPieces(pieces, getNodes(selectedNodes, pieces), map[location.CountryCode]struct{}{}, true, false, c[10])
 
 		// offline nodes
 		require.Equal(t, 5, result.Missing.Count())
@@ -109,7 +110,7 @@ func TestClassifySegmentPieces(t *testing.T) {
 
 		// first 5: online, 2 in each subnet --> healthy: one from (0,1) (2,3) (4), offline: (5,6) but 5 is in the same subnet as 6
 		pieces := createPieces(selectedNodes, 0, 1, 2, 3, 4, 5, 6)
-		result := ClassifySegmentPieces(pieces, getNodes(selectedNodes, pieces), map[location.CountryCode]struct{}{}, true, true, c[0])
+		result := repair.ClassifySegmentPieces(pieces, getNodes(selectedNodes, pieces), map[location.CountryCode]struct{}{}, true, true, c[0])
 
 		// offline nodes
 		require.Equal(t, 2, result.Missing.Count())
@@ -136,7 +137,7 @@ func TestClassifySegmentPieces(t *testing.T) {
 
 		// first 5: online, 2 in each subnet --> healthy: one from (0,1) (2,3) (4), offline: (5,6) but 5 is in the same subnet as 6
 		pieces := createPieces(selectedNodes, 0, 1, 2, 3, 4, 5, 6)
-		result := ClassifySegmentPieces(pieces, getNodes(selectedNodes, pieces), map[location.CountryCode]struct{}{}, true, true, c[10])
+		result := repair.ClassifySegmentPieces(pieces, getNodes(selectedNodes, pieces), map[location.CountryCode]struct{}{}, true, true, c[10])
 
 		// offline nodes
 		require.Equal(t, 2, result.Missing.Count())

--- a/satellite/repair/repair_test.go
+++ b/satellite/repair/repair_test.go
@@ -2488,7 +2488,7 @@ func (m *mockConnector) getAddressesDialed() []string {
 	return append([]string(nil), m.addressesDialed...)
 }
 
-func ecRepairerWithMockConnector(t testing.TB, sat *testplanet.Satellite, mock *mockConnector) *repairer.ECRepairer {
+func ecRepairerWithMockConnector(sat *testplanet.Satellite, mock *mockConnector) *repairer.ECRepairer {
 	tlsOptions := sat.Dialer.TLSOptions
 	newDialer := rpc.NewDefaultDialer(tlsOptions)
 	mock.realConnector = newDialer.Connector
@@ -2951,7 +2951,7 @@ func TestECRepairerGetDoesNameLookupIfNecessary(t *testing.T) {
 		}
 
 		mock := &mockConnector{}
-		ec := ecRepairerWithMockConnector(t, testSatellite, mock)
+		ec := ecRepairerWithMockConnector(testSatellite, mock)
 
 		redundancy, err := eestream.NewRedundancyStrategyFromStorj(segment.Redundancy)
 		require.NoError(t, err)
@@ -3039,7 +3039,7 @@ func TestECRepairerGetPrefersCachedIPPort(t *testing.T) {
 			realAddresses = append(realAddresses, address)
 		}
 
-		ec := ecRepairerWithMockConnector(t, testSatellite, mock)
+		ec := ecRepairerWithMockConnector(testSatellite, mock)
 
 		redundancy, err := eestream.NewRedundancyStrategyFromStorj(segment.Redundancy)
 		require.NoError(t, err)

--- a/satellite/satellite-config.yaml.lock
+++ b/satellite/satellite-config.yaml.lock
@@ -1899,7 +1899,7 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # as of system interval
 # ranged-loop.as-of-system-interval: -5m0s
 
-# how many items to query in a batch
+# how many items to query in a batch, capped at 50000
 # ranged-loop.batch-size: 2500
 
 # how often to run the loop

--- a/satellite/satellite-config.yaml.lock
+++ b/satellite/satellite-config.yaml.lock
@@ -1809,11 +1809,14 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # price user should pay for storage per month in dollars/TB
 # payments.usage-price.storage-tb: "4"
 
-# how long after the resource is marked for deletion should we wait before deleting data
-# pending-delete-cleanup.billing-freeze.buffer-time: 720h0m0s
+# how long after the resource is marked for deletion to wait before deleting data in buckets without object lock enabled
+# pending-delete-cleanup.billing-freeze.buffer-time: 0s
 
 # whether data of this type of pending deletion resource should be deleted or not
 # pending-delete-cleanup.billing-freeze.enabled: false
+
+# how long after the resource is marked for deletion to wait before deleting data in buckets with object lock enabled
+# pending-delete-cleanup.billing-freeze.lock-buffer-time: 720h0m0s
 
 # how many delete workers to run at a time
 # pending-delete-cleanup.delete-concurrency: 1
@@ -1827,29 +1830,41 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # how many events to query in a batch
 # pending-delete-cleanup.list-limit: 100
 
-# how long after the resource is marked for deletion should we wait before deleting data
-# pending-delete-cleanup.project.buffer-time: 720h0m0s
+# how long after the resource is marked for deletion to wait before deleting data in buckets without object lock enabled
+# pending-delete-cleanup.project.buffer-time: 0s
 
 # whether data of this type of pending deletion resource should be deleted or not
 # pending-delete-cleanup.project.enabled: false
 
-# how long after the resource is marked for deletion should we wait before deleting data
-# pending-delete-cleanup.trial-freeze.buffer-time: 720h0m0s
+# how long after the resource is marked for deletion to wait before deleting data in buckets with object lock enabled
+# pending-delete-cleanup.project.lock-buffer-time: 720h0m0s
+
+# how long after the resource is marked for deletion to wait before deleting data in buckets without object lock enabled
+# pending-delete-cleanup.trial-freeze.buffer-time: 0s
 
 # whether data of this type of pending deletion resource should be deleted or not
 # pending-delete-cleanup.trial-freeze.enabled: false
 
-# how long after the resource is marked for deletion should we wait before deleting data
-# pending-delete-cleanup.user.buffer-time: 720h0m0s
+# how long after the resource is marked for deletion to wait before deleting data in buckets with object lock enabled
+# pending-delete-cleanup.trial-freeze.lock-buffer-time: 720h0m0s
+
+# how long after the resource is marked for deletion to wait before deleting data in buckets without object lock enabled
+# pending-delete-cleanup.user.buffer-time: 0s
 
 # whether data of this type of pending deletion resource should be deleted or not
 # pending-delete-cleanup.user.enabled: false
 
-# how long after the resource is marked for deletion should we wait before deleting data
-# pending-delete-cleanup.violation-freeze.buffer-time: 720h0m0s
+# how long after the resource is marked for deletion to wait before deleting data in buckets with object lock enabled
+# pending-delete-cleanup.user.lock-buffer-time: 720h0m0s
+
+# how long after the resource is marked for deletion to wait before deleting data in buckets without object lock enabled
+# pending-delete-cleanup.violation-freeze.buffer-time: 0s
 
 # whether data of this type of pending deletion resource should be deleted or not
 # pending-delete-cleanup.violation-freeze.enabled: false
+
+# how long after the resource is marked for deletion to wait before deleting data in buckets with object lock enabled
+# pending-delete-cleanup.violation-freeze.lock-buffer-time: 720h0m0s
 
 # batch size for updating nodes with number of pieces
 # piece-tracker.update-batch-size: 1000

--- a/satellite/satellitedb/consoledb/accountfreezeevents.go
+++ b/satellite/satellitedb/consoledb/accountfreezeevents.go
@@ -278,37 +278,42 @@ func (events *accountFreezeEvents) GetOptOutFreezes(ctx context.Context, tenantI
 func (events *accountFreezeEvents) GetEscalatedEventsBefore(ctx context.Context, params console.GetEscalatedEventsBeforeParams) (_ []console.EventWithUser, err error) {
 	defer mon.Task()(&ctx)(&err)
 
+	// status_updated_at is projected so the outer query can order by it. For the
+	// multi-type UNION ALL case, ordering must happen at the outer (combined) level
+	// -- ordering inside the subqueries does not constrain the order of the combined
+	// result, which OFFSET paging depends on. user_id is a unique tie-breaker so
+	// paging stays deterministic when rows share a timestamp or leave the set between
+	// calls (e.g. as their data is finalized).
 	baseQuery := `
-			SELECT afe.event as event, u.id AS user_id
+			SELECT afe.event as event, u.id AS user_id, u.status_updated_at AS status_updated_at
 				FROM account_freeze_events AS afe
-			JOIN users AS u 
+			JOIN users AS u
 				ON u.id = afe.user_id
 			WHERE u.status = ?
 				AND (u.status_updated_at IS NULL OR u.status_updated_at < ?)
-				AND afe.event = ?
-			ORDER BY u.status_updated_at ASC`
+				AND afe.event = ?`
 
-	query := fmt.Sprintf("%s\nLIMIT ?", baseQuery)
+	const orderAndPage = "\nORDER BY status_updated_at ASC, user_id ASC, event ASC\nLIMIT ? OFFSET ?"
+
+	query := fmt.Sprintf("SELECT event, user_id FROM (%s) AS combined_results%s", baseQuery, orderAndPage)
 
 	queryParams := make([]interface{}, 0)
 	if len(params.EventTypes) > 1 {
 		/*
 			craft a query like this:
-			SELECT event, user_id, project_id FROM (
-				(SELECT ...
+			SELECT event, user_id FROM (
+				(SELECT ... status_updated_at ...
 					JOIN ...
 					WHERE u.status = ?
 						AND u.status_updated_at < ?
-						AND afe.event = ?
-					ORDER BY u.status_updated_at ASC)
+						AND afe.event = ?)
 			UNION ALL
-				(SELECT ...
+				(SELECT ... status_updated_at ...
 						JOIN ...
 						WHERE u.status = ?
 							AND u.status_updated_at < ?
-							AND afe.event = ?
-						ORDER BY u.status_updated_at ASC)
-			) AS combined_results LIMIT ?
+							AND afe.event = ?)
+			) AS combined_results ORDER BY status_updated_at ASC, user_id ASC LIMIT ? OFFSET ?
 		*/
 		query = ``
 		for i, eventType := range params.EventTypes {
@@ -320,12 +325,12 @@ func (events *accountFreezeEvents) GetEscalatedEventsBefore(ctx context.Context,
 			query += fmt.Sprintf("\n UNION ALL (%s)", baseQuery)
 
 			if i == len(params.EventTypes)-1 {
-				query += "\n) AS combined_results LIMIT ?"
+				query += "\n) AS combined_results" + orderAndPage
 			}
 		}
-		queryParams = append(queryParams, params.Limit)
+		queryParams = append(queryParams, params.Limit, params.Offset)
 	} else {
-		queryParams = append(queryParams, console.PendingDeletion, params.EventTypes[0].OlderThan, params.EventTypes[0].EventType, params.Limit)
+		queryParams = append(queryParams, console.PendingDeletion, params.EventTypes[0].OlderThan, params.EventTypes[0].EventType, params.Limit, params.Offset)
 	}
 
 	rows, err := events.db.QueryContext(ctx, events.db.Rebind(query), queryParams...)

--- a/satellite/satellitedb/consoledb/projects.go
+++ b/satellite/satellitedb/consoledb/projects.go
@@ -669,7 +669,7 @@ func (projects *projects) ListPendingDeletionBefore(
 ) (page console.ProjectIdOwnerIdPage, err error) {
 	defer mon.Task()(&ctx)(&err)
 
-	dbxProjects, err := projects.db.Limited_Project_Id_Project_PublicId_Project_OwnerId_By_Status_And_StatusUpdatedAt_Less_OrderBy_Asc_StatusUpdatedAt(ctx,
+	dbxProjects, err := projects.db.Limited_Project_Id_Project_PublicId_Project_OwnerId_By_Status_And_StatusUpdatedAt_Less_OrderBy_Asc_StatusUpdatedAt_Asc_Id(ctx,
 		dbx.Project_Status(int(console.ProjectPendingDeletion)),
 		dbx.Project_StatusUpdatedAt(before.UTC()),
 		limit+1,

--- a/satellite/satellitedb/consoledb/users.go
+++ b/satellite/satellitedb/consoledb/users.go
@@ -985,12 +985,12 @@ func (users *users) SetStatusPendingDeletion(
 	return nil
 }
 
-// ListPendingDeletionBefore returns a list of user IDs that are pending deletion and were marked before the specified time.
+// ListPendingDeletionBefore returns a page of user IDs that are pending deletion and were marked
+// before the specified time, ordered by status_updated_at ascending and starting at the given offset.
 // This does not include users that have been frozen.
-// NB: This is intended to be used to delete the users this list returns so that every next call
-// does not return the same users again.
 func (users *users) ListPendingDeletionBefore(
 	ctx context.Context,
+	offset int64,
 	limit int,
 	before time.Time,
 ) (page console.UserIDsPage, err error) {
@@ -1003,11 +1003,13 @@ func (users *users) ListPendingDeletionBefore(
 				AND (u.status_updated_at IS NULL OR u.status_updated_at < ?)
 				-- exclude frozen users
 				AND (SELECT COUNT(1) FROM account_freeze_events as afe WHERE u.id = afe.user_id) = 0
-			ORDER BY u.status_updated_at ASC
-			LIMIT ?
+			-- u.id is a unique tie-breaker so OFFSET paging is deterministic across
+			-- rows that share status_updated_at (e.g. bulk-marked in one operation).
+			ORDER BY u.status_updated_at ASC, u.id ASC
+			LIMIT ? OFFSET ?
 		`)
 
-	rows, err := users.db.QueryContext(ctx, query, console.PendingDeletion, before.UTC(), limit+1)
+	rows, err := users.db.QueryContext(ctx, query, console.PendingDeletion, before.UTC(), limit+1, offset)
 	if err != nil {
 		return console.UserIDsPage{}, err
 	}

--- a/satellite/satellitedb/dbx/project.dbx
+++ b/satellite/satellitedb/dbx/project.dbx
@@ -236,7 +236,7 @@ read limitoffset (
 	select project.id project.public_id project.owner_id
 	where project.status = ?
 	where project.status_updated_at < ?
-	orderby asc project.status_updated_at
+	orderby (asc project.status_updated_at, asc project.id)
 )
 
 // project_member is an association table between projects and users.

--- a/satellite/satellitedb/dbx/satellitedb.dbx.go
+++ b/satellite/satellitedb/dbx/satellitedb.dbx.go
@@ -20033,7 +20033,7 @@ func (obj *pgxImpl) Limited_Project_By_CreatedAt_Less_OrderBy_Asc_CreatedAt(ctx 
 
 }
 
-func (obj *pgxImpl) Limited_Project_Id_Project_PublicId_Project_OwnerId_By_Status_And_StatusUpdatedAt_Less_OrderBy_Asc_StatusUpdatedAt(ctx context.Context,
+func (obj *pgxImpl) Limited_Project_Id_Project_PublicId_Project_OwnerId_By_Status_And_StatusUpdatedAt_Less_OrderBy_Asc_StatusUpdatedAt_Asc_Id(ctx context.Context,
 	project_status Project_Status_Field,
 	project_status_updated_at_less Project_StatusUpdatedAt_Field,
 	limit int, offset int64) (
@@ -20045,7 +20045,7 @@ func (obj *pgxImpl) Limited_Project_Id_Project_PublicId_Project_OwnerId_By_Statu
 
 	var __cond_0 = &__sqlbundle_Condition{Left: "projects.status", Equal: true, Right: "?", Null: true}
 
-	var __embed_stmt = __sqlbundle_Literals{Join: "", SQLs: []__sqlbundle_SQL{__sqlbundle_Literal("SELECT projects.id, projects.public_id, projects.owner_id FROM projects WHERE "), __cond_0, __sqlbundle_Literal(" AND projects.status_updated_at < ? ORDER BY projects.status_updated_at LIMIT ? OFFSET ?")}}
+	var __embed_stmt = __sqlbundle_Literals{Join: "", SQLs: []__sqlbundle_SQL{__sqlbundle_Literal("SELECT projects.id, projects.public_id, projects.owner_id FROM projects WHERE "), __cond_0, __sqlbundle_Literal(" AND projects.status_updated_at < ? ORDER BY projects.status_updated_at, projects.id LIMIT ? OFFSET ?")}}
 
 	var __values []any
 	if !project_status.isnull() {
@@ -31852,7 +31852,7 @@ func (obj *pgxcockroachImpl) Limited_Project_By_CreatedAt_Less_OrderBy_Asc_Creat
 
 }
 
-func (obj *pgxcockroachImpl) Limited_Project_Id_Project_PublicId_Project_OwnerId_By_Status_And_StatusUpdatedAt_Less_OrderBy_Asc_StatusUpdatedAt(ctx context.Context,
+func (obj *pgxcockroachImpl) Limited_Project_Id_Project_PublicId_Project_OwnerId_By_Status_And_StatusUpdatedAt_Less_OrderBy_Asc_StatusUpdatedAt_Asc_Id(ctx context.Context,
 	project_status Project_Status_Field,
 	project_status_updated_at_less Project_StatusUpdatedAt_Field,
 	limit int, offset int64) (
@@ -31864,7 +31864,7 @@ func (obj *pgxcockroachImpl) Limited_Project_Id_Project_PublicId_Project_OwnerId
 
 	var __cond_0 = &__sqlbundle_Condition{Left: "projects.status", Equal: true, Right: "?", Null: true}
 
-	var __embed_stmt = __sqlbundle_Literals{Join: "", SQLs: []__sqlbundle_SQL{__sqlbundle_Literal("SELECT projects.id, projects.public_id, projects.owner_id FROM projects WHERE "), __cond_0, __sqlbundle_Literal(" AND projects.status_updated_at < ? ORDER BY projects.status_updated_at LIMIT ? OFFSET ?")}}
+	var __embed_stmt = __sqlbundle_Literals{Join: "", SQLs: []__sqlbundle_SQL{__sqlbundle_Literal("SELECT projects.id, projects.public_id, projects.owner_id FROM projects WHERE "), __cond_0, __sqlbundle_Literal(" AND projects.status_updated_at < ? ORDER BY projects.status_updated_at, projects.id LIMIT ? OFFSET ?")}}
 
 	var __values []any
 	if !project_status.isnull() {
@@ -39280,7 +39280,7 @@ type Methods interface {
 		limit int, offset int64) (
 		rows []*Project, err error)
 
-	Limited_Project_Id_Project_PublicId_Project_OwnerId_By_Status_And_StatusUpdatedAt_Less_OrderBy_Asc_StatusUpdatedAt(ctx context.Context,
+	Limited_Project_Id_Project_PublicId_Project_OwnerId_By_Status_And_StatusUpdatedAt_Less_OrderBy_Asc_StatusUpdatedAt_Asc_Id(ctx context.Context,
 		project_status Project_Status_Field,
 		project_status_updated_at_less Project_StatusUpdatedAt_Field,
 		limit int, offset int64) (


### PR DESCRIPTION
Cherry-picks onto `release-v1.162` for point release `v1.162.1-rc`:

- 08b95ebae4bbf7d842ac114287109b87695fb5c8 — satellite/metabase: give each batched loop entry its own AliasPieces
- d0803fd16ca9b5ed49ef03856156c81128004883 — satellite/repair: avoid heap allocation per piece in classification
- 377c5e174a06bccaa234a43715ee82940dfccca6 — satellite/console/dbcleanup/pendingdelete: reduce non-locked delete buffer to 0h, retain object lock buckets

All three applied without conflicts. `go build ./...` and `go vet` on the touched packages pass.