### PR TITLE
fix: File browser has problems with free tier limitations

### DIFF
--- a/web/satellite/src/components/dialogs/CreateBucketDialog.vue
+++ b/web/satellite/src/components/dialogs/CreateBucketDialog.vue
@@ -912,7 +912,7 @@ async function onCreate(): Promise<void> {
         return;
     }
 
-    if (edgeCredentialsForCreate.value.accessKeyId) {
+    if (edgeCredentialsForCreate.value.accessKeyId && !edgeCredentialsForCreate.value.isExpired) {
         await bucketsStore.createBucketWithNoPassphrase({
             name: bucketName.value,
             enableObjectLock: enableObjectLock.value,

--- a/web/satellite/src/components/dialogs/SetBucketObjectLockConfigDialog.vue
+++ b/web/satellite/src/components/dialogs/SetBucketObjectLockConfigDialog.vue
@@ -179,10 +179,9 @@ function onSetLock(): void {
                 return;
             }
 
-            if (edgeCredentialsForObjectLock.value.accessKeyId) {
+            if (edgeCredentialsForObjectLock.value.accessKeyId && !edgeCredentialsForObjectLock.value.isExpired) {
                 await bucketsStore.setObjectLockConfig(props.bucketName, ClientType.FOR_OBJECT_LOCK, rule);
                 await bucketsStore.getBuckets(bucketsPage, projectID.value, bucketsLimit);
-
                 notify.success('Bucket Object Lock configuration has been updated.');
                 model.value = false;
                 return;

--- a/web/satellite/src/composables/useLinksharing.ts
+++ b/web/satellite/src/composables/useLinksharing.ts
@@ -97,7 +97,9 @@ export function useLinksharing() {
             'ObjectsModule: S3 Client is uninitialized',
         );
 
-        const url = new URL(`${linksharingURL.value}/s/${objectBrowserStore.state.accessKey}/${path}`);
+        const creds = await objectBrowserStore.state.s3.config.credentials();
+
+        const url = new URL(`${linksharingURL.value}/s/${creds.accessKeyId}/${path}`);
         const request: HttpRequest = {
             method: 'GET',
             protocol: url.protocol,
@@ -112,7 +114,6 @@ export function useLinksharing() {
             },
         };
 
-        const creds = await objectBrowserStore.state.s3.config.credentials();
         const signer = new SignatureV4({
             applyChecksum: true,
             uriEscapePath: false,

--- a/web/satellite/src/store/modules/bucketsStore.ts
+++ b/web/satellite/src/store/modules/bucketsStore.ts
@@ -18,6 +18,7 @@ import {
     PutObjectLockConfigurationCommand,
     ListObjectVersionsCommand,
 } from '@aws-sdk/client-s3';
+import type { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { SignatureV4 } from '@smithy/signature-v4';
 
 import {
@@ -244,7 +245,7 @@ export const useBucketsStore = defineStore('buckets', () => {
         state.s3ClientForEventing = new S3Client(s3Config);
     }
 
-    async function setS3Client(projectID: string): Promise<void> {
+    async function generateEdgeCredentials(projectID: string): Promise<EdgeCredentials> {
         if (!state.passphrase) throw new Error('Passphrase can\'t be empty');
 
         const agStore = useAccessGrantsStore();
@@ -279,13 +280,28 @@ export const useBucketsStore = defineStore('buckets', () => {
             passphrase: state.passphrase,
         }, projectID);
 
-        state.edgeCredentials = await agStore.getEdgeCredentials(accessGrant);
+        return await agStore.getEdgeCredentials(accessGrant);
+    }
+
+    function edgeCredentialsProvider(projectID: string): AwsCredentialIdentityProvider {
+        return async () => {
+            if (!state.edgeCredentials.accessKeyId || state.edgeCredentials.isExpired) {
+                state.edgeCredentials = await generateEdgeCredentials(projectID);
+            }
+
+            return {
+                accessKeyId: state.edgeCredentials.accessKeyId,
+                secretAccessKey: state.edgeCredentials.secretKey,
+                expiration: state.edgeCredentials.freeTierRestrictedExpiration ?? undefined,
+            };
+        };
+    }
+
+    async function setS3Client(projectID: string): Promise<void> {
+        state.edgeCredentials = await generateEdgeCredentials(projectID);
 
         const s3Config: S3ClientConfig = {
-            credentials: {
-                accessKeyId: state.edgeCredentials.accessKeyId || '',
-                secretAccessKey: state.edgeCredentials.secretKey || '',
-            },
+            credentials: edgeCredentialsProvider(projectID),
             endpoint: state.edgeCredentials.endpoint,
             forcePathStyle: true,
             signerConstructor: SignatureV4,
@@ -510,6 +526,7 @@ export const useBucketsStore = defineStore('buckets', () => {
         setEdgeCredentialsForEventing,
         setObjectLockConfig,
         setS3Client,
+        edgeCredentialsProvider,
         setPassphrase,
         setApiKey,
         setFileComponentBucketName,

--- a/web/satellite/src/store/modules/objectBrowserStore.ts
+++ b/web/satellite/src/store/modules/objectBrowserStore.ts
@@ -34,6 +34,7 @@ import {
     ObjectLockLegalHoldStatus,
 } from '@aws-sdk/client-s3';
 import type {
+    AwsCredentialIdentityProvider,
     BuildHandler,
     BuildHandlerArguments,
     BuildHandlerOutput,
@@ -109,7 +110,6 @@ export type FileToUpload = {
 
 export class FilesState {
     s3: S3Client | null = null;
-    accessKey: null | string = null;
     path = '';
     bucket = '';
     browserRoot = '/';
@@ -245,23 +245,18 @@ export const useObjectBrowserStore = defineStore('objectBrowser', () => {
     }
 
     function init({
-        accessKey,
-        secretKey,
+        credentials,
         bucket,
         endpoint,
         browserRoot,
     }: {
-        accessKey: string;
-        secretKey: string;
+        credentials: AwsCredentialIdentityProvider;
         bucket: string;
         endpoint: string;
         browserRoot: string;
     }): void {
         const s3Config: S3ClientConfig = {
-            credentials: {
-                accessKeyId: accessKey,
-                secretAccessKey: secretKey,
-            },
+            credentials,
             endpoint,
             forcePathStyle: true,
             signerConstructor: SignatureV4,
@@ -269,7 +264,6 @@ export const useObjectBrowserStore = defineStore('objectBrowser', () => {
         };
 
         state.s3 = createS3Client(s3Config);
-        state.accessKey = accessKey;
         state.bucket = bucket;
         state.browserRoot = browserRoot;
         state.path = '';
@@ -277,19 +271,14 @@ export const useObjectBrowserStore = defineStore('objectBrowser', () => {
     }
 
     function reinit({
-        accessKey,
-        secretKey,
+        credentials,
         endpoint,
     }: {
-        accessKey: string;
-        secretKey: string;
+        credentials: AwsCredentialIdentityProvider;
         endpoint: string;
     }): void {
         const s3Config: S3ClientConfig = {
-            credentials: {
-                accessKeyId: accessKey,
-                secretAccessKey: secretKey,
-            },
+            credentials,
             endpoint,
             forcePathStyle: true,
             signerConstructor: SignatureV4,
@@ -298,7 +287,6 @@ export const useObjectBrowserStore = defineStore('objectBrowser', () => {
 
         state.files = [];
         state.s3 = createS3Client(s3Config);
-        state.accessKey = accessKey;
     }
 
     function updateFiles(path: string, files: BrowserObject[]): void {
@@ -1238,7 +1226,6 @@ export const useObjectBrowserStore = defineStore('objectBrowser', () => {
 
     function clear(): void {
         state.s3 = null;
-        state.accessKey = null;
         state.path = '';
         state.bucket = '';
         state.browserRoot = '/';

--- a/web/satellite/src/types/accessGrants.ts
+++ b/web/satellite/src/types/accessGrants.ts
@@ -112,6 +112,8 @@ export class AccessGrant {
     }
 }
 
+const EDGE_CREDENTIALS_REFRESH_MARGIN_MS = 60 * 1000;
+
 /**
  * EdgeCredentials class holds info for edge credentials generated from access grant.
  */
@@ -124,4 +126,10 @@ export class EdgeCredentials {
         public endpoint: string = '',
         public freeTierRestrictedExpiration: Date | null = null,
     ) {}
+
+    public get isExpired(): boolean {
+        if (!this.freeTierRestrictedExpiration) return false;
+
+        return this.freeTierRestrictedExpiration.getTime() - EDGE_CREDENTIALS_REFRESH_MARGIN_MS <= Date.now();
+    }
 }

--- a/web/satellite/src/views/Bucket.vue
+++ b/web/satellite/src/views/Bucket.vue
@@ -551,8 +551,7 @@ async function initObjectStore() {
     }
     obStore.init({
         endpoint: edgeCredentials.value.endpoint,
-        accessKey: edgeCredentials.value.accessKeyId,
-        secretKey: edgeCredentials.value.secretKey,
+        credentials: bucketsStore.edgeCredentialsProvider(projectId.value),
         bucket: bucketName.value,
         browserRoot: '', // unused
     });
@@ -673,8 +672,7 @@ watch(() => bucketsStore.state.passphrase, async newPass => {
         await bucketsStore.setS3Client(projectId.value);
         obStore.reinit({
             endpoint: edgeCredentials.value.endpoint,
-            accessKey: edgeCredentials.value.accessKeyId,
-            secretKey: edgeCredentials.value.secretKey,
+            credentials: bucketsStore.edgeCredentialsProvider(projectId.value),
         });
         await router.push(`${bucketsURL}/${bucketsStore.state.fileComponentBucketName}`);
         isInitialized.value = true;


### PR DESCRIPTION
Fixes #7521

## Root cause

Satellite web console caches edge (S3) credentials forever, ignoring freeTierRestrictedExpiration

## Changes

- Added an expiration check to EdgeCredentials and made the object browser / buckets S3 clients use an AWS credential provider that regenerates edge credentials when the free tier restricted expiration is reached, plus stopped reusing expired cached credentials for bucket creation and object lock configuration.