### PR TITLE
Point release v1.163.1-rc

### DIFF
--- a/cmd/satellite/gc-bf.go
+++ b/cmd/satellite/gc-bf.go
@@ -18,6 +18,7 @@ import (
 	"storj.io/storj/private/revocation"
 	"storj.io/storj/satellite"
 	"storj.io/storj/satellite/metabase"
+	"storj.io/storj/satellite/metabase/rangedloop"
 	"storj.io/storj/satellite/satellitedb"
 	"storj.io/storj/shared/dbutil"
 	"storj.io/storj/shared/dbutil/tidbutil"
@@ -116,6 +117,14 @@ func cmdGCBloomFilterRun(cmd *cobra.Command, args []string) (err error) {
 			zap.Time("read_timestamp", readTimestamp),
 			zap.Strings("service_ids", holds.ServiceIDs()),
 			zap.Duration("ttl", safepoint.TTL))
+	}
+
+	// the modular path enforces this off the bloom filter observer; here
+	// NewGarbageCollectionBF builds the splitter, and testplanet builds that
+	// peer too, so the command checks what its splitter is going to read
+	splitter := rangedloop.NewMetabaseRangeSplitterWithReadTimestamp(log, metabaseDB, runCfg.RangedLoop, readTimestamp)
+	if !splitter.ReadsSnapshot() {
+		return rangedloop.ErrNoSnapshot
 	}
 
 	peer, err := satellite.NewGarbageCollectionBF(log, db, metabaseDB, revocationDB, version.Build, &runCfg.Config, process.AtomicLevel(cmd), readTimestamp)

--- a/satellite/accounting/retentionremainder.go
+++ b/satellite/accounting/retentionremainder.go
@@ -40,6 +40,10 @@ type RetentionRemainderDB interface {
 	Upsert(ctx context.Context, charge RetentionRemainderCharge) error
 	// GetUnbilledCharges retrieves unbilled charges for a project in the given time period.
 	GetUnbilledCharges(ctx context.Context, options GetUnbilledChargesOptions) ([]RetentionRemainderCharge, *RetentionRemainderContinuationToken, error)
-	// MarkChargesAsBilled marks all unbilled charges in the time period as billed.
-	MarkChargesAsBilled(ctx context.Context, projectID uuid.UUID, from, to time.Time) error
+	// MarkChargesAsBilled marks the unbilled charges in the time period as billed, restricted
+	// to the given product IDs. Charges belonging to any other product, or to no product at
+	// all, are left unbilled: they were never invoiced, so the flag must not claim otherwise.
+	// Charges that stay unbilled are retained deliberately, as the record of what was not
+	// invoiced, and are reported on.
+	MarkChargesAsBilled(ctx context.Context, projectID uuid.UUID, from, to time.Time, productIDs []int32) error
 }

--- a/satellite/accounting/retentionremainderrecorder_test.go
+++ b/satellite/accounting/retentionremainderrecorder_test.go
@@ -33,7 +33,7 @@ func (m *mockRetentionRemainderDB) GetUnbilledCharges(_ context.Context, _ accou
 	return nil, nil, nil
 }
 
-func (m *mockRetentionRemainderDB) MarkChargesAsBilled(_ context.Context, _ uuid.UUID, _, _ time.Time) error {
+func (m *mockRetentionRemainderDB) MarkChargesAsBilled(_ context.Context, _ uuid.UUID, _, _ time.Time, _ []int32) error {
 	return nil
 }
 
@@ -164,4 +164,65 @@ func TestRemainderChargeRecorderEventkitEmission(t *testing.T) {
 			require.NotEqual(t, "retention_remainder_charge", event.Name, "expected no retention_remainder_charge event when tracking is disabled")
 		}
 	})
+}
+
+func TestRemainderChargeRecorderZeroDuration(t *testing.T) {
+	ctx := testcontext.New(t)
+	defer ctx.Cleanup()
+
+	const productID int32 = 2
+	const placement = 0
+
+	// A zero minimum retention duration disables the feature for the product.
+	pricingConfig := accounting.PricingConfig{
+		PlacementProductMap: map[int]int32{
+			placement: productID,
+		},
+		ProductPrices: map[int32]accounting.RemainderProductInfo{
+			productID: {
+				ProductID: productID,
+			},
+		},
+	}
+
+	mockDB := &mockRetentionRemainderDB{}
+
+	recorder := accounting.NewRemainderChargeRecorder(
+		zaptest.NewLogger(t),
+		mockDB,
+		pricingConfig,
+		nil,
+		accounting.RetentionRemainderRecorderConfig{
+			CacheExpiration:         10 * time.Minute,
+			CacheCapacity:           100,
+			EventkitTrackingEnabled: true,
+		},
+	)
+
+	deletedAt := time.Date(2026, 1, 15, 14, 23, 45, 0, time.UTC)
+	createdAt := deletedAt.Add(-30 * 24 * time.Hour)
+
+	eventkitspy.Clear()
+
+	recorder.Record(ctx, accounting.RecordRemainderChargesParams{
+		ProjectID:       uuid.UUID{1, 2, 3, 4},
+		ProjectPublicID: uuid.UUID{5, 6, 7, 8},
+		BucketName:      "test-bucket",
+		Placement:       placement,
+		DeletedAt:       deletedAt,
+		ObjectsFunc: func() []metabase.DeleteObjectsInfo {
+			return []metabase.DeleteObjectsInfo{
+				{
+					CreatedAt:          createdAt,
+					Status:             metabase.CommittedUnversioned,
+					TotalEncryptedSize: 1024 * 1024,
+				},
+			}
+		},
+	})
+
+	require.Empty(t, mockDB.upserted, "expected no charge to be recorded when minimum retention duration is zero")
+	for _, event := range eventkitspy.GetEvents() {
+		require.NotEqual(t, "retention_remainder_charge", event.Name, "expected no retention_remainder_charge event when minimum retention duration is zero")
+	}
 }

--- a/satellite/gc/bloomfilter/mud.go
+++ b/satellite/gc/bloomfilter/mud.go
@@ -4,6 +4,8 @@
 package bloomfilter
 
 import (
+	"go.uber.org/zap"
+
 	"storj.io/storj/satellite/metabase/rangedloop"
 	"storj.io/storj/shared/modular/config"
 	"storj.io/storj/shared/mud"
@@ -14,7 +16,16 @@ func Module(ball *mud.Ball) {
 
 	config.RegisterConfig[Config](ball, "garbage-collection-bf")
 
-	mud.Provide[*Observer](ball, NewObserver)
+	// the check hangs off the observer rather than off a subcommand, because any
+	// --components selection that generates filters needs it; the splitter knows
+	// whether its scan is a snapshot, so sources that are one by construction
+	// (like the Avro export) pass without a stale interval
+	mud.Provide[*Observer](ball, func(log *zap.Logger, config Config, overlay Overlay, splitter rangedloop.RangeSplitter) (*Observer, error) {
+		if splitter == nil || !splitter.ReadsSnapshot() {
+			return nil, rangedloop.ErrNoSnapshot
+		}
+		return NewObserver(log, config, overlay), nil
+	})
 	mud.Implementation[[]rangedloop.Observer, *Observer](ball)
 	mud.Tag[*Observer, mud.Optional](ball, mud.Optional{})
 }

--- a/satellite/metabase/loop.go
+++ b/satellite/metabase/loop.go
@@ -63,9 +63,15 @@ type IterateLoopSegments struct {
 	AsOfSystemInterval time.Duration
 	// ReadTimestamp makes all queries read a consistent snapshot of the
 	// database at the given timestamp. It takes precedence over
-	// AsOfSystemInterval and is supported only on backends providing
-	// fixed-timestamp reads (TiDB, CockroachDB).
+	// AsOfSystemInterval and only backends providing fixed-timestamp reads
+	// (TiDB, CockroachDB) can serve it; the others fail the request.
 	ReadTimestamp time.Time
+	// AllowLiveReads lets a metabase whose backends cannot serve ReadTimestamp
+	// read live instead of failing: DB.IterateLoopSegments drops the timestamp
+	// when no adapter can serve it, and refuses a mixed metabase, where the
+	// adapters that can would read a snapshot the others do not. Meant for
+	// testing and restored backups only, as the scan then reads no snapshot.
+	AllowLiveReads bool
 }
 
 // Verify verifies segments request fields.
@@ -99,6 +105,27 @@ func (db *DB) IterateLoopSegments(ctx context.Context, opts IterateLoopSegments,
 	}
 
 	loopIteratorBatchSizeLimit.Ensure(&opts.BatchSize)
+
+	if opts.AllowLiveReads && !opts.ReadTimestamp.IsZero() {
+		// Postgres has no AS OF SYSTEM TIME, so a fixed read timestamp is not
+		// something it can be asked for. The caller chose to let it read live
+		// rather than fail the scan, which is only a snapshot when no backend
+		// could have served the timestamp: on a mixed metabase the others
+		// would read a snapshot it does not, so that is refused here, where
+		// the timestamp would be dropped, rather than left to the callers.
+		serving := 0
+		for _, a := range db.adapters {
+			if a.Implementation().AsOfSystemTime(opts.ReadTimestamp) != "" {
+				serving++
+			}
+		}
+		switch {
+		case serving == 0:
+			opts.ReadTimestamp = time.Time{}
+		case serving < len(db.adapters):
+			return ErrInvalidRequest.New("live reads on a mixed metabase would read a partial snapshot")
+		}
+	}
 
 	for _, a := range db.adapters {
 		err := a.IterateLoopSegments(ctx, db.aliasCache, opts, fn)

--- a/satellite/metabase/loop_test.go
+++ b/satellite/metabase/loop_test.go
@@ -497,6 +497,36 @@ func TestIterateLoopSegments(t *testing.T) {
 					ErrClass: &metabase.ErrInvalidRequest,
 					ErrText:  "/ReadTimestamp is not supported/",
 				}.Check(ctx, t, db)
+
+				// unless the caller allows live reads, for testing and
+				// restored backups
+				defer metabasetest.DeleteAll{}.Check(ctx, t, db)
+
+				segment := metabasetest.DefaultRawSegment(metabasetest.RandObjectStream(), metabase.SegmentPosition{})
+				require.NoError(t, db.TestingBatchInsertSegments(ctx, []metabase.RawSegment{segment}))
+
+				metabasetest.IterateLoopSegments{
+					Opts: metabase.IterateLoopSegments{
+						BatchSize:      1,
+						ReadTimestamp:  time.Now(),
+						AllowLiveReads: true,
+					},
+					Result: []metabase.LoopSegmentEntry{{
+						StreamID:      segment.StreamID,
+						Position:      segment.Position,
+						CreatedAt:     segment.CreatedAt,
+						ExpiresAt:     segment.ExpiresAt,
+						RepairedAt:    segment.RepairedAt,
+						RootPieceID:   segment.RootPieceID,
+						EncryptedSize: segment.EncryptedSize,
+						PlainOffset:   segment.PlainOffset,
+						PlainSize:     segment.PlainSize,
+						Pieces:        segment.Pieces,
+						Redundancy:    segment.Redundancy,
+						Placement:     segment.Placement,
+						Source:        db.ChooseAdapter(uuid.UUID{}).Name(),
+					}},
+				}.Check(ctx, t, db)
 				return
 			}
 

--- a/satellite/metabase/rangedloop/mud.go
+++ b/satellite/metabase/rangedloop/mud.go
@@ -4,10 +4,6 @@
 package rangedloop
 
 import (
-	"time"
-
-	"go.uber.org/zap"
-
 	"storj.io/storj/satellite/metabase"
 	"storj.io/storj/satellite/metabase/avrometabase"
 	"storj.io/storj/shared/modular/config"
@@ -35,15 +31,10 @@ func Module(ball *mud.Ball) {
 	mud.Provide[*LiveCountObserver](ball, func(db *metabase.DB, cfg Config) *LiveCountObserver {
 		return NewLiveCountObserver(db, cfg.SuspiciousProcessedRatio, cfg.AsOfSystemInterval)
 	})
-	mud.Provide[*SegmentsCountValidation](ball, func(log *zap.Logger, db *metabase.DB, cfg Config) *SegmentsCountValidation {
-		return NewSegmentsCountValidation(log, db, time.Time{}, cfg.StaleInterval)
-	})
 	mud.Provide[*RunOnce](ball, NewRunOnce)
 	config.RegisterConfig[Config](ball, "ranged-loop")
 	mud.RegisterImplementation[[]Observer](ball)
 
 	mud.Implementation[[]Observer, *LiveCountObserver](ball)
-	mud.Implementation[[]Observer, *SegmentsCountValidation](ball)
-	mud.Tag[*SegmentsCountValidation, mud.Optional](ball, mud.Optional{})
 
 }

--- a/satellite/metabase/rangedloop/observerstats.go
+++ b/satellite/metabase/rangedloop/observerstats.go
@@ -87,6 +87,7 @@ type SegmentsCountValidation struct {
 	staleInterval  time.Duration
 
 	runTimestamp time.Time
+	skipped      bool
 	initialStats metabase.SegmentsStats
 
 	processedSegments map[string]int64
@@ -96,8 +97,17 @@ type SegmentsCountValidation struct {
 // A non-zero checkTimestamp pins both counts to that time. Otherwise a fresh
 // timestamp of now()-staleInterval is derived at the start of every run, so a
 // long-lived observer does not keep reading at a timestamp that the database
-// has already garbage collected; if staleInterval is zero too, the counts are
-// live reads.
+// has already garbage collected. Without a timestamp, or on a backend that
+// cannot count at one, the validation is left out for that run: a live count
+// of a table under write traffic differs from itself, let alone from what the
+// scan saw.
+//
+// Start counts the whole segments table at that timestamp, and Finish compares
+// the count with what the scan processed. Where the run holds a safepoint, as
+// the gc-bf subcommand does on TiDB, the timestamp stays readable for the
+// whole scan; otherwise the scan itself fails once the database has garbage
+// collected it. On CockroachDB, a legacy backend with limited support, the
+// count is a full table scan.
 func NewSegmentsCountValidation(log *zap.Logger, mb *metabase.DB, checkTimestamp time.Time, staleInterval time.Duration) *SegmentsCountValidation {
 	return &SegmentsCountValidation{
 		log:            log,
@@ -114,6 +124,13 @@ func (s *SegmentsCountValidation) Start(ctx context.Context, startTime time.Time
 		s.runTimestamp = time.Now().Add(-s.staleInterval)
 	}
 	s.processedSegments = make(map[string]int64)
+
+	s.skipped = s.runTimestamp.IsZero() || !ServesFixedReadTimestamp(s.mb.Implementations())
+	if s.skipped {
+		s.log.Info("leaving out segments count validation, the counts would describe no snapshot",
+			zap.Time("check_timestamp", s.runTimestamp))
+		return nil
+	}
 
 	s.log.Info("starting segments count validation", zap.Time("check_timestamp", s.runTimestamp))
 
@@ -142,11 +159,10 @@ func (s *SegmentsCountValidation) Join(ctx context.Context, partial Partial) err
 	return nil
 }
 
-// Finish fetches the final segments count and compares it to the initial count and the processed segments.
+// Finish compares the initial segments count with the processed segments.
 func (s *SegmentsCountValidation) Finish(ctx context.Context) error {
-	finalStats, err := s.mb.CountSegments(ctx, s.runTimestamp)
-	if err != nil {
-		return Error.Wrap(err)
+	if s.skipped {
+		return nil
 	}
 
 	var totalProcessed int64
@@ -154,12 +170,11 @@ func (s *SegmentsCountValidation) Finish(ctx context.Context) error {
 		totalProcessed += count
 	}
 
-	if s.initialStats.SegmentCount != finalStats.SegmentCount || s.initialStats.SegmentCount != totalProcessed {
+	if s.initialStats.SegmentCount != totalProcessed {
 		s.log.Warn("segments count validation failed",
 			zap.Int64("processed", totalProcessed),
 			zap.Any("processed_by_source", s.processedSegments),
-			zap.String("initial_stats", fmt.Sprintf("%d %v", s.initialStats.SegmentCount, s.initialStats.PerAdapterSegmentCount)),
-			zap.String("final_stats", fmt.Sprintf("%d %v", finalStats.SegmentCount, finalStats.PerAdapterSegmentCount)))
+			zap.String("initial_stats", fmt.Sprintf("%d %v", s.initialStats.SegmentCount, s.initialStats.PerAdapterSegmentCount)))
 	}
 
 	return nil

--- a/satellite/metabase/rangedloop/provider.go
+++ b/satellite/metabase/rangedloop/provider.go
@@ -13,6 +13,16 @@ import (
 // It is a subcomponent of the ranged segment loop.
 type RangeSplitter interface {
 	CreateRanges(ctx context.Context, nRanges int, batchSize int) ([]SegmentProvider, error)
+
+	// ReadsSnapshot reports whether the scan reads one snapshot of the
+	// segments: the source is immutable by construction, or every range is
+	// read at one fixed timestamp that every backend serves. A backend that
+	// cannot serve the timestamp (Postgres) fails the scan, unless live reads
+	// were allowed for a metabase where no backend could have served one; see
+	// CanReadSnapshot. Garbage collection refuses to generate bloom filters
+	// from a scan that reads no snapshot, as it could miss the pieces of a
+	// concurrent server-side copy.
+	ReadsSnapshot() bool
 }
 
 // SegmentProvider iterates through a range of segments.

--- a/satellite/metabase/rangedloop/provider_avro.go
+++ b/satellite/metabase/rangedloop/provider_avro.go
@@ -33,6 +33,10 @@ func NewAvroSegmentsSplitter(segmentsAvroIterator, nodeAliasesAvroIterator avrom
 	}
 }
 
+// ReadsSnapshot is always true: the Avro export is a single snapshot of the
+// segments by construction.
+func (s *AvroSegmentsSplitter) ReadsSnapshot() bool { return true }
+
 // CreateRanges creates ranges for the given number of ranges and batch size.
 func (s *AvroSegmentsSplitter) CreateRanges(ctx context.Context, nRanges int, batchSize int) (_ []SegmentProvider, err error) {
 	defer mon.Task()(&ctx)(&err)

--- a/satellite/metabase/rangedloop/providerdb.go
+++ b/satellite/metabase/rangedloop/providerdb.go
@@ -5,6 +5,7 @@ package rangedloop
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -20,6 +21,7 @@ type MetabaseRangeSplitter struct {
 
 	config                Config
 	overrideReadTimestamp time.Time
+	warnedLiveReads       sync.Once
 }
 
 // MetabaseSegmentProvider implements SegmentProvider.
@@ -29,6 +31,7 @@ type MetabaseSegmentProvider struct {
 	uuidRange          UUIDRange
 	asOfSystemInterval time.Duration
 	readTimestamp      time.Time
+	allowLiveReads     bool
 	batchSize          int
 }
 
@@ -77,6 +80,13 @@ func (provider *MetabaseRangeSplitter) CreateRanges(ctx context.Context, nRanges
 	if !readTimestamp.IsZero() {
 		provider.log.Info("Setting fixed read timestamp", zap.Time("timestamp", readTimestamp))
 	}
+	if provider.config.AllowLiveReads {
+		// whether the scan reads live is a property of the metabase, not of
+		// the pass, so say it once rather than on every pass of a continuous loop
+		provider.warnedLiveReads.Do(func() {
+			WarnLiveReads(provider.log, provider.db.Implementations())
+		})
+	}
 
 	rangeProviders := []SegmentProvider{}
 	for _, uuidRange := range uuidRanges {
@@ -85,11 +95,23 @@ func (provider *MetabaseRangeSplitter) CreateRanges(ctx context.Context, nRanges
 			uuidRange:          uuidRange,
 			asOfSystemInterval: provider.config.AsOfSystemInterval,
 			readTimestamp:      readTimestamp,
+			allowLiveReads:     provider.config.AllowLiveReads,
 			batchSize:          batchSize,
 		})
 	}
 
 	return rangeProviders, err
+}
+
+// ReadsSnapshot reports whether the scan reads one snapshot of the whole
+// metabase: at one fixed timestamp, one the caller pinned or one derived from
+// the stale interval, that every backend serves; or live, where live reads
+// were allowed and no backend could have served a timestamp anyway, which is
+// a single Postgres backend for testing or a restored backup, one snapshot by
+// construction. See CanReadSnapshot.
+func (provider *MetabaseRangeSplitter) ReadsSnapshot() bool {
+	fixed := !provider.overrideReadTimestamp.IsZero() || provider.config.StaleInterval > 0
+	return CanReadSnapshot(fixed, provider.config.AllowLiveReads, provider.db.Implementations())
 }
 
 // Range returns range which is processed by this provider.
@@ -115,6 +137,7 @@ func (provider *MetabaseSegmentProvider) Iterate(ctx context.Context, fn func([]
 		StartStreamID:      startStreamID,
 		EndStreamID:        endStreamID,
 		ReadTimestamp:      provider.readTimestamp,
+		AllowLiveReads:     provider.allowLiveReads,
 	}, func(ctx context.Context, iterator metabase.LoopSegmentsIterator) error {
 		segments := make([]Segment, 0, provider.batchSize)
 

--- a/satellite/metabase/rangedloop/rangedlooptest/infiniteprovider.go
+++ b/satellite/metabase/rangedloop/rangedlooptest/infiniteprovider.go
@@ -16,6 +16,9 @@ var _ rangedloop.SegmentProvider = (*InfiniteSegmentProvider)(nil)
 type InfiniteSegmentProvider struct {
 }
 
+// ReadsSnapshot is always true: the generated segments are independent of any store.
+func (m *InfiniteSegmentProvider) ReadsSnapshot() bool { return true }
+
 // CreateRanges splits the segments into equal ranges.
 func (m *InfiniteSegmentProvider) CreateRanges(ctx context.Context, nRanges int, batchSize int) (segmentsProviders []rangedloop.SegmentProvider, err error) {
 	for i := 0; i < nRanges; i++ {

--- a/satellite/metabase/rangedloop/rangedlooptest/provider.go
+++ b/satellite/metabase/rangedloop/rangedlooptest/provider.go
@@ -27,6 +27,9 @@ type SegmentProvider struct {
 	batchSize int
 }
 
+// ReadsSnapshot is always true: the in-memory segments are a snapshot by construction.
+func (m *RangeSplitter) ReadsSnapshot() bool { return true }
+
 // CreateRanges splits the segments into equal ranges.
 func (m *RangeSplitter) CreateRanges(ctx context.Context, nRanges int, batchSize int) ([]rangedloop.SegmentProvider, error) {
 	// The segments for a given stream must be handled by a single segment

--- a/satellite/metabase/rangedloop/readtimestamp.go
+++ b/satellite/metabase/rangedloop/readtimestamp.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package rangedloop
+
+import (
+	"errors"
+	"time"
+
+	"go.uber.org/zap"
+
+	"storj.io/storj/shared/dbutil"
+)
+
+// ServesFixedReadTimestamp reports whether every metabase backend can read at a
+// fixed timestamp. Postgres has no AS OF SYSTEM TIME, and the scan reads it live
+// whatever is configured.
+func ServesFixedReadTimestamp(impls map[string]dbutil.Implementation) bool {
+	return CanReadSnapshot(true, false, impls)
+}
+
+// ErrNoSnapshot refuses a bloom filter run whose scan would read no snapshot.
+var ErrNoSnapshot = errors.New("the segment scan does not read a snapshot: set ranged-loop.stale-interval on a metabase whose backends can serve it, or ranged-loop.allow-live-reads on a single-backend test or restored-backup metabase")
+
+// CanReadSnapshot reports whether a scan reads one snapshot of the whole
+// metabase. fixed says a read timestamp is set, and then every backend has to
+// serve it. Otherwise live reads have to be allowed and no backend may be able
+// to serve a timestamp at all, so that the scan is no worse than one: that is
+// a single Postgres backend for testing or a restored backup, one snapshot by
+// construction. A mixed metabase never qualifies for live reads, as the
+// backends that serve the timestamp would read a snapshot the others do not,
+// and bloom filters built from that miss the pieces of a concurrent
+// server-side copy on the live-reading ones.
+func CanReadSnapshot(fixed, allowLiveReads bool, impls map[string]dbutil.Implementation) bool {
+	serving := 0
+	for _, impl := range impls {
+		if impl.AsOfSystemTime(time.Now()) != "" {
+			serving++
+		}
+	}
+	return len(impls) > 0 && ((fixed && serving == len(impls)) || (allowLiveReads && serving == 0))
+}
+
+// WarnLiveReads logs that the scan reads live, which ranged-loop.allow-live-reads
+// permits where no backend could serve a fixed read timestamp, for testing and
+// restored backups only; so that the requirement of a snapshot is not taken as
+// an assurance those backends cannot give. A mixed metabase is refused by the
+// scan itself, so nothing is logged for it here.
+func WarnLiveReads(log *zap.Logger, impls map[string]dbutil.Implementation) {
+	if len(impls) == 0 || !CanReadSnapshot(false, true, impls) {
+		return
+	}
+	backends := make([]string, 0, len(impls))
+	for label, impl := range impls {
+		backends = append(backends, label+"="+impl.String())
+	}
+	log.Warn("no metabase backend can read at a fixed timestamp and live reads are allowed: the scan reads live and can miss the pieces of a concurrent server-side copy, which is acceptable for testing and restored backups only",
+		zap.Strings("backends", backends))
+}

--- a/satellite/metabase/rangedloop/readtimestamp_test.go
+++ b/satellite/metabase/rangedloop/readtimestamp_test.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package rangedloop_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"storj.io/common/testcontext"
+	"storj.io/storj/satellite/metabase"
+	"storj.io/storj/satellite/metabase/metabasetest"
+	"storj.io/storj/satellite/metabase/rangedloop"
+	"storj.io/storj/shared/dbutil"
+)
+
+// Bloom filters built from a scan that is not a snapshot can omit live pieces,
+// so a run has to read at a fixed timestamp, one the caller pinned or one
+// derived from the stale interval, on a backend that can serve it.
+func TestMetabaseRangeSplitterReadsSnapshot(t *testing.T) {
+	metabasetest.Run(t, func(ctx *testcontext.Context, t *testing.T, db *metabase.DB) {
+		split := func(cfg rangedloop.Config, readTimestamp time.Time) bool {
+			return rangedloop.NewMetabaseRangeSplitterWithReadTimestamp(zaptest.NewLogger(t), db, cfg, readTimestamp).ReadsSnapshot()
+		}
+		serves := rangedloop.ServesFixedReadTimestamp(db.Implementations())
+
+		require.False(t, split(rangedloop.Config{}, time.Time{}))
+
+		// a stale interval gives every pass a fixed timestamp, and so does a
+		// timestamp the caller has already pinned, where the backend serves it
+		require.Equal(t, serves, split(rangedloop.Config{StaleInterval: 5 * time.Minute}, time.Time{}))
+		require.Equal(t, serves, split(rangedloop.Config{}, time.Now()))
+
+		// a metabase whose backend cannot serve one may be read live for
+		// testing, and then needs no fixed timestamp
+		require.True(t, split(rangedloop.Config{StaleInterval: 5 * time.Minute, AllowLiveReads: true}, time.Time{}))
+		require.Equal(t, !serves, split(rangedloop.Config{AllowLiveReads: true}, time.Time{}))
+	})
+}
+
+// The counts of a validated run have to come from the snapshot the scan read,
+// which a live-reading backend cannot serve, so the validation is left out
+// there instead of comparing live counts against the scan.
+func TestSegmentsCountValidationLeavesOutLiveBackend(t *testing.T) {
+	metabasetest.Run(t, func(ctx *testcontext.Context, t *testing.T, db *metabase.DB) {
+		// From the database clock once the schema exists, as a read at a fixed
+		// timestamp sees the schema of that time too; then let a moment pass,
+		// as TiDB and CockroachDB refuse timestamps at or after the current time.
+		checkTimestamp, err := db.Now(ctx)
+		require.NoError(t, err)
+		time.Sleep(500 * time.Millisecond)
+
+		validation := rangedloop.NewSegmentsCountValidation(zaptest.NewLogger(t), db, checkTimestamp, 0)
+		require.NoError(t, validation.Start(ctx, checkTimestamp))
+		require.NoError(t, validation.Finish(ctx))
+
+		// and without a timestamp the counts would describe no snapshot at all
+		validation = rangedloop.NewSegmentsCountValidation(zaptest.NewLogger(t), db, time.Time{}, 0)
+		require.NoError(t, validation.Start(ctx, checkTimestamp))
+		require.NoError(t, validation.Finish(ctx))
+	})
+}
+
+// The counts of a validated run have to come from the snapshot the scan read,
+// which a live-reading backend cannot serve.
+func TestServesFixedReadTimestamp(t *testing.T) {
+	require.False(t, rangedloop.ServesFixedReadTimestamp(map[string]dbutil.Implementation{"p": dbutil.Postgres}))
+	require.False(t, rangedloop.ServesFixedReadTimestamp(map[string]dbutil.Implementation{"p": dbutil.Postgres, "c": dbutil.Cockroach}))
+	require.True(t, rangedloop.ServesFixedReadTimestamp(map[string]dbutil.Implementation{"t": dbutil.TiDB}))
+}
+
+// Live reads only qualify as a snapshot on a metabase with no backend that
+// could serve the timestamp: a mixed one would read a partial snapshot.
+func TestCanReadSnapshot(t *testing.T) {
+	postgres := map[string]dbutil.Implementation{"p": dbutil.Postgres}
+	mixed := map[string]dbutil.Implementation{"p": dbutil.Postgres, "t": dbutil.TiDB}
+	tidb := map[string]dbutil.Implementation{"t": dbutil.TiDB}
+
+	fixed, live := true, false
+
+	// a fixed timestamp is a snapshot where every backend serves it
+	require.True(t, rangedloop.CanReadSnapshot(fixed, false, tidb))
+	require.False(t, rangedloop.CanReadSnapshot(fixed, false, postgres))
+	require.False(t, rangedloop.CanReadSnapshot(fixed, false, mixed))
+
+	// live reads pass only where no backend could have served a timestamp
+	require.True(t, rangedloop.CanReadSnapshot(live, true, postgres))
+	require.True(t, rangedloop.CanReadSnapshot(fixed, true, postgres))
+	require.False(t, rangedloop.CanReadSnapshot(live, true, tidb))
+	require.False(t, rangedloop.CanReadSnapshot(fixed, true, mixed))
+	require.False(t, rangedloop.CanReadSnapshot(live, true, mixed))
+
+	require.False(t, rangedloop.CanReadSnapshot(live, false, postgres))
+
+	// a metabase without backends is no snapshot of anything
+	require.False(t, rangedloop.CanReadSnapshot(fixed, false, nil))
+	require.False(t, rangedloop.CanReadSnapshot(live, true, nil))
+}

--- a/satellite/metabase/rangedloop/service.go
+++ b/satellite/metabase/rangedloop/service.go
@@ -31,7 +31,8 @@ type Config struct {
 	BatchSize          int           `help:"how many items to query in a batch, capped at 50000" default:"2500"`
 	AsOfSystemInterval time.Duration `help:"as of system interval" releaseDefault:"-5m" devDefault:"-1us" testDefault:"-1us"`
 	Interval           time.Duration `help:"how often to run the loop" releaseDefault:"2h" devDefault:"10s" testDefault:"0"`
-	StaleInterval      time.Duration `help:"sets the fixed read timestamp as now()-interval" default:"0"`
+	StaleInterval      time.Duration `help:"sets the fixed read timestamp as now()-interval" releaseDefault:"0" devDefault:"1s" testDefault:"0"`
+	AllowLiveReads     bool          `help:"let a metabase whose only backend has no AS OF SYSTEM TIME (Postgres) read live instead of at a fixed read timestamp; for testing and restored backups only" releaseDefault:"false" devDefault:"true" testDefault:"true"`
 	Safepoint          SafepointConfig
 
 	SuspiciousProcessedRatio float64 `help:"ratio where to consider processed count as supicious" default:"0.03"`

--- a/satellite/metabase/stats.go
+++ b/satellite/metabase/stats.go
@@ -9,8 +9,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/zeebo/errs"
-
 	"storj.io/storj/shared/dbutil"
 )
 
@@ -185,8 +183,25 @@ func (db *DB) CountSegments(ctx context.Context, checkTimestamp time.Time) (resu
 }
 
 // CountSegments returns the number of segments in the segments table.
+// Postgres has no AS OF SYSTEM TIME, so it can only count live and refuses a
+// checkTimestamp rather than silently describing a different snapshot than
+// the caller asked for. CockroachDB inherits this and counts AS OF SYSTEM
+// TIME, which is a full scan of the segments table at that timestamp;
+// CockroachDB is a legacy metabase backend with limited support, and that
+// cost is accepted there.
 func (p *PostgresAdapter) CountSegments(ctx context.Context, checkTimestamp time.Time) (result int64, err error) {
-	return 0, errs.New("not implemented")
+	defer mon.Task()(&ctx)(&err)
+
+	asOf := p.Implementation().AsOfSystemTime(checkTimestamp)
+	if !checkTimestamp.IsZero() && asOf == "" {
+		return 0, ErrInvalidRequest.New("checkTimestamp is not supported on %v", p.Implementation())
+	}
+
+	err = p.db.QueryRowContext(ctx, `SELECT count(1) FROM segments`+asOf).Scan(&result)
+	if err != nil {
+		return 0, Error.Wrap(err)
+	}
+	return result, nil
 }
 
 // CountSegments returns the number of segments in the segments table.

--- a/satellite/metabase/stats_test.go
+++ b/satellite/metabase/stats_test.go
@@ -115,27 +115,37 @@ func TestGetTableStats(t *testing.T) {
 }
 
 func TestCountSegments(t *testing.T) {
-	t.Skip("TiDB broken at the moment due to db timing.")
-
 	metabasetest.Run(t, func(ctx *testcontext.Context, t *testing.T, db *metabase.DB) {
-		if db.Implementation() != dbutil.TiDB {
-			t.Skip("implemented only for TiDB")
+		if db.Implementation() == dbutil.TiDB {
+			t.Skip("TiDB broken at the moment due to db timing.")
 		}
 
 		metabasetest.CreateObject(ctx, t, db, metabasetest.RandObjectStream(), 4)
 
-		now, err := db.Now(ctx)
-		require.NoError(t, err)
-
-		result, err := db.CountSegments(ctx, now)
+		// without a timestamp the count is a live read, which is all a backend
+		// without AS OF SYSTEM TIME can do
+		result, err := db.CountSegments(ctx, time.Time{})
 		require.NoError(t, err)
 		require.EqualValues(t, 4, result.SegmentCount)
 		require.EqualValues(t, []int64{4}, result.PerAdapterSegmentCount)
 
+		now, err := db.Now(ctx)
+		require.NoError(t, err)
+		if db.Implementation().AsOfSystemTime(now) != "" {
+			result, err := db.CountSegments(ctx, now)
+			require.NoError(t, err)
+			require.EqualValues(t, 4, result.SegmentCount)
+			require.EqualValues(t, []int64{4}, result.PerAdapterSegmentCount)
+		} else {
+			// rather than silently counting a different snapshot than asked for
+			_, err := db.CountSegments(ctx, now)
+			require.True(t, metabase.ErrInvalidRequest.Has(err), err)
+		}
+
 		// A failing query must surface as an error, not a nil-row panic.
 		cancelCtx, cancel := context.WithCancel(ctx)
 		cancel()
-		_, err = db.CountSegments(cancelCtx, now)
+		_, err = db.CountSegments(cancelCtx, time.Time{})
 		require.Error(t, err)
 	})
 }

--- a/satellite/payments/paymentsconfig/README.md
+++ b/satellite/payments/paymentsconfig/README.md
@@ -28,6 +28,7 @@ STORJ_PAYMENTS_PRODUCTS: |
     small-object-fee-sku: "small_object_sku_value"
     minimum-retention-fee: "fee_per_TB_per_month"
     minimum-retention-fee-sku: "minimum_retention_sku_value"
+    minimum-retention-duration: "duration_value"
     use-gb-units: boolean_value
     storage-remainder: "memory.Size"
 ```
@@ -50,8 +51,12 @@ In that case, it will default to 0 (no segment charges).
 - `segment-sku`: SKU for segment storage
 - `small-object-fee`: Fee for small objects per TB
 - `small-object-fee-sku`: SKU for small object fee
-- `minimum-retention-fee`: Minimum retention fee per TB per month
+- `minimum-retention-fee`: Minimum retention fee per TB per month. Only charged when `minimum-retention-duration` is set.
 - `minimum-retention-fee-sku`: SKU for minimum retention fee
+- `minimum-retention-duration`: Minimum period objects are expected to be retained, in Go duration format (e.g., "720h").
+Objects deleted before this period accrue a retention remainder charged at `minimum-retention-fee`. Omitting it, or setting
+it to zero, disables minimum retention billing for the product, and `minimum-retention-fee` is then ignored. Configuring a
+fee without a duration is logged as an error at startup, since the fee has no effect.
 - `use-gb-units`: Boolean flag to use GB units instead of MB units on invoices (true for GB, false for MB)
 - `storage-remainder`: Remainder storage in `memory.Size` parsable format (e.g., "50KB", "1MB")
 
@@ -99,6 +104,7 @@ STORJ_PAYMENTS_PRODUCTS: |
     small-object-fee-sku: "small_object_sku_value_4"
     minimum-retention-fee: 15
     minimum-retention-fee-sku: "minimum_retention_sku_value_4"
+    minimum-retention-duration: "720h"
     egress-overage-mode: true
     use-gb-units: true
     storage-remainder: "50KB"

--- a/satellite/payments/stripe/accounts.go
+++ b/satellite/payments/stripe/accounts.go
@@ -704,7 +704,7 @@ func (accounts *accounts) ProductCharges(ctx context.Context, userID uuid.UUID, 
 				}
 
 				// Round up retention remainder when PopulateMinRetentionInvoiceLineItem is enabled.
-				if accounts.service.stripeConfig.PopulateMinRetentionInvoiceLineItem && discountedUsage.RetentionRemainder > 0 {
+				if accounts.service.stripeConfig.PopulateMinRetentionInvoiceLineItem && info.MinimumRetentionDuration > 0 && discountedUsage.RetentionRemainder > 0 {
 					retentionRemainderGBMonth := decimal.NewFromFloat(discountedUsage.RetentionRemainder).Shift(-6).Div(conversionFactor).Div(decimal.NewFromInt(hoursPerMonth))
 					roundedRetentionRemainderGBMonth := retentionRemainderGBMonth.Ceil()
 					if roundedRetentionRemainderGBMonth.IsZero() {
@@ -727,7 +727,7 @@ func (accounts *accounts) ProductCharges(ctx context.Context, userID uuid.UUID, 
 			}
 			var minimumRetentionFeePrice decimal.Decimal
 			if accounts.service.stripeConfig.PopulateMinRetentionInvoiceLineItem {
-				if !info.MinimumRetentionFeeCents.IsZero() && discountedUsage.RetentionRemainder > 0 {
+				if info.MinimumRetentionDuration > 0 && !info.MinimumRetentionFeeCents.IsZero() && discountedUsage.RetentionRemainder > 0 {
 					minimumRetentionFeePrice = info.MinimumRetentionFeeCents.Mul(storageMBMonthDecimal(discountedUsage.RetentionRemainder)).Round(0)
 				}
 			}

--- a/satellite/payments/stripe/invoice_product_test.go
+++ b/satellite/payments/stripe/invoice_product_test.go
@@ -338,11 +338,12 @@ func TestInvoiceByProduct_withFees(t *testing.T) {
 
 	// Set up products with different placeholder fee configurations.
 	productWithBothFees := paymentsconfig.ProductUsagePrice{
-		Name:                "Product Both Fees",
-		SmallObjectFee:      "0.10",
-		MinimumRetentionFee: "0.05",
-		StorageRemainder:    "50KB",
-		ProjectUsagePrice:   defaultPrice,
+		Name:                     "Product Both Fees",
+		SmallObjectFee:           "0.10",
+		MinimumRetentionFee:      "0.05",
+		MinimumRetentionDuration: "720h",
+		StorageRemainder:         "50KB",
+		ProjectUsagePrice:        defaultPrice,
 	}
 	productWithNoFees := paymentsconfig.ProductUsagePrice{
 		Name:                "Product No Fees",
@@ -358,10 +359,11 @@ func TestInvoiceByProduct_withFees(t *testing.T) {
 		ProjectUsagePrice:   defaultPrice,
 	}
 	productWithRetentionFee := paymentsconfig.ProductUsagePrice{
-		Name:                "Product Retention Fee",
-		SmallObjectFee:      "0",
-		MinimumRetentionFee: "0.07",
-		ProjectUsagePrice:   defaultPrice,
+		Name:                     "Product Retention Fee",
+		SmallObjectFee:           "0",
+		MinimumRetentionFee:      "0.07",
+		MinimumRetentionDuration: "720h",
+		ProjectUsagePrice:        defaultPrice,
 	}
 
 	// Set up product ID mappings.
@@ -1425,6 +1427,133 @@ func TestMinimumRetentionInvoicingZeroFee(t *testing.T) {
 		expectedQuantity := stripe.StorageGBMonthDecimal(charge.RemainderByteHours).Ceil().IntPart()
 		require.Equal(t, expectedQuantity, *retentionItem.Quantity)
 		require.Equal(t, 0.0, *retentionItem.UnitAmountDecimal) // $0 fee
+	})
+}
+
+func TestMinimumRetentionInvoicingZeroDuration(t *testing.T) {
+	// A zero minimum retention duration disables the feature, even when a fee is configured.
+	zeroDurationProduct := paymentsconfig.ProductUsagePrice{
+		ID:   6,
+		Name: "Zero Duration Retention Product",
+		ProjectUsagePrice: paymentsconfig.ProjectUsagePrice{
+			StorageTB: "10",
+			EgressTB:  "5",
+			Segment:   "1",
+		},
+		MinimumRetentionFee:    "10",
+		MinimumRetentionFeeSKU: "min_retention_fee_sku_zero_duration",
+		UseGBUnits:             true,
+	}
+
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1, StorageNodeCount: 1, UplinkCount: 1,
+		Reconfigure: testplanet.Reconfigure{
+			Satellite: func(log *zap.Logger, index int, config *satellite.Config) {
+				config.Payments.StripeCoinPayments.PopulateMinRetentionInvoiceLineItem = true
+				config.Payments.PlacementPriceOverrides.SetMap(map[int]int32{
+					0: 6,
+				})
+				config.Payments.Products.SetMap(map[int32]paymentsconfig.ProductUsagePrice{
+					6: zeroDurationProduct,
+				})
+			},
+		},
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		sat := planet.Satellites[0]
+		stripeService := sat.API.Payments.StripeService
+
+		project := planet.Uplinks[0].Projects[0]
+
+		now := time.Now()
+		period := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+		size := 10 * memory.TB
+		// Charges may exist from a period when the duration was still configured.
+		charge := accounting.RetentionRemainderCharge{
+			ProjectID:          project.ID,
+			BucketName:         "test-bucket",
+			DeletedAt:          period,
+			RemainderByteHours: float64(240 * size),
+			ProductID:          zeroDurationProduct.ID,
+			Billed:             false,
+		}
+		require.NoError(t, sat.DB.RetentionRemainderCharges().Upsert(ctx, charge))
+
+		productUsages := make(map[int32]accounting.ProjectUsage)
+		productInfos := make(map[int32]payments.ProductUsagePriceModel)
+
+		start := time.Date(period.Year(), period.Month(), 1, 0, 0, 0, 0, time.UTC)
+		end := start.AddDate(0, 1, 0)
+
+		record := stripe.ProjectRecord{ProjectID: project.ID, Storage: 1}
+		_, err := stripeService.ProcessRecord(ctx, record, productUsages, productInfos, start, end)
+		require.NoError(t, err)
+
+		require.Zero(t, productUsages[zeroDurationProduct.ID].RetentionRemainder)
+
+		invoiceItems := stripeService.InvoiceItemsFromTotalProjectUsages(productUsages, productInfos, period)
+		for _, item := range invoiceItems {
+			require.NotContains(t, *item.Description, "Storage Retention Remainder")
+		}
+	})
+}
+
+func TestMinimumRetentionInvoicingSkippedRecord(t *testing.T) {
+	// A record with no usage is skipped before its retention remainder charges are
+	// aggregated, so nothing is invoiced and they must not be marked as billed.
+	product := paymentsconfig.ProductUsagePrice{
+		ID:                       7,
+		Name:                     "Skipped Record Product",
+		ProjectUsagePrice:        paymentsconfig.ProjectUsagePrice{StorageTB: "10", EgressTB: "5", Segment: "1"},
+		MinimumRetentionDuration: "720h",
+		MinimumRetentionFee:      "10",
+		UseGBUnits:               true,
+	}
+
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1,
+		Reconfigure: testplanet.Reconfigure{
+			Satellite: func(log *zap.Logger, index int, config *satellite.Config) {
+				config.Payments.StripeCoinPayments.PopulateMinRetentionInvoiceLineItem = true
+				config.Payments.PlacementPriceOverrides.SetMap(map[int]int32{0: 7})
+				config.Payments.Products.SetMap(map[int32]paymentsconfig.ProductUsagePrice{7: product})
+			},
+		},
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		sat := planet.Satellites[0]
+
+		now := time.Now()
+		start := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+		end := start.AddDate(0, 1, 0)
+		// Invoicing is allowed for past periods only.
+		sat.API.Payments.StripeService.SetNow(func() time.Time { return end.AddDate(0, 0, 1) })
+
+		user, err := sat.AddUser(ctx, console.CreateUser{
+			FullName: "Test User", Email: "skipped-record@mail.test", Kind: console.PaidUser,
+		}, 1)
+		require.NoError(t, err)
+		project, err := sat.AddProject(ctx, user.ID, "testproject")
+		require.NoError(t, err)
+
+		charge := accounting.RetentionRemainderCharge{
+			ProjectID:          project.ID,
+			BucketName:         "test-bucket",
+			DeletedAt:          start,
+			RemainderByteHours: float64(240 * 10 * memory.TB),
+			ProductID:          product.ID,
+		}
+		require.NoError(t, sat.DB.RetentionRemainderCharges().Upsert(ctx, charge))
+
+		// A record with no storage, egress or segments is skipped by ProcessRecord.
+		require.NoError(t, sat.DB.StripeCoinPayments().ProjectRecords().Create(ctx,
+			[]stripe.CreateProjectRecord{{ProjectID: project.ID}}, start, end))
+
+		require.NoError(t, sat.API.Payments.StripeService.InvoiceApplyProjectRecordsGrouped(ctx, start))
+
+		unbilled, _, err := sat.DB.RetentionRemainderCharges().GetUnbilledCharges(ctx,
+			accounting.GetUnbilledChargesOptions{ProjectID: project.ID, From: start, To: end, Limit: 10})
+		require.NoError(t, err)
+		require.Len(t, unbilled, 1, "a skipped record must not consume its retention remainder charges")
 	})
 }
 

--- a/satellite/payments/stripe/service.go
+++ b/satellite/payments/stripe/service.go
@@ -154,6 +154,16 @@ func NewService(
 		legacyPricingUserAgents[ua] = struct{}{}
 	}
 
+	// Report, rather than reject, a fee that can never be charged. This combination was
+	// accepted before minimum retention billing was gated on the duration, so failing
+	// here would stop satellites booting on a configuration that used to work.
+	for productID, priceModel := range pricing.ProductPriceMap {
+		if priceModel.MinimumRetentionDuration <= 0 && !priceModel.MinimumRetentionFeeCents.IsZero() {
+			log.Error("product configures a minimum retention fee without a usable minimum retention duration; the fee will not be charged",
+				zap.Int32("product_id", productID))
+		}
+	}
+
 	return &Service{
 		log:          log,
 		stripeClient: stripeClient,
@@ -368,6 +378,15 @@ func (service *Service) InvoiceApplyProjectRecordsGrouped(ctx context.Context, p
 		limiter.Wait()
 	}()
 
+	// Products whose retention remainder charges can produce an invoice item. Charges of
+	// any other product are skipped when usage is aggregated, so they must not be marked.
+	var billableProductIDs []int32
+	for productID, priceModel := range service.pricingConfig.ProductPriceMap {
+		if priceModel.MinimumRetentionDuration > 0 {
+			billableProductIDs = append(billableProductIDs, productID)
+		}
+	}
+
 	customersPage := CustomersPage{
 		Next: true,
 	}
@@ -425,6 +444,10 @@ func (service *Service) InvoiceApplyProjectRecordsGrouped(ctx context.Context, p
 					return
 				}
 
+				// Projects whose usage was aggregated. A skipped record never reaches
+				// getAndProcessUsages, so none of its retention remainder charges are invoiced.
+				processedProjectIDs := make([]uuid.UUID, 0, len(records))
+
 				for _, r := range records {
 					totalRecords.Add(1)
 
@@ -441,7 +464,10 @@ func (service *Service) InvoiceApplyProjectRecordsGrouped(ctx context.Context, p
 					}
 					if skipped {
 						totalSkipped.Add(1)
+						continue
 					}
+
+					processedProjectIDs = append(processedProjectIDs, r.ProjectID)
 				}
 
 				items := service.InvoiceItemsFromTotalProjectUsages(productUsages, productInfos, period)
@@ -472,12 +498,14 @@ func (service *Service) InvoiceApplyProjectRecordsGrouped(ctx context.Context, p
 				}
 
 				if service.stripeConfig.PopulateMinRetentionInvoiceLineItem {
-					// Mark retention remainder charges as billed for all projects in this batch.
-					for _, r := range records {
-						err = service.retentionRemainderDB.MarkChargesAsBilled(ctx, r.ProjectID, from, to)
+					// Mark retention remainder charges as billed, restricted to the projects
+					// whose usage was aggregated and to the products that can produce an
+					// invoice item. Anything else was never invoiced, so it stays unbilled.
+					for _, projectID := range processedProjectIDs {
+						err = service.retentionRemainderDB.MarkChargesAsBilled(ctx, projectID, from, to, billableProductIDs)
 						if err != nil {
 							service.log.Error("failed to mark retention charges as billed",
-								zap.String("project_id", r.ProjectID.String()),
+								zap.String("project_id", projectID.String()),
 								zap.Error(err))
 						}
 					}
@@ -752,9 +780,40 @@ func (service *Service) getAndProcessUsages(
 		return err
 	}
 
+	// Charges recorded before a product's minimum retention duration was removed are
+	// skipped below and deliberately left unbilled: an unbilled row is the record that its
+	// byte-hours were never invoiced, which is what reporting reads. Warn as well, so an
+	// accidental removal is visible in operations and not only in a report.
+	skippedByProduct := make(map[int32]int64)
+	defer func() {
+		for productID, count := range skippedByProduct {
+			service.log.Warn("skipping retention remainder charges for product with zero minimum retention duration",
+				zap.Int("product_id", int(productID)),
+				zap.Int64("charge_count", count),
+				zap.String("project_id", projectID.String()))
+		}
+	}()
+
+	// Unknown products are reported once each, not once per charge row.
+	reportedUnknownProducts := make(map[int32]struct{})
+
 	for {
 		// Aggregate deletion remainder charges by product ID.
 		for _, charge := range deletionCharges {
+			priceModel, ok := service.pricingConfig.ProductPriceMap[charge.ProductID]
+			if !ok {
+				if _, reported := reportedUnknownProducts[charge.ProductID]; !reported {
+					reportedUnknownProducts[charge.ProductID] = struct{}{}
+					service.log.Error("failed to get product for ID in deletion charges", zap.Int("product_id", int(charge.ProductID)))
+				}
+				continue
+			}
+			// A zero minimum retention duration disables the feature for the product,
+			// so any recorded charges must not be billed.
+			if priceModel.MinimumRetentionDuration <= 0 {
+				skippedByProduct[charge.ProductID]++
+				continue
+			}
 
 			if existingUsage, ok := productUsages[charge.ProductID]; ok {
 				// Add to existing product usage.
@@ -768,29 +827,17 @@ func (service *Service) getAndProcessUsages(
 
 				// Initialize product info if not already present.
 				if _, ok := productInfos[charge.ProductID]; !ok {
-					var (
-						productName string
-						storageSKU  string
-						egressSKU   string
-						segmentSKU  string
-					)
-					if product, ok := service.pricingConfig.ProductPriceMap[charge.ProductID]; ok {
-						productName = product.ProductName
-						storageSKU = product.StorageSKU
-						egressSKU = product.EgressSKU
-						segmentSKU = product.SegmentSKU
-					} else {
-						service.log.Error("failed to get product for ID in deletion charges", zap.Int("product_id", int(charge.ProductID)))
+					productName := priceModel.ProductName
+					if productName == "" {
 						productName = fmt.Sprintf("Product %d", charge.ProductID)
 					}
 
-					priceModel := service.pricingConfig.ProductPriceMap[charge.ProductID]
 					productInfos[charge.ProductID] = payments.ProductUsagePriceModel{
 						ProductID:                charge.ProductID,
 						ProductName:              productName,
-						StorageSKU:               storageSKU,
-						EgressSKU:                egressSKU,
-						SegmentSKU:               segmentSKU,
+						StorageSKU:               priceModel.StorageSKU,
+						EgressSKU:                priceModel.EgressSKU,
+						SegmentSKU:               priceModel.SegmentSKU,
 						SmallObjectFeeCents:      priceModel.SmallObjectFeeCents,
 						MinimumRetentionFeeCents: priceModel.MinimumRetentionFeeCents,
 						MinimumRetentionDuration: priceModel.MinimumRetentionDuration,
@@ -1106,14 +1153,12 @@ func (service *Service) InvoiceItemsFromTotalProjectUsages(productUsages map[int
 			result = append(result, smallObjectFeeItem)
 		}
 
-		if !info.MinimumRetentionFeeCents.IsZero() || info.MinimumRetentionDuration > 0 {
+		// A zero minimum retention duration disables the feature entirely for the product,
+		// regardless of whether a fee is configured.
+		if info.MinimumRetentionDuration > 0 {
 			minimumRetentionFeeItem := &stripe.InvoiceItemParams{}
 			if service.stripeConfig.PopulateMinRetentionInvoiceLineItem {
-				durStr := fmt.Sprintf("%d Days", int(info.MinimumRetentionDuration.Hours())/24)
-				hoursInt := int(info.MinimumRetentionDuration.Hours()) % 24
-				if hoursInt != 0 {
-					durStr = fmt.Sprintf("%s %d Hours", durStr, hoursInt)
-				}
+				durStr := FormatRetentionDuration(info.MinimumRetentionDuration)
 
 				minimumRetentionFeeDesc := prefix + " - Minimum " + durStr + " Storage Retention Remainder (GB-Month)"
 				if !info.UseGBUnits {
@@ -1171,6 +1216,47 @@ func (service *Service) InvoiceItemsFromTotalProjectUsages(productUsages map[int
 
 	service.log.Info("invoice items by product", zap.Any("result", result))
 	return result
+}
+
+// FormatRetentionDuration renders a minimum retention duration for invoice line item
+// descriptions, e.g. "30 Days", "1 Day 12 Hours" or "30 Minutes". Units without a value
+// are omitted, so a duration shorter than a day never renders as "0 Days".
+// Exported for testing.
+func FormatRetentionDuration(duration time.Duration) string {
+	units := []struct {
+		name string
+		size time.Duration
+	}{
+		{"Day", 24 * time.Hour},
+		{"Hour", time.Hour},
+		{"Minute", time.Minute},
+		{"Second", time.Second},
+	}
+
+	var (
+		parts     []string
+		remainder = duration
+	)
+	for _, unit := range units {
+		count := int64(remainder / unit.size)
+		if count == 0 {
+			continue
+		}
+		remainder -= time.Duration(count) * unit.size
+
+		part := fmt.Sprintf("%d %s", count, unit.name)
+		if count > 1 {
+			part += "s"
+		}
+		parts = append(parts, part)
+	}
+
+	if len(parts) == 0 {
+		// Sub-second durations have no whole unit to render.
+		return duration.String()
+	}
+
+	return strings.Join(parts, " ")
 }
 
 func getSortedProductIDs(productUsages map[int32]accounting.ProjectUsage) (productIDs []int32) {

--- a/satellite/payments/stripe/service_test.go
+++ b/satellite/payments/stripe/service_test.go
@@ -2678,3 +2678,24 @@ func TestPrepareInvoiceItemForCustomer(t *testing.T) {
 		require.Equal(t, from.Unix(), *item.Period.Start)
 	})
 }
+
+func TestFormatRetentionDuration(t *testing.T) {
+	for _, tt := range []struct {
+		duration time.Duration
+		expected string
+	}{
+		{30 * 24 * time.Hour, "30 Days"},
+		{24 * time.Hour, "1 Day"},
+		{36*time.Hour + 30*time.Minute, "1 Day 12 Hours 30 Minutes"},
+		{12 * time.Hour, "12 Hours"},
+		{time.Hour, "1 Hour"},
+		{90 * time.Minute, "1 Hour 30 Minutes"},
+		{30 * time.Minute, "30 Minutes"},
+		{time.Minute, "1 Minute"},
+		{90 * time.Second, "1 Minute 30 Seconds"},
+		{time.Second, "1 Second"},
+		{500 * time.Millisecond, "500ms"},
+	} {
+		require.Equal(t, tt.expected, stripe1.FormatRetentionDuration(tt.duration), tt.duration.String())
+	}
+}

--- a/satellite/satellite-config.yaml.lock
+++ b/satellite/satellite-config.yaml.lock
@@ -1893,6 +1893,9 @@ identity.key-path: /root/.local/share/storj/identity/satellite/identity.key
 # Username for the basic auth of the Prometheus server
 # prometheus-tracker.username: ""
 
+# let a metabase whose only backend has no AS OF SYSTEM TIME (Postgres) read live instead of at a fixed read timestamp; for testing and restored backups only
+# ranged-loop.allow-live-reads: false
+
 # as of system interval
 # ranged-loop.as-of-system-interval: -5m0s
 

--- a/satellite/satellitedb/retentionremainder.go
+++ b/satellite/satellitedb/retentionremainder.go
@@ -5,6 +5,7 @@ package satellitedb
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/zeebo/errs"
@@ -72,9 +73,22 @@ func (d *retentionRemainderDB) GetUnbilledCharges(ctx context.Context, options a
 	return charges, nextToken, nil
 }
 
-// MarkChargesAsBilled marks all unbilled charges in the time period as billed.
-func (d *retentionRemainderDB) MarkChargesAsBilled(ctx context.Context, projectID uuid.UUID, from, to time.Time) (err error) {
+// MarkChargesAsBilled marks the unbilled charges in the time period as billed, restricted
+// to the given product IDs. Charges belonging to any other product, or to no product at
+// all, are left unbilled: they were never invoiced, so the flag must not claim otherwise.
+func (d *retentionRemainderDB) MarkChargesAsBilled(ctx context.Context, projectID uuid.UUID, from, to time.Time, productIDs []int32) (err error) {
 	defer mon.Task()(&ctx)(&err)
+
+	if len(productIDs) == 0 {
+		return nil
+	}
+
+	args := []interface{}{projectID, from, to}
+	placeholders := make([]string, 0, len(productIDs))
+	for _, productID := range productIDs {
+		placeholders = append(placeholders, "?")
+		args = append(args, productID)
+	}
 
 	_, err = d.db.ExecContext(ctx, d.db.Rebind(`
 		UPDATE retention_remainder_charges
@@ -83,7 +97,8 @@ func (d *retentionRemainderDB) MarkChargesAsBilled(ctx context.Context, projectI
 		  AND deleted_at >= ?
 		  AND deleted_at < ?
 		  AND billed = false
-	`), projectID, from, to)
+		  AND product_id IN (`+strings.Join(placeholders, ", ")+`)
+	`), args...)
 
 	return Error.Wrap(err)
 }

--- a/satellite/satellitedb/retentionremainder_test.go
+++ b/satellite/satellitedb/retentionremainder_test.go
@@ -122,11 +122,17 @@ func TestRetentionRemainderCharges(t *testing.T) {
 		require.Equal(t, otherProjectID, otherCharges[0].ProjectID)
 		require.Equal(t, int32(2), otherCharges[0].ProductID)
 
-		// Test MarkChargesAsBilled
-		err = retentionRemainderDB.MarkChargesAsBilled(ctx, projectID, from, to)
-		require.NoError(t, err)
-
 		options.ProjectID = projectID
+
+		// Only charges of the given products are marked; the project's charges are product 1.
+		require.NoError(t, retentionRemainderDB.MarkChargesAsBilled(ctx, projectID, from, to, []int32{2}))
+		stillUnbilled, _, err := retentionRemainderDB.GetUnbilledCharges(ctx, options)
+		require.NoError(t, err)
+		require.Len(t, stillUnbilled, 2, "charges of other products should stay unbilled")
+
+		// Test MarkChargesAsBilled
+		err = retentionRemainderDB.MarkChargesAsBilled(ctx, projectID, from, to, []int32{1})
+		require.NoError(t, err)
 
 		// Verify charges are now marked as billed
 		chargesAfterBilling, _, err := retentionRemainderDB.GetUnbilledCharges(ctx, options)

--- a/web/satellite/src/components/billing/ProductUsageAndChargesItemComponent.vue
+++ b/web/satellite/src/components/billing/ProductUsageAndChargesItemComponent.vue
@@ -138,7 +138,7 @@
                                     </td>
                                 </tr>
 
-                                <tr v-if="parseFloat(charge.priceModel.minimumRetentionFeeCents) > 0">
+                                <tr v-if="charge.priceModel.minimumRetentionDuration > 0 && parseFloat(charge.priceModel.minimumRetentionFeeCents) > 0">
                                     <td>
                                         <p>Minimum {{ getMinimumRetentionDuration(charge) }} Storage Retention Remainder</p>
                                     </td>
@@ -299,15 +299,31 @@ function getRetentionRemainderFormatted(charge: ProductCharge): string {
     return (charge.retentionRemainder / HOURS_IN_MONTH / BYTES_IN_GB).toFixed(2);
 }
 
+/**
+ * Returns the minimum retention duration formatted the same way the invoice
+ * line item description is, e.g. "30 Days", "1 Day 12 Hours" or "30 Minutes".
+ * Units without a value are omitted, so a duration shorter than a day never
+ * renders as "0 Days".
+ */
 function getMinimumRetentionDuration(charge: ProductCharge): string {
     const dur = new Duration(charge.priceModel.minimumRetentionDuration);
-    const days = Math.floor(dur.fullHours / 24);
-    const hours = dur.fullHours % 24;
-    let durStr = `${days} Days`;
-    if (hours !== 0) {
-        durStr = `${durStr} ${hours} Hours`;
+
+    const parts: string[] = [];
+    const units: [number, string][] = [
+        [Math.floor(dur.fullHours / 24), 'Day'],
+        [dur.hours, 'Hour'],
+        [dur.minutes, 'Minute'],
+        [dur.seconds, 'Second'],
+    ];
+    for (const [count, name] of units) {
+        if (count === 0) continue;
+        parts.push(`${count} ${name}${count > 1 ? 's' : ''}`);
     }
-    return durStr;
+
+    // Sub-second durations have no whole unit to render.
+    if (!parts.length) return `${dur.nanoseconds / 1e6}ms`;
+
+    return parts.join(' ');
 }
 
 /**


### PR DESCRIPTION
Cherry-picks onto `release-v1.163` for point release `v1.163.1-rc`:

- `a1b36c95f` satellite/gc/bloomfilter: require a fixed read timestamp
- `ac5a0cca0` satellite/payments: don't bill zero min retention

Both applied cleanly with no conflicts.