### PR TITLE
concurrent project creation bypasses the account project limit

### DIFF
--- a/satellite/console/projectlimit_race_test.go
+++ b/satellite/console/projectlimit_race_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package console_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"storj.io/common/testcontext"
+	"storj.io/storj/private/testplanet"
+	"storj.io/storj/satellite"
+	"storj.io/storj/satellite/console"
+)
+
+func TestCreateProjectLimitConcurrentRequests(t *testing.T) {
+	testplanet.Run(t, testplanet.Config{
+		SatelliteCount: 1, StorageNodeCount: 0, UplinkCount: 0,
+		Reconfigure: testplanet.Reconfigure{
+			Satellite: func(log *zap.Logger, index int, config *satellite.Config) {
+				// OpenRegistrationEnabled must be off so that the registration
+				// token created by AddUser applies the requested project limit.
+				config.Console.OpenRegistrationEnabled = false
+			},
+		},
+	}, func(t *testing.T, ctx *testcontext.Context, planet *testplanet.Planet) {
+		sat := planet.Satellites[0]
+		service := sat.API.Console.Service
+
+		// An account limited to a single project must never end up with more
+		// than one, even when several creation requests arrive at the same
+		// time. See https://github.com/storj/storj/issues/7814.
+		const concurrentRequests = 8
+		for attempt := 0; attempt < 3; attempt++ {
+			user, err := sat.AddUser(ctx, console.CreateUser{
+				FullName: "Concurrent Projects",
+				Email:    fmt.Sprintf("concurrent-%d@mail.test", attempt),
+			}, 1)
+			require.NoError(t, err)
+
+			userCtx, err := sat.UserContext(ctx, user.ID)
+			require.NoError(t, err)
+
+			start := make(chan struct{})
+			var (
+				wg      sync.WaitGroup
+				mu      sync.Mutex
+				created int
+				failed  int
+			)
+			for i := 0; i < concurrentRequests; i++ {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					<-start
+					_, err := service.CreateProject(userCtx, console.UpsertProjectInfo{
+						Name: fmt.Sprintf("race-%d-%d", attempt, i),
+					})
+					mu.Lock()
+					defer mu.Unlock()
+					if err == nil {
+						created++
+					} else {
+						failed++
+					}
+				}(i)
+			}
+			close(start)
+			wg.Wait()
+
+			require.Equal(t, 1, created, "expected exactly one project creation to succeed")
+			require.Equal(t, concurrentRequests-1, failed)
+
+			projects, err := service.GetUsersProjects(userCtx)
+			require.NoError(t, err)
+			require.Len(t, projects, 1, "project limit bypassed: user owns more projects than allowed")
+		}
+	})
+}

--- a/satellite/console/service.go
+++ b/satellite/console/service.go
@@ -4650,6 +4650,36 @@ func (s *Service) CreateProject(ctx context.Context, projectInfo UpsertProjectIn
 		satManagedPassphrase = false
 		p = nil
 
+		// Concurrent project creation requests for the same user race the
+		// project limit check: two transactions can both observe the count of
+		// existing projects before either inserts, and both then insert,
+		// bypassing the limit (see https://github.com/storj/storj/issues/7814).
+		// Take a transaction-scoped lock on the user's row so concurrent
+		// creations for the same user are serialized, and check the limit and
+		// the project name while holding the lock.
+		if err := tx.Users().AcquireProjectCreationLock(ctx, user.ID); err != nil {
+			return Error.Wrap(err)
+		}
+
+		limit, err := tx.Users().GetProjectLimit(ctx, user.ID)
+		if err != nil {
+			return err
+		}
+
+		projects, err := tx.Projects().GetOwnActive(ctx, user.ID)
+		if err != nil {
+			return err
+		}
+		if len(projects) >= limit {
+			s.analytics.TrackProjectLimitError(user.ID, user.Email, user.HubspotObjectID, user.TenantID)
+			return ErrProjLimit.New(projLimitErrMsg)
+		}
+		for _, other := range projects {
+			if other.Name == projectInfo.Name {
+				return ErrProjName.New(projNameErrMsg)
+			}
+		}
+
 		storageLimit := memory.Size(newProjectLimits.Storage)
 		bandwidthLimit := memory.Size(newProjectLimits.Bandwidth)
 
@@ -4690,37 +4720,9 @@ func (s *Service) CreateProject(ctx context.Context, projectInfo UpsertProjectIn
 			return ErrSatelliteManagedEncryption
 		}
 
-		var err error
 		p, err = tx.Projects().Insert(ctx, newProject)
 		if err != nil {
 			return Error.Wrap(err)
-		}
-
-		limit, err := tx.Users().GetProjectLimit(ctx, user.ID)
-		if err != nil {
-			return err
-		}
-
-		projects, err := tx.Projects().GetOwnActive(ctx, user.ID)
-		if err != nil {
-			return err
-		}
-
-		// We check again for project name duplication and whether the project limit
-		// has been exceeded in case a parallel project creation transaction created
-		// a project at the same time as this one.
-		var numBefore int
-		for _, other := range projects {
-			if other.CreatedAt.Before(p.CreatedAt) || (other.CreatedAt.Equal(p.CreatedAt) && other.ID.Less(p.ID)) {
-				if other.Name == p.Name {
-					return errs.Combine(ErrProjName.New(projNameErrMsg), tx.Projects().Delete(ctx, p.ID))
-				}
-				numBefore++
-			}
-		}
-		if numBefore >= limit {
-			s.analytics.TrackProjectLimitError(user.ID, user.Email, user.HubspotObjectID, user.TenantID)
-			return errs.Combine(ErrProjLimit.New(projLimitErrMsg), tx.Projects().Delete(ctx, p.ID))
 		}
 
 		_, err = tx.ProjectMembers().Insert(ctx, user.ID, p.ID, RoleAdmin)

--- a/satellite/console/users.go
+++ b/satellite/console/users.go
@@ -76,6 +76,10 @@ type Users interface {
 	UpdateDefaultPlacement(ctx context.Context, id uuid.UUID, placement storj.PlacementConstraint) error
 	// GetProjectLimit is a method to get the users project limit
 	GetProjectLimit(ctx context.Context, id uuid.UUID) (limit int, err error)
+	// AcquireProjectCreationLock takes a transaction-scoped lock on the user's
+	// row, serializing concurrent project creations for the same user so that
+	// the project limit check and the project insert are atomic.
+	AcquireProjectCreationLock(ctx context.Context, id uuid.UUID) error
 	// GetUserProjectLimits is a method to get the users storage and bandwidth limits for new projects.
 	GetUserProjectLimits(ctx context.Context, id uuid.UUID) (limit *ProjectLimits, err error)
 	// GetUserKind returns the kind of user.

--- a/satellite/satellitedb/consoledb/users.go
+++ b/satellite/satellitedb/consoledb/users.go
@@ -761,6 +761,26 @@ func (users *users) GetProjectLimit(ctx context.Context, id uuid.UUID) (limit in
 	return row.ProjectLimit, nil
 }
 
+// AcquireProjectCreationLock takes a transaction-scoped lock on the user's row
+// by re-writing project_limit to its current value. The update is a no-op on
+// the data but acquires a row lock that is held until the surrounding
+// transaction commits, which serializes concurrent project creations for the
+// same user.
+func (users *users) AcquireProjectCreationLock(ctx context.Context, id uuid.UUID) (err error) {
+	defer mon.Task()(&ctx)(&err)
+
+	row, err := users.db.Get_User_ProjectLimit_By_Id(ctx, dbx.User_Id(id[:]))
+	if err != nil {
+		return err
+	}
+
+	_, err = users.db.Update_User_By_Id(ctx, dbx.User_Id(id[:]), dbx.User_Update_Fields{
+		ProjectLimit: dbx.User_ProjectLimit(row.ProjectLimit),
+	})
+
+	return err
+}
+
 // GetUserProjectLimits is a method to get the users storage and bandwidth limits for new projects.
 func (users *users) GetUserProjectLimits(ctx context.Context, id uuid.UUID) (limits *console.ProjectLimits, err error) {
 	defer mon.Task()(&ctx)(&err)


### PR DESCRIPTION
the project limit gets enforced by counting active projects before the insert, and the transaction-level recheck that ran after the insert could only see rows that were already committed. two creations hitting the api at the same time both count the pre-insert state and both get through, so an account limited to one project ends up with several. #7814 has a video of exactly that.

the change serializes creation per user: at the start of the transaction we take a lock on the user's row (a no-op update of project_limit back to its current value, held until commit), then run the limit and name checks while holding it. concurrent creations for the same user now queue on that row, so the check sees every committed project and is authoritative. on cockroach the overlapping transaction hits a serialization conflict instead, txutil retries it, and the retry sees the committed row and fails with the regular ErrProjLimit.

files touched:

satellite/console/users.go, satellite/satellitedb/consoledb/users.go: AcquireProjectCreationLock on the Users interface plus its implementation
satellite/console/service.go: lock + pre-insert limit/name checks in CreateProject; removed the post-insert recheck since it's redundant once the lock is held (and it was the window the race slipped through)

testing: TestCreateProjectLimitConcurrentRequests fires 8 concurrent creations at a limit-1 account three rounds in a row and asserts exactly one succeeds and the account ends up with exactly one project. against master it fails with all 8 creations going through; with the change it passes. ran it against postgres locally.

one side effect worth flagging: the checks now sit inside the transaction, so for managed-passphrase users the kms call happens while the user row is locked. it's a short call and contention is only between creations for the same user.
