### PR TITLE
fix: multinode wallet listing not using up whitespace correctly

### DIFF
--- a/web/multinode/src/app/store/operatorsStore.ts
+++ b/web/multinode/src/app/store/operatorsStore.ts
@@ -8,10 +8,12 @@ import { Operator, Operators } from '@/operators';
 import { Operators as OperatorsClient } from '@/api/operators';
 import { Cursor } from '@/private/pagination';
 
+const WALLETS_PER_PAGE = 10;
+
 class OperatorsState {
     public constructor(
         public operators: Operator[] = [],
-        public limit: number = 2,
+        public limit: number = WALLETS_PER_PAGE,
         public currentPage: number = 1,
         public pageCount: number = 0,
         public totalCount: number = 0,


### PR DESCRIPTION
Fixes #6749

## Root cause

Multinode wallets page size hard-coded to 2

## Changes

- Raised the wallets listing page size in the multinode operators store from the leftover placeholder value of 2 to 10 via a named constant, so the table fills the available area before pagination kicks in.